### PR TITLE
Remove public key pinning instructions from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,6 @@ Prepare OpenSSL:
     cd ../OpenSSL-for-iPhone
     ./build-libssl.sh
 
-## Public Key Pinning
-
-Create a file named `.env` and define environment variables in it as follows:
-
-    DEV=""
-    STAGING=""
-    TESTNET=""
-
-Get certificates:
-
-    sh scripts/update-certs.sh
-
 ## PSD and Asset Catalog
 
 Images.xcassets contains all images the app needs, but they must be generated first from the PSD sources in /Artwork. This requires ImageMagick and Grunt.


### PR DESCRIPTION
Since it's now part of the build phase. 

Merge after #86 is complete.