### PR TITLE
fix(Exchange): prevent global reload method from dismissing exchange …

### DIFF
--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -239,7 +239,7 @@ BOOL displayingLocalSymbolSend;
 
     [app.wallet createNewPayment:self.assetType];
     [self resetFromAddress];
-    if (app.tabControllerManager.tabViewController.activeViewController == self) {
+    if (app.tabControllerManager.tabViewController.activeViewController == self && !app.tabControllerManager.tabViewController.presentedViewController) {
         [app closeModalWithTransition:kCATransitionPush];
     }
     


### PR DESCRIPTION
…success modal

After confirming an exchange payment, a modal view appears with a close button. In some cases a global `reload` is triggered by the payment, which causes the modal view to close prematurely when the app is showing the Send tab. This interrupts the transition back to the exchange screen with the table view of orders.

This is an example of how difficult it is to debug and keep components separate when so many processes depend on global methods like `reload`.