### PR TITLE
Enable scrolling in iframe and fix focus jump

### DIFF
--- a/Blockchain/BuyBitcoinViewController.m
+++ b/Blockchain/BuyBitcoinViewController.m
@@ -41,7 +41,7 @@ NSString* funcWithArgs(NSString*, NSString*, NSString*, NSString*, NSString*);
         
         self.webView.UIDelegate = self;
         self.webView.navigationDelegate = self;
-        self.webView.scrollView.scrollEnabled = NO;
+        self.webView.scrollView.scrollEnabled = YES;
         self.automaticallyAdjustsScrollViewInsets = NO;
         
         NSURL *login = [NSURL URLWithString:URL_BUY_WEBVIEW];


### PR DESCRIPTION
Thank you @jtormey for helping out with this one. My favorite parts were:

1. Commenting out bitcoin network
2. When fixing the autofocus worked but broke scroll entirely
3. When @jtormey made an MVP to test locally
4. When it worked on iphone safari but not ios webview
5. When I didn't have write access to push the changes to My-Wallet-V3-iOS @tuzzolo 

Thanks again @jtormey 