### PR TITLE
fix(AppDelegate): Using AppDelegate as UIApplicationDelegate over RootService

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -115,8 +115,6 @@
 		511646C9208129D800C43522 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C7208129D800C43522 /* Environment.swift */; };
 		511646CC208509F900C43522 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646CB208509F900C43522 /* API.swift */; };
 		511646CD208509F900C43522 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646CB208509F900C43522 /* API.swift */; };
-		511646DC208519DF00C43522 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646DB208519DF00C43522 /* UserAgent.swift */; };
-		511646DD208519DF00C43522 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646DB208519DF00C43522 /* UserAgent.swift */; };
 		511646DF20851BC600C43522 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646DE20851BC600C43522 /* Bundle.swift */; };
 		511646E020851BC600C43522 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646DE20851BC600C43522 /* Bundle.swift */; };
 		511646E2208523E300C43522 /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646E1208523E300C43522 /* UIDevice.swift */; };
@@ -138,8 +136,6 @@
 		5164E4D72059734800FC706A /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5164E4D62059734800FC706A /* Config.swift */; };
 		5164E4D82059734800FC706A /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5164E4D62059734800FC706A /* Config.swift */; };
 		5185B18A208697F1003C9AC2 /* BCPriceMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5185B189208697F1003C9AC2 /* BCPriceMarker.swift */; };
-		51A665C4207FF5B00040EE7C /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A665C3207FF5B00040EE7C /* LoadingView.swift */; };
-		51A665C5207FF5B00040EE7C /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A665C3207FF5B00040EE7C /* LoadingView.swift */; };
 		51A665C72080EBD80040EE7C /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A665C62080EBD80040EE7C /* AuthenticationError.swift */; };
 		51A665C82080EBD80040EE7C /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A665C62080EBD80040EE7C /* AuthenticationError.swift */; };
 		51C0C7542076B05E00684C52 /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E5C72F20741A130000A7FD /* AuthenticationManager.swift */; };
@@ -946,7 +942,6 @@
 		511646C4208124E200C43522 /* AssetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetType.swift; path = Assets/AssetType.swift; sourceTree = "<group>"; };
 		511646C7208129D800C43522 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		511646CB208509F900C43522 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = API.swift; path = Network/API.swift; sourceTree = "<group>"; };
-		511646DB208519DF00C43522 /* UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UserAgent.swift; path = Network/Extensions/UserAgent.swift; sourceTree = "<group>"; };
 		511646DE20851BC600C43522 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Bundle.swift; path = Extensions/Bundle.swift; sourceTree = "<group>"; };
 		511646E1208523E300C43522 /* UIDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIDevice.swift; path = Extensions/UIDevice.swift; sourceTree = "<group>"; };
 		511646E4208527EE00C43522 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NetworkManager.swift; path = Network/NetworkManager.swift; sourceTree = "<group>"; };
@@ -966,7 +961,6 @@
 		516594A7204F1DE600C50E78 /* Staging.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Staging.xcconfig; sourceTree = "<group>"; };
 		516594A9204F1E1000C50E78 /* Testnet.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Testnet.xcconfig; sourceTree = "<group>"; };
 		5185B189208697F1003C9AC2 /* BCPriceMarker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BCPriceMarker.swift; path = Views/BCPriceMarker.swift; sourceTree = "<group>"; };
-		51A665C3207FF5B00040EE7C /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LoadingView.swift; path = Views/LoadingView.swift; sourceTree = "<group>"; };
 		51A665C62080EBD80040EE7C /* AuthenticationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AuthenticationError.swift; path = Authentication/Models/AuthenticationError.swift; sourceTree = "<group>"; };
 		51E5C72D20741A120000A7FD /* RootServiceSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootServiceSwift.swift; sourceTree = "<group>"; };
 		51E5C72F20741A130000A7FD /* AuthenticationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthenticationManager.swift; path = Authentication/AuthenticationManager.swift; sourceTree = "<group>"; };
@@ -1547,7 +1541,6 @@
 		511646D62085199000C43522 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				511646DB208519DF00C43522 /* UserAgent.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2235,7 +2228,6 @@
 				5185B189208697F1003C9AC2 /* BCPriceMarker.swift */,
 				237827191B7E472D00E9EE03 /* BCSecureTextField.swift */,
 				67D95A251B3DD86B0012EBB1 /* BCTextField.swift */,
-				51A665C3207FF5B00040EE7C /* LoadingView.swift */,
 				678AD5EC19D4731C00E9A778 /* Modal Content Views */,
 			);
 			name = Views;
@@ -2552,9 +2544,7 @@
 				511646E920852C3C00C43522 /* CertificatePinner.swift in Sources */,
 				511646E020851BC600C43522 /* Bundle.swift in Sources */,
 				51C0C7542076B05E00684C52 /* AuthenticationManager.swift in Sources */,
-				51A665C5207FF5B00040EE7C /* LoadingView.swift in Sources */,
 				515902342049AF5000A4C2D8 /* WalletTests.swift in Sources */,
-				511646DD208519DF00C43522 /* UserAgent.swift in Sources */,
 				510EA1712080F16100A63AB8 /* Passcode.swift in Sources */,
 				513913F12081206C002578FD /* UserDefaults.swift in Sources */,
 				511646C6208124E200C43522 /* AssetType.swift in Sources */,
@@ -2758,7 +2748,6 @@
 				C75F70E41E241D69005B4EAF /* BCContactRequestView.m in Sources */,
 				9F4A5092152F585E00F9ED9D /* UIDevice+Hardware.m in Sources */,
 				6780DB921A40BDA70048EED2 /* AddressInOut.m in Sources */,
-				511646DC208519DF00C43522 /* UserAgent.swift in Sources */,
 				2322DCC11D771831000E5AC1 /* SRSIMDHelpers.m in Sources */,
 				9F2780B715343A7D0015F83F /* UncaughtExceptionHandler.m in Sources */,
 				673107F219F6D49F00BE6899 /* PrivateKeyReader.m in Sources */,
@@ -2795,7 +2784,6 @@
 				23BA220E1D6B4AB500D0472B /* KeychainItemWrapper+Credentials.m in Sources */,
 				23DEF96E1DB11C98004AAAB6 /* TransferAllFundsBuilder.m in Sources */,
 				C74E21C72024E6D700A9FBB1 /* BCPricePreviewView.m in Sources */,
-				51A665C4207FF5B00040EE7C /* LoadingView.swift in Sources */,
 				A269E92E1B32D51F0052F953 /* SecondPasswordViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -113,16 +113,10 @@
 		511646C6208124E200C43522 /* AssetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C4208124E200C43522 /* AssetType.swift */; };
 		511646C8208129D800C43522 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C7208129D800C43522 /* Environment.swift */; };
 		511646C9208129D800C43522 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C7208129D800C43522 /* Environment.swift */; };
-		511646CC208509F900C43522 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646CB208509F900C43522 /* API.swift */; };
-		511646CD208509F900C43522 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646CB208509F900C43522 /* API.swift */; };
 		511646DF20851BC600C43522 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646DE20851BC600C43522 /* Bundle.swift */; };
 		511646E020851BC600C43522 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646DE20851BC600C43522 /* Bundle.swift */; };
 		511646E2208523E300C43522 /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646E1208523E300C43522 /* UIDevice.swift */; };
 		511646E3208523E300C43522 /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646E1208523E300C43522 /* UIDevice.swift */; };
-		511646E5208527EE00C43522 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646E4208527EE00C43522 /* NetworkManager.swift */; };
-		511646E6208527EE00C43522 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646E4208527EE00C43522 /* NetworkManager.swift */; };
-		511646E820852C3C00C43522 /* CertificatePinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646E720852C3C00C43522 /* CertificatePinner.swift */; };
-		511646E920852C3C00C43522 /* CertificatePinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646E720852C3C00C43522 /* CertificatePinner.swift */; };
 		513468002056BC6700DE6A1E /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 513467FE2056BC6600DE6A1E /* Fabric.framework */; };
 		513913F02081206C002578FD /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513913EF2081206C002578FD /* UserDefaults.swift */; };
 		513913F12081206C002578FD /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513913EF2081206C002578FD /* UserDefaults.swift */; };
@@ -941,11 +935,8 @@
 		510EA17520810EF600A63AB8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		511646C4208124E200C43522 /* AssetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetType.swift; path = Assets/AssetType.swift; sourceTree = "<group>"; };
 		511646C7208129D800C43522 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
-		511646CB208509F900C43522 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = API.swift; path = Network/API.swift; sourceTree = "<group>"; };
 		511646DE20851BC600C43522 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Bundle.swift; path = Extensions/Bundle.swift; sourceTree = "<group>"; };
 		511646E1208523E300C43522 /* UIDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIDevice.swift; path = Extensions/UIDevice.swift; sourceTree = "<group>"; };
-		511646E4208527EE00C43522 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NetworkManager.swift; path = Network/NetworkManager.swift; sourceTree = "<group>"; };
-		511646E720852C3C00C43522 /* CertificatePinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CertificatePinner.swift; path = Network/CertificatePinner.swift; sourceTree = "<group>"; };
 		513467FE2056BC6600DE6A1E /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fabric.framework; path = Frameworks/Fabric.framework; sourceTree = "<group>"; };
 		513467FF2056BC6700DE6A1E /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Crashlytics.framework; path = Frameworks/Crashlytics.framework; sourceTree = "<group>"; };
 		513913EF2081206C002578FD /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UserDefaults.swift; path = Extensions/UserDefaults.swift; sourceTree = "<group>"; };
@@ -1527,24 +1518,6 @@
 			name = Ethereum;
 			sourceTree = "<group>";
 		};
-		511646CA2085095800C43522 /* Network */ = {
-			isa = PBXGroup;
-			children = (
-				511646CB208509F900C43522 /* API.swift */,
-				511646E720852C3C00C43522 /* CertificatePinner.swift */,
-				511646E4208527EE00C43522 /* NetworkManager.swift */,
-				511646D62085199000C43522 /* Extensions */,
-			);
-			name = Network;
-			sourceTree = "<group>";
-		};
-		511646D62085199000C43522 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Extensions;
-			sourceTree = "<group>";
-		};
 		515902322049AF5000A4C2D8 /* WalletTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1839,7 +1812,6 @@
 				510EA19620811FF100A63AB8 /* Extensions */,
 				9F0CBAAB15135DF200CD945D /* JavaScript */,
 				9F765F3A14BC7C3100048EFB /* Models */,
-				511646CA2085095800C43522 /* Network */,
 				C9D4B2AF193E023C00EDA9EA /* Resources */,
 				9FB3637C14B60128004BEA02 /* Supporting Files */,
 				9FCA4D18151494A300ECDFBE /* View Controllers */,
@@ -2540,8 +2512,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				511646CD208509F900C43522 /* API.swift in Sources */,
-				511646E920852C3C00C43522 /* CertificatePinner.swift in Sources */,
 				511646E020851BC600C43522 /* Bundle.swift in Sources */,
 				51C0C7542076B05E00684C52 /* AuthenticationManager.swift in Sources */,
 				515902342049AF5000A4C2D8 /* WalletTests.swift in Sources */,
@@ -2551,7 +2521,6 @@
 				510EA17720810EF600A63AB8 /* AppDelegate.swift in Sources */,
 				51A665C82080EBD80040EE7C /* AuthenticationError.swift in Sources */,
 				5164E4D82059734800FC706A /* Config.swift in Sources */,
-				511646E6208527EE00C43522 /* NetworkManager.swift in Sources */,
 				511646C9208129D800C43522 /* Environment.swift in Sources */,
 				511646E3208523E300C43522 /* UIDevice.swift in Sources */,
 			);
@@ -2632,7 +2601,6 @@
 				23BF73391C454B8C00204503 /* AccountsAndAddressesNavigationController.m in Sources */,
 				2378271A1B7E472D00E9EE03 /* BCSecureTextField.swift in Sources */,
 				9F2D934A14C05DD00053F0FF /* Address.m in Sources */,
-				511646E5208527EE00C43522 /* NetworkManager.swift in Sources */,
 				235BD5661C58216000969B31 /* BCModalViewController.m in Sources */,
 				67FA1A4D1ABA092D000C9196 /* RegExCategories.m in Sources */,
 				23DF4EFC1DBA586C0059CF92 /* KeychainItemWrapper+SwipeAddresses.m in Sources */,
@@ -2643,7 +2611,6 @@
 				9F0CBAD81513CA2600CD945D /* BCFadeView.m in Sources */,
 				511646C5208124E200C43522 /* AssetType.swift in Sources */,
 				67E9674E19DF285000305358 /* SideMenuViewController.m in Sources */,
-				511646CC208509F900C43522 /* API.swift in Sources */,
 				C7CE34BB1F4DE14500032806 /* DashboardViewController.m in Sources */,
 				9FCA4D161514949500ECDFBE /* ReceiveBitcoinViewController.m in Sources */,
 				2322DCBD1D771831000E5AC1 /* SRHTTPConnectMessage.m in Sources */,
@@ -2767,7 +2734,6 @@
 				23444F931DCD21B700573C8C /* BTCBase58.m in Sources */,
 				23EA61C51B54258D0032B907 /* SettingsTableViewController.m in Sources */,
 				C793E1FC1F8E7921001F171C /* ExchangeOverviewViewController.m in Sources */,
-				511646E820852C3C00C43522 /* CertificatePinner.swift in Sources */,
 				511646C8208129D800C43522 /* Environment.swift in Sources */,
 				23FB5C161D9ABBB20008C6AB /* TransactionDetailValueCell.m in Sources */,
 				23444F841DCD217000573C8C /* NSData+BTCData.m in Sources */,

--- a/Blockchain/Blockchain-Info.plist
+++ b/Blockchain/Blockchain-Info.plist
@@ -63,8 +63,6 @@
 	<string>Enabling Face ID allows you to securely access your wallet.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Blockchain needs access to your location to show you nearby businesses that accept Bitcoin</string>
-	<key>NSMainNibFile</key>
-	<string>MainWindow</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Your permission is needed in order to upload documents from your photo library</string>
 	<key>UIAppFonts</key>

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -147,6 +147,28 @@ void (^secondPasswordSuccess)(NSString *);
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+//    [Fabric with:@[[Crashlytics class]]];
+//
+//    AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
+//    app.window = appDelegate.window;
+//
+//    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+//
+//    [userDefaults registerDefaults:@{USER_DEFAULTS_KEY_ASSET_TYPE : [NSNumber numberWithInt:AssetTypeBitcoin]}];
+//
+//    [[NSUserDefaults standardUserDefaults] registerDefaults:@{USER_DEFAULTS_KEY_DEBUG_ENABLE_CERTIFICATE_PINNING : @YES}];
+//    [[NSUserDefaults standardUserDefaults] registerDefaults:@{USER_DEFAULTS_KEY_SWIPE_TO_RECEIVE_ENABLED : @YES}];
+//#ifndef DEBUG
+//    [[NSUserDefaults standardUserDefaults] setObject:ENV_INDEX_PRODUCTION forKey:USER_DEFAULTS_KEY_ENV];
+//    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:USER_DEFAULTS_KEY_DEBUG_ENABLE_CERTIFICATE_PINNING];
+//
+//    [[NSUserDefaults standardUserDefaults] removeObjectForKey:USER_DEFAULTS_KEY_DEBUG_SECURITY_REMINDER_CUSTOM_TIMER];
+//    [[NSUserDefaults standardUserDefaults] removeObjectForKey:USER_DEFAULTS_KEY_DEBUG_APP_REVIEW_PROMPT_CUSTOM_TIMER];
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:USER_DEFAULTS_KEY_DEBUG_SIMULATE_ZERO_TICKER];
+//    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:USER_DEFAULTS_KEY_DEBUG_SIMULATE_SURGE];
+//
+//    [[NSUserDefaults standardUserDefaults] synchronize];
+
     // TODO: migrate all code below to RootServiceSwift
 
 //    SharedSessionDelegate *sharedSessionDelegate = [[SharedSessionDelegate alloc] initWithCertificatePinner:self.certificatePinner];

--- a/Blockchain/RootServiceSwift.swift
+++ b/Blockchain/RootServiceSwift.swift
@@ -75,7 +75,7 @@ final class RootServiceSwift {
         //: Was initialized with `NSNumber numberWithInt:AssetTypeBitcoin` before, could cause side unwanted effects...
         // TODO: test for potential side effects
         let assetTypekey = UserDefaults.Keys.assetType.rawValue
-        UserDefaults.standard.register(defaults: [assetTypekey: [AssetType.bitcoin]])
+        UserDefaults.standard.register(defaults: [assetTypekey: [NSNumber(integerLiteral: AssetType.bitcoin.rawValue)]])
 
         let certPinningkey = UserDefaults.DebugKeys.enableCertificatePinning.rawValue
         UserDefaults.standard.register(defaults: [certPinningkey: true])


### PR DESCRIPTION
Looks like `RootService` was still the app's `UIAppDelegate` in the `swift` branch. This PR fixes that by making `AppDelegate.swift` as the new `UIAppDelegate`. There was also a bug in registering the asset type in NSUserDefaults that I fixed.

I also added commented out code in RootService so that we can reference it as we port changes to the new architecture.

Please merge and review #98 before reviewing/merging this.