### PR TITLE
Revert "fix(Send-Eth): use websocket to listen for loading transactio…

### DIFF
--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -2540,11 +2540,6 @@ void (^secondPasswordSuccess)(NSString *);
     [self.tabControllerManager didGetEtherAddressWithSecondPassword];
 }
 
-- (void)reloadEthTransactions
-{
-    [self.tabControllerManager.transactionsEtherViewController reload];
-}
-
 - (void)didGetExchangeTrades:(NSArray *)trades
 {
     [self.tabControllerManager didGetExchangeTrades:trades];

--- a/Blockchain/SendEtherViewController.m
+++ b/Blockchain/SendEtherViewController.m
@@ -155,7 +155,7 @@
     
     [self resetFrame];
     
-    [self reload];
+    [self getHistory];
 }
 
 - (void)resetFrame
@@ -220,6 +220,11 @@
 - (void)setAddress:(NSString *)address
 {
     [self selectToAddress:address];
+}
+
+- (void)getHistory
+{
+    [app.wallet getEthHistory];
 }
 
 - (void)updateExchangeRate:(NSDecimalNumber *)rate

--- a/Blockchain/Wallet.h
+++ b/Blockchain/Wallet.h
@@ -147,7 +147,6 @@
 - (void)didGetBitcoinCashExchangeRates;
 - (void)didFetchBitcoinCashHistory;
 - (void)initializeWebView;
-- (void)reloadEthTransactions;
 @end
 
 @interface Wallet : NSObject <UIWebViewDelegate, SRWebSocketDelegate, ExchangeAccountDelegate> {

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -41,9 +41,6 @@
 #import "NSData+BTCData.h"
 
 #define DICTIONARY_KEY_CURRENCY @"currency"
-#define DICTIONARY_KEY_BLOCK_SUB @"block_sub"
-#define DICTIONARY_KEY_ACCOUNT_SUB @"account_sub"
-#define DICTIONARY_KEY_OP @"op"
 
 @interface Wallet ()
 @property (nonatomic) JSContext *context;
@@ -918,10 +915,6 @@
         [weakSelf did_get_ether_address_with_second_password];
     };
     
-    self.context[@"objc_reload_eth_transactions"] = ^() {
-        [weakSelf reload_eth_transactions];
-    };
-    
 #pragma mark Bitcoin Cash
     
     self.context[@"objc_on_fetch_bch_history_success"] = ^() {
@@ -998,7 +991,6 @@
 {
     _ethSocket = [[SRWebSocket alloc] initWithURLRequest:[self getWebSocketRequest:AssetTypeEther]];
     _ethSocket.delegate = self;
-    [_ethSocket open];
 }
 
 - (void)setupSocket:(AssetType)assetType
@@ -1217,10 +1209,10 @@
 {
     if (webSocket == self.ethSocket) {
         DLog(@"eth websocket opened");
-        NSString *blocksSub = [[self.context evaluateScript:@"MyWalletPhone.getEthBlockMessage()"] toString];
-        NSString *accountSub = [[self.context evaluateScript:@"MyWalletPhone.getEthAccountMessage()"] toString];
-        [self sendEthSocketMessage:blocksSub];
-        [self sendEthSocketMessage:accountSub];
+        for (NSString *message in [self.pendingEthSocketMessages reverseObjectEnumerator]) {
+            DLog(@"Sending queued eth socket message %@", message);
+            [self sendEthSocketMessage:message];
+        }
         [self.pendingEthSocketMessages removeAllObjects];
     } else if (webSocket == self.btcSocket) {
         DLog(@"btc websocket opened");
@@ -1248,17 +1240,14 @@
 
 - (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean
 {
-    if (code == WEBSOCKET_CODE_BACKGROUNDED_APP || code == WEBSOCKET_CODE_LOGGED_OUT || code == WEBSOCKET_CODE_RECEIVED_TO_SWIPE_ADDRESS) {
-        // Socket will reopen when app becomes active and after decryption
-        return;
-    }
-    
     if (webSocket == self.ethSocket) {
         DLog(@"eth websocket closed: code %li, reason: %@", code, reason);
-        if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive) {
-            [self setupEthSocket];
-        }
     } else if (webSocket == self.btcSocket || webSocket == self.bchSocket) {
+        if (code == WEBSOCKET_CODE_BACKGROUNDED_APP || code == WEBSOCKET_CODE_LOGGED_OUT || code == WEBSOCKET_CODE_RECEIVED_TO_SWIPE_ADDRESS) {
+            // Socket will reopen when app becomes active and after decryption
+            return;
+        }
+        
         DLog(@"websocket closed: code %li, reason: %@", code, reason);
         if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive) {
             if (self.btcSocket.readyState != 1) {
@@ -1276,14 +1265,8 @@
 - (void)webSocket:(SRWebSocket *)webSocket didReceiveMessageWithString:(NSString *)string
 {
     if (webSocket == self.ethSocket) {
-        DLog(@"received eth socket message string %@", string);
-        NSDictionary *message = [string getJSONObject];
-        NSString *op = [message objectForKey:DICTIONARY_KEY_OP];
-        if ([op isEqualToString:DICTIONARY_KEY_BLOCK_SUB]) {
-            [self.context evaluateScript:[NSString stringWithFormat:@"MyWalletPhone.didReceiveEthSocketMessageBlock(\"%@\")", [string escapeStringForJS]]];
-        } else if ([op isEqualToString:DICTIONARY_KEY_ACCOUNT_SUB]) {
-            [self.context evaluateScript:[NSString stringWithFormat:@"MyWalletPhone.didReceiveEthSocketMessageAccount(\"%@\")", [string escapeStringForJS]]];
-        }
+        DLog(@"received eth socket message string");
+        [self.context evaluateScript:[NSString stringWithFormat:@"MyWalletPhone.didReceiveEthSocketMessage(\"%@\")", [string escapeStringForJS]]];
     } else {
         DLog(@"received websocket message string");
         
@@ -4695,15 +4678,6 @@
         [self.delegate didGetEtherAddressWithSecondPassword];
     } else {
         DLog(@"Error: delegate of class %@ does not respond to selector didGetEtherAddressWithSecondPassword!", [delegate class]);
-    }
-}
-
-- (void)reload_eth_transactions
-{
-    if ([self.delegate respondsToSelector:@selector(reloadEthTransactions)]) {
-        [self.delegate reloadEthTransactions];
-    } else {
-        DLog(@"Error: delegate of class %@ does not respond to selector reloadEthTransactions!", [delegate class]);
     }
 }
 

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -28,6 +28,35 @@ if (typeof Buffer.prototype.reverse !== 'function') {
     }
 }
 
+function NativeEthSocket () {
+  this.handlers = []
+}
+
+NativeEthSocket.prototype.on = function (type, callback) {
+}
+
+NativeEthSocket.prototype.onMessage = function (msg) {
+  this.handlers.forEach(function (handler) {
+    handler(msg)
+  })
+}
+
+NativeEthSocket.prototype.subscribeToAccount = function (account) {
+  var accountMsg = EthSocket.accountSub(account)
+  objc_eth_socket_send(accountMsg)
+  var handler = EthSocket.accountMessageHandler(account)
+  this.handlers.push(handler)
+}
+
+NativeEthSocket.prototype.subscribeToBlocks = function (ethWallet) {
+  var blockMsg = EthSocket.blocksSub(ethWallet)
+  objc_eth_socket_send(blockMsg)
+  var handler = EthSocket.blockMessageHandler(ethWallet)
+  this.handlers.push(handler)
+}
+
+var ethSocketInstance = new NativeEthSocket();
+
 APP_NAME = 'javascript_iphone_app';
 APP_VERSION = '3.0';
 API_CODE = '35e77459-723f-48b0-8c9e-6e9e8f54fbd3';
@@ -679,6 +708,8 @@ MyWalletPhone.login = function(user_guid, shared_key, resend_code, inputedPasswo
         objc_loading_stop();
 
         objc_did_load_wallet();
+
+        MyWallet.wallet.useEthSocket(ethSocketInstance);
     };
 
     var history_error = function(error) {console.log(error);
@@ -2324,14 +2355,6 @@ function WalletOptions (api) {
 
 // MARK: - Ethereum
 
-MyWalletPhone.getEthAccountMessage = function () {
-    return EthSocket.accountSub(MyWallet.wallet.eth.defaultAccount);
-}
-
-MyWalletPhone.getEthBlockMessage = function () {
-    return EthSocket.blocksSub(MyWallet.wallet.eth);
-}
-
 MyWalletPhone.getEthExchangeRate = function(currencyCode) {
 
     var success = function(result) {
@@ -2498,16 +2521,8 @@ MyWalletPhone.saveEtherNote = function(txHash, note) {
     MyWalletPhone.getEthHistory();
 }
 
-MyWalletPhone.didReceiveEthSocketMessageBlock = function(msg) {
-    var blockMessageHandler = EthSocket.blockMessageHandler(MyWallet.wallet.eth);
-    blockMessageHandler(msg);
-    objc_reload_eth_transactions();
-}
-
-MyWalletPhone.didReceiveEthSocketMessageAccount = function(msg) {
-    var accountMessageHandler = EthSocket.accountMessageHandler(MyWallet.wallet.eth, MyWallet.wallet.eth.defaultAccount);
-    accountMessageHandler(msg);
-    objc_reload();
+MyWalletPhone.didReceiveEthSocketMessage = function(msg) {
+    ethSocketInstance.onMessage(msg);
 }
 
 MyWalletPhone.getEtherAddress = function(helperText) {


### PR DESCRIPTION
…ns instead of getting history each time Send is shown"

This reverts commit 1bc90671a52b3b2362a0d22190b02c5cdc7cfeb1.

This undoes a change that was intended to use the ETH socket, but due to the My-Wallet-V3 submodule commit being so behind it's become too ambitious to fix for the BCH release.