### PR TITLE
Root Service Refactor

### DIFF
--- a/Blockchain/AuthenticationManager.swift
+++ b/Blockchain/AuthenticationManager.swift
@@ -1,0 +1,120 @@
+//
+//  AuthenticationManager.swift
+//  Blockchain
+//
+//  Created by Maurice A. on 2/15/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+import LocalAuthentication
+
+@objc final class AuthenticationManager : NSObject {
+    static let shared = AuthenticationManager()
+    
+    struct AuthenticationError {
+        let code: Int
+        let message: String
+    }
+    
+    typealias handler = (_ authenticated: Bool, _ error: AuthenticationError?) -> Void
+    
+    private let context: LAContext
+    private let genericAuthenticationError: AuthenticationError!
+    private lazy var authenticationReason: String = {
+        if #available(iOS 11.0, *) {
+            if self.context.biometryType == .faceID {
+                return BC_STRING_FACE_ID_AUTHENTICATE
+            }
+        }
+        return BC_STRING_TOUCH_ID_AUTHENTICATE
+    }()
+    var preFlightError: NSError?
+    
+    override init() {
+        context = LAContext()
+        context.localizedFallbackTitle = BC_STRING_AUTH_USE_PASSCODE
+        if #available(iOS 10.0, *) {
+            context.localizedCancelTitle = BC_STRING_AUTH_CANCEL
+        }
+        genericAuthenticationError = AuthenticationError(code: Int.min, message: BC_STRING_AUTH_GENERIC_ERROR)
+        preFlightError = nil
+    }
+    
+    // MARK: - Authentication with Biometrics
+    
+    func biometricAuthentication(with reply: @escaping handler) {
+        if !canAuthenticateUsingBiometry() {
+            reply(false, preFlightError(for: preFlightError!.code)); return
+        }
+        context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: authenticationReason, reply: { authenticated, error in
+            if let authError = error {
+                reply(false, self.authenticationError(for: authError)); return
+            }
+            reply(authenticated, nil)
+        })
+    }
+    
+    private func canAuthenticateUsingBiometry() -> Bool {
+        return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &preFlightError)
+    }
+    
+    //: MARK: - Authentication with Passcode
+    
+    func passcodeAuthentication(with reply: @escaping handler) {
+        // TODO: authenticate user with passcode...
+    }
+    
+    // MARK: - Authentication Errors
+    
+    //: Preflight errors occur prior to policy evaluation
+    private func preFlightError(for errorCode: Int) -> AuthenticationError {
+        if #available(iOS 11.0, *) {
+            return preFlightError(forBiometry: errorCode)
+        }
+        return preFlightError(forDeprecated: errorCode)
+    }
+    
+    private func preFlightError(forBiometry errorCode: Int) -> AuthenticationError {
+        if #available(iOS 11.0, *) {
+            switch errorCode {
+            case LAError.biometryLockout.rawValue:
+                return AuthenticationError(code: errorCode, message: BC_STRING_AUTH_BIOMETRY_LOCKOUT)
+            case LAError.biometryNotAvailable.rawValue:
+                return AuthenticationError(code: errorCode, message: BC_STRING_AUTH_BIOMETRY_NOT_AVAILABLE)
+            case LAError.biometryNotEnrolled.rawValue:
+                return AuthenticationError(code: errorCode, message: BC_STRING_AUTH_BIOMETRY_NOT_ENROLLED)
+            default:
+                return genericAuthenticationError
+            }
+        }
+        return genericAuthenticationError
+    }
+    
+    private func preFlightError(forDeprecated errorCode: Int) -> AuthenticationError {
+        switch errorCode {
+        case LAError.touchIDLockout.rawValue:
+            return AuthenticationError(code: errorCode, message: BC_STRING_AUTH_TOUCH_ID_LOCKOUT)
+        case LAError.touchIDNotAvailable.rawValue:
+            return AuthenticationError(code: errorCode, message: BC_STRING_AUTH_TOUCH_ID_NOT_AVAILABLE)
+        case LAError.touchIDNotEnrolled.rawValue:
+            return AuthenticationError(code: errorCode, message: BC_STRING_AUTH_TOUCH_ID_NOT_ENROLLED)
+        default:
+            return genericAuthenticationError
+        }
+    }
+    
+    //: Inflight errors occur during policy evaluation
+    private func authenticationError(for error: Error) -> AuthenticationError {
+        switch error {
+        case LAError.authenticationFailed:
+            return AuthenticationError(code: LAError.authenticationFailed.rawValue, message: BC_STRING_AUTH_AUTHENTICATION_FAILED)
+        case LAError.appCancel:
+            return AuthenticationError(code: LAError.appCancel.rawValue, message: BC_STRING_AUTH_APP_CANCEL)
+        case LAError.passcodeNotSet:
+            return AuthenticationError(code: LAError.passcodeNotSet.rawValue, message: BC_STRING_AUTH_PASSCODE_NOT_SET)
+        default:
+            return genericAuthenticationError
+        }
+    }
+}

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -1,0 +1,36 @@
+//
+//  LocalizationConstants.swift
+//  Blockchain
+//
+//  Created by Maurice A. on 2/15/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+let BC_STRING_ERROR = NSLocalizedString("Error", comment: "")
+let BC_STRING_OK = NSLocalizedString("OK", comment: "")
+
+//: Local Authentication - Face ID & Touch ID
+
+let BC_STRING_AUTH_CANCEL = NSLocalizedString("Cancel", comment: "")
+let BC_STRING_AUTH_USE_PASSCODE = NSLocalizedString("Use Passcode", comment: "")
+
+let BC_STRING_FACE_ID_AUTHENTICATE = NSLocalizedString("Authenticate with Face ID", comment: "")
+let BC_STRING_TOUCH_ID_AUTHENTICATE = NSLocalizedString("Authenticate with Touch ID", comment: "")
+
+//: Authentication Errors
+let BC_STRING_AUTH_GENERIC_ERROR = NSLocalizedString("Authentication Failed. Please try again.", comment: "")
+let BC_STRING_AUTH_AUTHENTICATION_FAILED = NSLocalizedString("Authentication was not successful because the user failed to provide valid credentials.", comment: "")
+let BC_STRING_AUTH_APP_CANCEL = NSLocalizedString("Authentication was canceled by the application.", comment: "")
+let BC_STRING_AUTH_PASSCODE_NOT_SET = NSLocalizedString("Failed to authenticate because a passcode has not been set on the device.", comment: "")
+
+//: Deprecated Authentication Errors (remove once we stop supporting iOS >= 8.0 and iOS <= 11)
+let BC_STRING_AUTH_TOUCH_ID_LOCKOUT = NSLocalizedString("Unable to authenticate because there were too many failed Touch ID attempts. Passcode is required to unlock Touch ID", comment: "")
+let BC_STRING_AUTH_TOUCH_ID_NOT_AVAILABLE = NSLocalizedString("Unable to authenticate because Touch ID is not available on the device.", comment: "")
+let BC_STRING_AUTH_TOUCH_ID_NOT_ENROLLED = NSLocalizedString("Unable to authenticate because Touch ID has no enrolled fingers.", comment: "")
+
+//: Biometry Authentication Errors (only available on iOS 11, possibly including newer versions)
+let BC_STRING_AUTH_BIOMETRY_LOCKOUT = NSLocalizedString("Unable to authenticate due to failing authentication too many times.", comment: "")
+let BC_STRING_AUTH_BIOMETRY_NOT_AVAILABLE = NSLocalizedString("Unable to authenticate because the device does not support biometric authentication.", comment: "")
+let BC_STRING_AUTH_BIOMETRY_NOT_ENROLLED = NSLocalizedString("Unable to authenticate because biometric authentication is not enrolled.", comment: "")


### PR DESCRIPTION
This PR will extract all code related to authentication into its own module and create a bridge between the old and new Root Service, so that the Swift code is temporarily accessible through Objective-C. Once the new code no longer depends on Objective-C, the old bridge will be removed.