### PR TITLE
Add showTx handler to buy webview

### DIFF
--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -388,6 +388,7 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 
 #define WEBKIT_HANDLER_BUY_COMPLETED @"buyCompleted"
 #define WEBKIT_HANDLER_FRONTEND_INITIALIZED @"frontendInitialized"
+#define WEBKIT_HANDLER_SHOW_TX @"showTx"
 
 #define INFORMATION_RECEIVE_URL @"https://support.blockchain.com/hc/en-us/articles/210353663-Why-is-my-bitcoin-address-changing"
 

--- a/Blockchain/BuyBitcoinViewController.m
+++ b/Blockchain/BuyBitcoinViewController.m
@@ -32,6 +32,7 @@ NSString* funcWithArgs(NSString*, NSString*, NSString*, NSString*, NSString*);
         
         [userController addScriptMessageHandler:self name:WEBKIT_HANDLER_BUY_COMPLETED];
         [userController addScriptMessageHandler:self name:WEBKIT_HANDLER_FRONTEND_INITIALIZED];
+        [userController addScriptMessageHandler:self name:WEBKIT_HANDLER_SHOW_TX];
         
         configuration.userContentController = userController;
         
@@ -103,15 +104,21 @@ NSString* funcWithArgs(NSString* name, NSString* a1, NSString* a2, NSString* a3,
 {
     DLog(@"Received script message: '%@'", message.name);
     
-    if ([message.name isEqual: WEBKIT_HANDLER_FRONTEND_INITIALIZED]) {
+    if ([message.name isEqual:WEBKIT_HANDLER_FRONTEND_INITIALIZED]) {
         self.isReady = YES;
         if (self.queuedScript != nil) {
             [self runScript:self.queuedScript];
         }
     }
-    
-    if ([message.name isEqual: WEBKIT_HANDLER_BUY_COMPLETED]) {
+
+    if ([message.name isEqual:WEBKIT_HANDLER_BUY_COMPLETED]) {
         self.didInitiateTrade = YES;
+    }
+
+    if ([message.name isEqual:WEBKIT_HANDLER_SHOW_TX]) {
+        [self dismissViewControllerAnimated:true completion:^(){
+            DLog(@"Go to tx feed");
+        }];
     }
 }
 


### PR DESCRIPTION
@woudini this handler will be called when the user presses the "See Your Bitcoin" button in the modal that's shown after a trade is completed. The intent is to take them to the native transaction details screen rather than the one in the webview. Could you implement that part? I'll pass the tx hash with to the completion handler.