### PR TITLE
Fix exchange

### DIFF
--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -835,16 +835,6 @@
     self.topLeftField.text = nil;
     self.bottomLeftField.text = nil;
 }
-    
-- (void)clearFromFieldReference
-{
-    [self clearFieldOfSymbol:self.fromSymbol];
-}
-
-- (void)clearToFieldReference
-{
-    [self clearFieldOfSymbol:self.toSymbol];
-}
 
 - (void)clearFieldOfSymbol:(NSString *)symbol
 {

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -738,15 +738,16 @@
 
 - (void)assetToggleButtonClicked
 {
-    if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_BTC]) {
-        [self selectFromEther];
-        [self selectToBitcoin];
-    } else if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_ETH]) {
+    [self clearFieldOfSymbol:self.fromSymbol];
+
+    NSString *toSymbol = self.toSymbol;
+    if ([toSymbol isEqualToString:CURRENCY_SYMBOL_BTC]) {
         [self selectFromBitcoin];
-        [self selectToEther];
+    } else if ([toSymbol isEqualToString:CURRENCY_SYMBOL_ETH]) {
+        [self selectFromEther];
+    } else if ([toSymbol isEqualToString:CURRENCY_SYMBOL_BCH]) {
+        [self selectFromBitcoinCash];
     }
-    
-    [self getRate];
 }
 
 - (void)fromButtonClicked

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -835,6 +835,27 @@
     self.topLeftField.text = nil;
     self.bottomLeftField.text = nil;
 }
+    
+- (void)clearFromFieldReference
+{
+    [self clearFieldOfSymbol:self.fromSymbol];
+}
+
+- (void)clearToFieldReference
+{
+    [self clearFieldOfSymbol:self.toSymbol];
+}
+
+- (void)clearFieldOfSymbol:(NSString *)symbol
+{
+    if ([symbol isEqualToString:CURRENCY_SYMBOL_BTC]) {
+        self.btcField = nil;
+    } else if ([symbol isEqualToString:CURRENCY_SYMBOL_ETH]) {
+        self.ethField = nil;
+    } else if ([symbol isEqualToString:CURRENCY_SYMBOL_BCH]) {
+        self.bchField = nil;
+    }
+}
 
 - (void)selectFromEther
 {
@@ -1231,6 +1252,8 @@
 {
     [self.navigationController popViewControllerAnimated:YES];
 
+    [self clearFieldOfSymbol:self.fromSymbol];
+
     switch (asset) {
         case AssetTypeBitcoin:
             self.btcAccount = account;
@@ -1255,6 +1278,8 @@
 - (void)didSelectToAccount:(int)account assetType:(AssetType)asset
 {
     [self.navigationController popViewControllerAnimated:YES];
+
+    [self clearFieldOfSymbol:self.toSymbol];
 
     switch (asset) {
         case AssetTypeBitcoin:

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -719,7 +719,7 @@
                 self.ethField.text = ethString;
             } else if (self.topLeftField == self.btcField) {
                 self.btcField.text = btcString;
-            } else if (self.topLeftField == self.btcField) {
+            } else if (self.topLeftField == self.bchField) {
                 self.bchField.text = bchString;
             }
         } else if ([self.bottomRightField isFirstResponder]) {
@@ -727,7 +727,7 @@
                 self.ethField.text = ethString;
             } else if (self.topRightField == self.btcField) {
                 self.btcField.text = btcString;
-            } else if (self.topRightField == self.btcField) {
+            } else if (self.topRightField == self.bchField) {
                 self.bchField.text = bchString;
             }
         }

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -1248,17 +1248,14 @@
         case AssetTypeBitcoin:
             self.btcAccount = account;
             [self selectFromBitcoin];
-            self.fromToView.fromLabel.text = [self bitcoinLabelText];
             break;
         case AssetTypeBitcoinCash:
             self.bchAccount = account;
             [self selectFromBitcoinCash];
-            self.fromToView.fromLabel.text = [self bitcoinCashLabelText];
             break;
         case AssetTypeEther:
             self.ethAccount = account;
             [self selectFromEther];
-            self.fromToView.fromLabel.text = [self etherLabelText];
             break;
     }
 


### PR DESCRIPTION
There's still a hard-to-find issue with this - sometimes when changing the amounts in fields you get different amounts (amounts you may not have typed in). This may be related to the async operation `getApproximateQuote` or an incorrect assignment to the pointers `btcField`, `bchField`, and `ethField`.