### PR TITLE
feat(AppCoordinator): add AppCoordinator

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -107,8 +107,6 @@
 		23FDEFAC1D6F669100FC80D6 /* NSURLSession+SendSynchronousRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 23FDEFAB1D6F669100FC80D6 /* NSURLSession+SendSynchronousRequest.m */; };
 		510EA1702080F16100A63AB8 /* Passcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510EA16F2080F16100A63AB8 /* Passcode.swift */; };
 		510EA1712080F16100A63AB8 /* Passcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510EA16F2080F16100A63AB8 /* Passcode.swift */; };
-		510EA17620810EF600A63AB8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510EA17520810EF600A63AB8 /* AppDelegate.swift */; };
-		510EA17720810EF600A63AB8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510EA17520810EF600A63AB8 /* AppDelegate.swift */; };
 		511646C5208124E200C43522 /* AssetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C4208124E200C43522 /* AssetType.swift */; };
 		511646C6208124E200C43522 /* AssetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C4208124E200C43522 /* AssetType.swift */; };
 		511646C8208129D800C43522 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C7208129D800C43522 /* Environment.swift */; };
@@ -202,6 +200,9 @@
 		A269E92E1B32D51F0052F953 /* SecondPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A269E92D1B32D51F0052F953 /* SecondPasswordViewController.swift */; };
 		A2913FA21B31830000DC6C15 /* BackupNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2913FA11B31830000DC6C15 /* BackupNavigationViewController.swift */; };
 		AA69F65F2086A7500054EFCE /* BlockchainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */; };
+		AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F6582086A2720054EFCE /* AppCoordinator.swift */; };
+		AAA3333320880A2C0019AD55 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333220880A2B0019AD55 /* AppDelegate.swift */; };
+		AAA3333B2088115C0019AD55 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333A2088115C0019AD55 /* Coordinator.swift */; };
 		C70FF55E1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = C70FF55D1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m */; };
 		C70FF5661E7B051C00AC7F8B /* ContactTransactionTableCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C70FF5651E7B051C00AC7F8B /* ContactTransactionTableCell.xib */; };
 		C71859471F3E227D00745A87 /* BCDescriptionView.m in Sources */ = {isa = PBXBuildFile; fileRef = C71859461F3E227C00745A87 /* BCDescriptionView.m */; };
@@ -933,7 +934,6 @@
 		23FDEFAA1D6F669100FC80D6 /* NSURLSession+SendSynchronousRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSession+SendSynchronousRequest.h"; sourceTree = "<group>"; };
 		23FDEFAB1D6F669100FC80D6 /* NSURLSession+SendSynchronousRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLSession+SendSynchronousRequest.m"; sourceTree = "<group>"; };
 		510EA16F2080F16100A63AB8 /* Passcode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Passcode.swift; path = Authentication/Models/Passcode.swift; sourceTree = "<group>"; };
-		510EA17520810EF600A63AB8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		511646C4208124E200C43522 /* AssetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetType.swift; path = Assets/AssetType.swift; sourceTree = "<group>"; };
 		511646C7208129D800C43522 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		511646DE20851BC600C43522 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Bundle.swift; path = Extensions/Bundle.swift; sourceTree = "<group>"; };
@@ -1105,6 +1105,9 @@
 		A2AADC041B0B98720085144B /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Backup.strings; sourceTree = "<group>"; };
 		A2AADC071B0B999F0085144B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Backup.strings; sourceTree = "<group>"; };
 		AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchainSettings.swift; sourceTree = "<group>"; };
+		AA69F6582086A2720054EFCE /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		AAA3333220880A2B0019AD55 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		AAA3333A2088115C0019AD55 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		C70FF55C1E76D5C600AC7F8B /* BuyBitcoinNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BuyBitcoinNavigationController.h; sourceTree = "<group>"; };
 		C70FF55D1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BuyBitcoinNavigationController.m; sourceTree = "<group>"; };
 		C70FF5651E7B051C00AC7F8B /* ContactTransactionTableCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ContactTransactionTableCell.xib; sourceTree = "<group>"; };
@@ -1802,7 +1805,7 @@
 				673107F019F6D49F00BE6899 /* PrivateKeyReader.h */,
 				84F4BDF9197F21D700B7BF7B /* PairingCodeParser.m */,
 				673107F119F6D49F00BE6899 /* PrivateKeyReader.m */,
-				510EA17520810EF600A63AB8 /* AppDelegate.swift */,
+				AAA3333220880A2B0019AD55 /* AppDelegate.swift */,
 				5164E4D62059734800FC706A /* Config.swift */,
 				67D95A271B3DDC900012EBB1 /* Constants.swift */,
 				511646C7208129D800C43522 /* Environment.swift */,
@@ -1811,6 +1814,7 @@
 				511646C02081247700C43522 /* Assets */,
 				510EA1732080F58700A63AB8 /* Authentication */,
 				9F1831F315176F2200FB3D52 /* Categories */,
+				AAA33338208811460019AD55 /* Coordinators */,
 				510EA19620811FF100A63AB8 /* Extensions */,
 				9F0CBAAB15135DF200CD945D /* JavaScript */,
 				9F765F3A14BC7C3100048EFB /* Models */,
@@ -1956,6 +1960,15 @@
 				AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		AAA33338208811460019AD55 /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				AA69F6582086A2720054EFCE /* AppCoordinator.swift */,
+				AAA3333A2088115C0019AD55 /* Coordinator.swift */,
+			);
+			path = Coordinators;
 			sourceTree = "<group>";
 		};
 		C790E0F91E5205620063D141 /* Fonts */ = {
@@ -2529,7 +2542,6 @@
 				510EA1712080F16100A63AB8 /* Passcode.swift in Sources */,
 				513913F12081206C002578FD /* UserDefaults.swift in Sources */,
 				511646C6208124E200C43522 /* AssetType.swift in Sources */,
-				510EA17720810EF600A63AB8 /* AppDelegate.swift in Sources */,
 				51A665C82080EBD80040EE7C /* AuthenticationError.swift in Sources */,
 				5164E4D82059734800FC706A /* Config.swift in Sources */,
 				511646C9208129D800C43522 /* Environment.swift in Sources */,
@@ -2628,7 +2640,6 @@
 				2322DCBD1D771831000E5AC1 /* SRHTTPConnectMessage.m in Sources */,
 				C790E0F81E4E60AE0063D141 /* NSDateFormatter+TimeAgoString.m in Sources */,
 				230FD2D31C5BD04000336683 /* BCEditAddressView.m in Sources */,
-				510EA17620810EF600A63AB8 /* AppDelegate.swift in Sources */,
 				C75EE7D8201BBA820067BA16 /* UITextView+Animations.m in Sources */,
 				23C95EA61C0779C600E4692A /* SettingsChangePasswordViewController.m in Sources */,
 				23FDEFA91D6E43DE00FC80D6 /* TransactionDetailTableCell.m in Sources */,
@@ -2641,6 +2652,7 @@
 				5164E4D72059734800FC706A /* Config.swift in Sources */,
 				511646E2208523E300C43522 /* UIDevice.swift in Sources */,
 				C7CE34BE1F4E128900032806 /* BCAmountInputView.m in Sources */,
+				AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */,
 				23964C001DC93882001323BE /* ContactsViewController.m in Sources */,
 				67D95A261B3DD86B0012EBB1 /* BCTextField.swift in Sources */,
 				2322DCC01D771831000E5AC1 /* SRRandom.m in Sources */,
@@ -2740,6 +2752,7 @@
 				23BD046A1D7761C000DB69E6 /* UITextView+AssertionFailureFix.m in Sources */,
 				23D423991D0878BE000054AA /* ModuleXMLHttpRequest.m in Sources */,
 				C70FF55E1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m in Sources */,
+				AAA3333320880A2C0019AD55 /* AppDelegate.swift in Sources */,
 				C7640FBF2056B70E00D14D51 /* BCSwipeAddressViewModel.m in Sources */,
 				23F601A41D09C931009102BF /* Reachability.m in Sources */,
 				510EA1702080F16100A63AB8 /* Passcode.swift in Sources */,
@@ -2754,6 +2767,7 @@
 				C790E1241E5358540063D141 /* BCVerifyMobileNumberViewController.m in Sources */,
 				C7448A962034BF2F0041947E /* AssetSelectionTableViewCell.m in Sources */,
 				C7B6855B1F17AE2A00A18A5C /* BCEmptyPageView.m in Sources */,
+				AAA3333B2088115C0019AD55 /* Coordinator.swift in Sources */,
 				84CCFAAF197D859C00DA4482 /* NSString+NSString_EscapeQuotes.m in Sources */,
 				232D7DE11E018E7800A7A2ED /* ContactNewMessageViewController.m in Sources */,
 				2390C10B1D87376E00342C38 /* TransactionRecipientsViewController.m in Sources */,

--- a/Blockchain/AccountTableCell.m
+++ b/Blockchain/AccountTableCell.m
@@ -19,7 +19,7 @@
     self = [super init];
     
     if (self) {
-        ECSlidingViewController *sideMenu = app.slidingViewController;
+        ECSlidingViewController *sideMenu = [AppCoordinator sharedInstance].slidingViewController;
         
         _iconImage = [[UIImageView alloc] initWithFrame:CGRectMake(18, 10, 22, 22)];
         [self addSubview:_iconImage];

--- a/Blockchain/AccountsAndAddressesNavigationController.m
+++ b/Blockchain/AccountsAndAddressesNavigationController.m
@@ -28,7 +28,7 @@
 {
     [super viewDidLoad];
     
-    self.view.frame = CGRectMake(0, 0, app.window.frame.size.width, app.window.frame.size.height);
+    self.view.frame = CGRectMake(0, 0, [UIApplication sharedApplication].keyWindow.frame.size.width, [UIApplication sharedApplication].keyWindow.frame.size.height);
     
     UIView *topBar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_HEADER_HEIGHT + 8 + ASSET_SELECTOR_ROW_HEIGHT)];
     topBar.backgroundColor = COLOR_BLOCKCHAIN_BLUE;
@@ -149,7 +149,7 @@
 
 - (void)setupBusyView
 {
-    BCFadeView *busyView = [[BCFadeView alloc] initWithFrame:app.window.rootViewController.view.frame];
+    BCFadeView *busyView = [[BCFadeView alloc] initWithFrame:[UIApplication sharedApplication].keyWindow.rootViewController.view.frame];
     busyView.backgroundColor = [UIColor colorWithRed:0.0 green:0.0 blue:0.0 alpha:0.5];
     UIView *textWithSpinnerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 250, 110)];
     textWithSpinnerView.backgroundColor = [UIColor whiteColor];

--- a/Blockchain/AccountsAndAddressesViewController.m
+++ b/Blockchain/AccountsAndAddressesViewController.m
@@ -34,9 +34,9 @@
 {
     [super viewDidLoad];
     
-    self.view.frame = app.window.frame;
+    self.view.frame = [UIApplication sharedApplication].keyWindow.frame;
     
-    UIView *containerView = [[UIView alloc] initWithFrame:CGRectOffset(app.window.frame, 0, DEFAULT_HEADER_HEIGHT + ASSET_SELECTOR_ROW_HEIGHT + 8)];
+    UIView *containerView = [[UIView alloc] initWithFrame:CGRectOffset([UIApplication sharedApplication].keyWindow.frame, 0, DEFAULT_HEADER_HEIGHT + ASSET_SELECTOR_ROW_HEIGHT + 8)];
     [self.view addSubview:containerView];
     self.containerView = containerView;
     

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -13,11 +13,9 @@ import Crashlytics
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var window: UIWindow?
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         Fabric.with([Crashlytics.self])
-        // TODO: instantiate root vc from login storyboard. Deprecate Root Service.        
+        // TODO: instantiate root vc from login storyboard. Deprecate Root Service.
         return RootServiceSwift.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 

--- a/Blockchain/BCAddressSelectionView.m
+++ b/Blockchain/BCAddressSelectionView.m
@@ -213,7 +213,7 @@ typedef enum {
         
         [self addSubview:mainView];
         
-        mainView.frame = CGRectMake(0, 0, app.window.frame.size.width, app.window.frame.size.height);
+        mainView.frame = CGRectMake(0, 0, [UIApplication sharedApplication].keyWindow.frame.size.width, [UIApplication sharedApplication].keyWindow.frame.size.height);
         
         [tableView layoutIfNeeded];
         float tableHeight = [tableView contentSize].height;

--- a/Blockchain/BCContactRequestView.m
+++ b/Blockchain/BCContactRequestView.m
@@ -30,7 +30,7 @@
 
 - (id)initWithContact:(Contact *)contact amount:(uint64_t)amount willSend:(BOOL)willSend accountOrAddress:(id)accountOrAddress
 {
-    UIWindow *window = app.window;
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
     
     self = [super initWithFrame:CGRectMake(0, DEFAULT_HEADER_HEIGHT, window.frame.size.width, window.frame.size.height - DEFAULT_HEADER_HEIGHT)];
     

--- a/Blockchain/BCCreateAccountView.m
+++ b/Blockchain/BCCreateAccountView.m
@@ -14,7 +14,7 @@
 
 -(id)init
 {
-    UIWindow *window = app.window;
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
     
     self = [super initWithFrame:CGRectMake(0, DEFAULT_HEADER_HEIGHT, window.frame.size.width, window.frame.size.height - DEFAULT_HEADER_HEIGHT)];
     

--- a/Blockchain/BCEditAccountView.m
+++ b/Blockchain/BCEditAccountView.m
@@ -14,7 +14,7 @@
 
 -(id)initWithAssetType:(AssetType)assetType
 {
-    UIWindow *window = app.window;
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
     
     self = [super initWithFrame:CGRectMake(0, DEFAULT_HEADER_HEIGHT, window.frame.size.width, window.frame.size.height - DEFAULT_HEADER_HEIGHT)];
     

--- a/Blockchain/BCEditAddressView.m
+++ b/Blockchain/BCEditAddressView.m
@@ -14,7 +14,7 @@
 
 -(id)initWithAddress:(NSString *)address
 {
-    UIWindow *window = app.window;
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
     
     self = [super initWithFrame:CGRectMake(0, DEFAULT_HEADER_HEIGHT, window.frame.size.width, window.frame.size.height - DEFAULT_HEADER_HEIGHT)];
     

--- a/Blockchain/BCManualPairView.m
+++ b/Blockchain/BCManualPairView.m
@@ -38,7 +38,7 @@
     passwordTextField.delegate = self;
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (![app.window.rootViewController presentedViewController]) {
+        if (![[UIApplication sharedApplication].keyWindow.rootViewController presentedViewController]) {
             [walletIdentifierTextField becomeFirstResponder];
         }
     });
@@ -81,7 +81,7 @@
         [passwordTextField becomeFirstResponder];
     }
     else if (textField == verifyTwoFactorTextField) {
-        [app.window.rootViewController dismissViewControllerAnimated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController dismissViewControllerAnimated:YES completion:nil];
         app.wallet.twoFactorInput = [textField.text uppercaseString];
         [self continueClicked:textField];
     } else {
@@ -147,7 +147,7 @@
         verifyTwoFactorTextField.returnKeyType = UIReturnKeyDone;
         verifyTwoFactorTextField.placeholder = BC_STRING_ENTER_VERIFICATION_CODE;
     }];
-    [app.window.rootViewController presentViewController:alertForVerifyingMobileNumber animated:YES completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertForVerifyingMobileNumber animated:YES completion:nil];
 }
 
 - (void)verifyTwoFactorGoogle
@@ -176,7 +176,7 @@
         verifyTwoFactorTextField.returnKeyType = UIReturnKeyDone;
         verifyTwoFactorTextField.placeholder = BC_STRING_ENTER_VERIFICATION_CODE;
     }];
-    [app.window.rootViewController presentViewController:alertForVerifying animated:YES completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertForVerifying animated:YES completion:nil];
 }
 
 @end

--- a/Blockchain/BCModalView.m
+++ b/Blockchain/BCModalView.m
@@ -14,7 +14,7 @@
 
 - (id)initWithCloseType:(ModalCloseType)closeType showHeader:(BOOL)showHeader headerText:(NSString *)headerText
 {
-    UIWindow *window = app.window;
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
     
     self = [super initWithFrame:CGRectMake(0, 0, window.frame.size.width, window.frame.size.height)];
     

--- a/Blockchain/BCWebViewController.m
+++ b/Blockchain/BCWebViewController.m
@@ -42,7 +42,7 @@ NSMutableArray *visitedPages;
 {
     [super viewDidLoad];
     
-    self.view.frame = CGRectMake(0, 0, app.window.frame.size.width, app.window.frame.size.height);
+    self.view.frame = CGRectMake(0, 0, [UIApplication sharedApplication].keyWindow.frame.size.width, [UIApplication sharedApplication].keyWindow.frame.size.height);
     
     UIView *topBar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_HEADER_HEIGHT)];
     topBar.backgroundColor = COLOR_BLOCKCHAIN_BLUE;

--- a/Blockchain/BCWelcomeView.m
+++ b/Blockchain/BCWelcomeView.m
@@ -10,6 +10,7 @@
 #import "RootService.h"
 #import "LocalizationConstants.h"
 #import "DebugTableViewController.h"
+#import "Blockchain-Swift.h"
 
 @implementation BCWelcomeView
 
@@ -18,7 +19,7 @@ Boolean shouldShowAnimation;
 
 -(id)init
 {
-    UIWindow *window = app.window;
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
     
     shouldShowAnimation = true;
     
@@ -96,7 +97,7 @@ Boolean shouldShowAnimation;
 - (void)handleLongPress:(UILongPressGestureRecognizer *)longPress
 {
     if (longPress.state == UIGestureRecognizerStateBegan) {
-        [app showDebugMenu:DEBUG_PRESENTER_WELCOME_VIEW];
+        [[AppCoordinator sharedInstance] showDebugViewWithPresenter: DEBUG_PRESENTER_WELCOME_VIEW];
     }
 }
 

--- a/Blockchain/Blockchain-Bridging-Header.h
+++ b/Blockchain/Blockchain-Bridging-Header.h
@@ -2,14 +2,18 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#import <openssl/x509.h>
 #import <UIKit/UIKit.h>
-#import "Wallet.h"
-#import "RootService.h"
-#import "KeychainItemWrapper.h"
+#import "BCFadeView.h"
+#import "BCNavigationController.h"
+#import "BCWelcomeView.h"
+#import "DebugTableViewController.h"
 #import "KeychainItemWrapper+Credentials.h"
 #import "KeychainItemWrapper+SwipeAddresses.h"
-#import "BCFadeView.h"
-#import "UIViewController+AutoDismiss.h"
+#import "KeychainItemWrapper.h"
+#import "RootService.h"
+#import "SideMenuViewController.h"
 #import "TransferAllFundsViewController.h"
-#import "BCNavigationController.h"
-#import <openssl/x509.h>
+#import "UIDevice+Hardware.h"
+#import "UIViewController+AutoDismiss.h"
+#import "Wallet.h"

--- a/Blockchain/BuyBitcoinViewController.m
+++ b/Blockchain/BuyBitcoinViewController.m
@@ -137,7 +137,7 @@ NSString* loginWithJsonScript(NSString* json, NSString* externalJson, NSString* 
             if (app.topViewControllerDelegate) {
                 targetController = app.topViewControllerDelegate;
             } else {
-                targetController = app.window.rootViewController;
+                targetController = [UIApplication sharedApplication].keyWindow.rootViewController;
             }
             
             UIAlertController *errorAlert = [UIAlertController alertControllerWithTitle:BC_STRING_ERROR message:BC_STRING_BUY_WEBVIEW_ERROR_MESSAGE preferredStyle:UIAlertControllerStyleAlert];

--- a/Blockchain/ContactTransactionTableViewCell.m
+++ b/Blockchain/ContactTransactionTableViewCell.m
@@ -172,7 +172,7 @@
         if (app.topViewControllerDelegate) {
             [app.topViewControllerDelegate presentViewController:navigationController animated:YES completion:nil];
         } else {
-            [app.window.rootViewController presentViewController:navigationController animated:YES completion:nil];
+            [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navigationController animated:YES completion:nil];
         }
     }
 }

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -1,0 +1,87 @@
+//
+//  AppCoordinator.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/17/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Application coordinator.
+
+ This Singleton coordinator is in charge of coordinating the set of views that are
+ presented when the app first launches.
+*/
+@objc class AppCoordinator: NSObject, Coordinator {
+    static let shared = AppCoordinator()
+
+    // class function declared so that the AppCoordinator singleton can be accessed from obj-C
+    @objc class func sharedInstance() -> AppCoordinator {
+        return AppCoordinator.shared
+    }
+
+    // MARK: Properties
+
+    private(set) var window: UIWindow
+
+    @objc lazy var slidingViewController: ECSlidingViewController = {
+        let viewController = ECSlidingViewController()
+        viewController.underLeftViewController = SideMenuViewController()
+        viewController.topViewController = tabControllerManager.tabViewController
+        return viewController
+    }()
+
+    @objc lazy var tabControllerManager: TabControllerManager = { [unowned self] in
+        let tabControllerManager = TabControllerManager()
+        tabControllerManager.delegate = self
+        return tabControllerManager
+    }()
+
+    // MARK: NSObject
+
+    override private init() {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        window.backgroundColor = UIColor.white
+        super.init()
+    }
+
+    // MARK: Public Methods
+
+    @objc func start() {
+        // Set rootViewController
+        window.rootViewController = slidingViewController
+        window.makeKeyAndVisible()
+
+        tabControllerManager.dashBoardClicked(nil)
+
+        // Display welcome screen if no wallet is authenticated
+        if KeychainItemWrapper.guid() == nil || KeychainItemWrapper.sharedKey() == nil {
+            // TODO start onboarding coordinator
+        } else {
+            // TODO otherwise, show pin screen
+        }
+    }
+
+    @objc func showDebugView(presenter: Int32) {
+        let debugViewController = DebugTableViewController()
+        debugViewController.presenter = presenter
+        let navigationController = UINavigationController(rootViewController: debugViewController)
+        window.rootViewController?.present(navigationController, animated: true)
+    }
+}
+
+extension AppCoordinator: TabControllerDelegate {
+    func toggleSideMenu() {
+        // If the sideMenu is not shown, show it
+        if slidingViewController.currentTopViewPosition == .centered {
+            slidingViewController.anchorTopViewToRight(animated: true)
+        } else {
+            slidingViewController.resetTopView(animated: true)
+        }
+
+        // TODO remove app reference and use wallet singleton
+        app.wallet.isFetchingTransactions = false
+    }
+}

--- a/Blockchain/Coordinators/Coordinator.swift
+++ b/Blockchain/Coordinators/Coordinator.swift
@@ -1,0 +1,17 @@
+//
+//  Coordinator.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/18/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol definition for a coordinator.
+/// Read more here: https://will.townsend.io/2016/an-ios-coordinator-pattern
+protocol Coordinator {
+
+    /// Starts the user flow encapsulated by this coordinator
+    func start()
+}

--- a/Blockchain/KeychainItemWrapper+Credentials.h
+++ b/Blockchain/KeychainItemWrapper+Credentials.h
@@ -9,12 +9,12 @@
 #import "KeychainItemWrapper.h"
 
 @interface KeychainItemWrapper (Credentials)
-+ (NSString *)guid;
++ (nullable NSString *)guid;
 + (NSString *)hashedGuid;
 + (void)setGuidInKeychain:(NSString *)guid;
 + (void)removeGuidFromKeychain;
 
-+ (NSString *)sharedKey;
++ (nullable NSString *)sharedKey;
 + (void)setSharedKeyInKeychain:(NSString *)sharedKey;
 + (void)removeSharedKeyFromKeychain;
 

--- a/Blockchain/PairingCodeParser.m
+++ b/Blockchain/PairingCodeParser.m
@@ -29,7 +29,7 @@
 {
     [super viewDidLoad];
     
-    self.view.frame = CGRectMake(0, 0, app.window.frame.size.width, app.window.frame.size.height - DEFAULT_HEADER_HEIGHT);
+    self.view.frame = CGRectMake(0, 0, [UIApplication sharedApplication].keyWindow.frame.size.width, [UIApplication sharedApplication].keyWindow.frame.size.height - DEFAULT_HEADER_HEIGHT);
     
     UIView *topBarView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_HEADER_HEIGHT)];
     topBarView.backgroundColor = COLOR_BLOCKCHAIN_BLUE;
@@ -89,7 +89,7 @@
     _videoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:_captureSession];
     [_videoPreviewLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
     
-    CGRect frame = CGRectMake(0, DEFAULT_HEADER_HEIGHT, app.window.frame.size.width, app.window.frame.size.height - DEFAULT_HEADER_HEIGHT);
+    CGRect frame = CGRectMake(0, DEFAULT_HEADER_HEIGHT, [UIApplication sharedApplication].keyWindow.frame.size.width, [UIApplication sharedApplication].keyWindow.frame.size.height - DEFAULT_HEADER_HEIGHT);
     
     [_videoPreviewLayer setFrame:frame];
     

--- a/Blockchain/PrivateKeyReader.m
+++ b/Blockchain/PrivateKeyReader.m
@@ -36,7 +36,7 @@
 {
     [super viewDidLoad];
     
-    self.view.frame = CGRectMake(0, 0, app.window.frame.size.width, app.window.frame.size.height - DEFAULT_HEADER_HEIGHT);
+    self.view.frame = CGRectMake(0, 0, [UIApplication sharedApplication].keyWindow.frame.size.width, [UIApplication sharedApplication].keyWindow.frame.size.height - DEFAULT_HEADER_HEIGHT);
     
     UIView *topBarView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_HEADER_HEIGHT)];
     topBarView.backgroundColor = COLOR_BLOCKCHAIN_BLUE;
@@ -94,7 +94,7 @@
     _videoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:_captureSession];
     [_videoPreviewLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
     
-    CGRect frame = CGRectMake(0, DEFAULT_HEADER_HEIGHT, app.window.frame.size.width, app.window.frame.size.height - DEFAULT_HEADER_HEIGHT);
+    CGRect frame = CGRectMake(0, DEFAULT_HEADER_HEIGHT, [UIApplication sharedApplication].keyWindow.frame.size.width, [UIApplication sharedApplication].keyWindow.frame.size.height - DEFAULT_HEADER_HEIGHT);
     
     [_videoPreviewLayer setFrame:frame];
     

--- a/Blockchain/ReceiveBitcoinViewController.m
+++ b/Blockchain/ReceiveBitcoinViewController.m
@@ -717,7 +717,7 @@
         
     }]];
     
-    [app.window.rootViewController presentViewController:alert animated:YES completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)alertUserOfWatchOnlyAddress:(NSString *)address
@@ -832,7 +832,7 @@
     descriptionLabelBottom.center = CGPointMake(introducingContactsView.center.x, descriptionLabelBottom.center.y);
     [introducingContactsView addSubview:descriptionLabelBottom];
 
-    UIButton *dismissButton = [[UIButton alloc] initWithFrame:CGRectMake(15, app.window.frame.size.height - BUTTON_HEIGHT - 16, introducingContactsView.frame.size.width - 30, BUTTON_HEIGHT)];
+    UIButton *dismissButton = [[UIButton alloc] initWithFrame:CGRectMake(15, [UIApplication sharedApplication].keyWindow.frame.size.height - BUTTON_HEIGHT - 16, introducingContactsView.frame.size.width - 30, BUTTON_HEIGHT)];
     [dismissButton setTitle:BC_STRING_ILL_DO_THIS_LATER forState:UIControlStateNormal];
     [dismissButton setTitleColor:COLOR_MEDIUM_GRAY forState:UIControlStateNormal];
     dismissButton.titleLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:17.0];
@@ -853,7 +853,7 @@
     
     [UIApplication sharedApplication].statusBarStyle = UIBarStyleDefault;
     
-    [app.window.rootViewController presentViewController:modalViewController animated:YES completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:modalViewController animated:YES completion:nil];
 }
 
 - (void)selectFromClicked
@@ -933,14 +933,14 @@
 {
     [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
     
-    [app.window.rootViewController dismissViewControllerAnimated:YES completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)showContacts
 {
     [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
     
-    [app.window.rootViewController dismissViewControllerAnimated:YES completion:^{
+    [[UIApplication sharedApplication].keyWindow.rootViewController dismissViewControllerAnimated:YES completion:^{
         [app contactsClicked:nil];
     }];
 }
@@ -973,7 +973,7 @@
         return NO;
     }
     
-    if (app.slidingViewController.currentTopViewPosition == ECSlidingViewControllerTopViewPositionAnchoredRight) {
+    if ([AppCoordinator sharedInstance].slidingViewController.currentTopViewPosition == ECSlidingViewControllerTopViewPositionAnchoredRight) {
         return NO;
     }
     

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -189,8 +189,8 @@
 
 - (void)showSendCoins;
 - (void)showAccountsAndAddresses;
-- (void)showDebugMenu:(int)presenter;
 - (void)showHdUpgrade;
+//- (void)showDebugMenu:(int)presenter;
 - (void)showBackupReminder:(BOOL)firstReceive;
 
 - (IBAction)webLoginClicked:(id)sender;

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -206,17 +206,19 @@ void (^secondPasswordSuccess)(NSString *);
         self.loadingText = [notification object];
     }];
 
-    app.window.backgroundColor = [UIColor whiteColor];
-
-    [self setupSideMenu];
-
-    [app.window makeKeyAndVisible];
-
-    // TODO: Migrate elsewhere
-    [self.tabControllerManager dashBoardClicked:nil];
+//    app.window.backgroundColor = [UIColor whiteColor];
+//
+//    [self setupSideMenu];
+//
+//    [app.window makeKeyAndVisible];
+//
+//    [self.tabControllerManager dashBoardClicked:nil];
 
     // Add busy view to root vc
     [app.window.rootViewController.view addSubview:busyView];
+
+    // Default view in TabViewController: dashboard
+    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:busyView];
 
     // Load settings
     symbolLocal = [[NSUserDefaults standardUserDefaults] boolForKey:USER_DEFAULTS_KEY_SYMBOL_LOCAL];
@@ -231,16 +233,16 @@ void (^secondPasswordSuccess)(NSString *);
     secondPasswordTextField.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_SMALL];
     secondPasswordButton.titleLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_LARGE];
 
-    // Show welcome screen if guid or sharedKey are not set
-    if (![KeychainItemWrapper guid] || ![KeychainItemWrapper sharedKey]) {
-        [self showWelcomeScreen];
-        [self checkAndWarnOnJailbrokenPhones];
-        return YES;
-    }
-
-    // ... Otherwise show the pin screen
-    //: This step should happen as the app delegate instantiates the login screen from the storyboard
-    [self showPinScreen];
+//    // Show welcome screen if guid or sharedKey are not set
+//    if (![KeychainItemWrapper guid] || ![KeychainItemWrapper sharedKey]) {
+//        [self showWelcomeScreen];
+//        [self checkAndWarnOnJailbrokenPhones];
+//        return YES;
+//    }
+//
+//    // ... Otherwise show the pin screen
+//    //: This step should happen as the app delegate instantiates the login screen from the storyboard
+//    [self showPinScreen];
 
     return YES;
 }
@@ -349,7 +351,7 @@ void (^secondPasswordSuccess)(NSString *);
 
     [self.loginTimer invalidate];
 
-    [app.window.rootViewController dismissViewControllerAnimated:NO completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController dismissViewControllerAnimated:NO completion:nil];
 
     [self hideSendAndReceiveKeyboards];
 
@@ -625,14 +627,14 @@ void (^secondPasswordSuccess)(NSString *);
     [NSURLCache setSharedURLCache:sharedCache];
 }
 
-- (void)setupSideMenu
-{
-    _slidingViewController = [[ECSlidingViewController alloc] init];
-    _slidingViewController.topViewController = self.tabControllerManager.tabViewController;
-    sideMenuViewController = [[SideMenuViewController alloc] init];
-    _slidingViewController.underLeftViewController = sideMenuViewController;
-    _window.rootViewController = _slidingViewController;
-}
+//- (void)setupSideMenu
+//{
+//    _slidingViewController = [[ECSlidingViewController alloc] init];
+//    _slidingViewController.topViewController = self.tabControllerManager.tabViewController;
+//    sideMenuViewController = [[SideMenuViewController alloc] init];
+//    _slidingViewController.underLeftViewController = sideMenuViewController;
+//    _window.rootViewController = _slidingViewController;
+//}
 
 //- (void)showWelcomeOrPinScreen
 //{
@@ -798,7 +800,7 @@ void (^secondPasswordSuccess)(NSString *);
 
     [busyLabel setText:text];
 
-    [app.window.rootViewController.view bringSubviewToFront:busyView];
+    [[UIApplication sharedApplication].keyWindow.rootViewController.view bringSubviewToFront:busyView];
 
     if (busyView.alpha < 1.0) {
         [busyView fadeIn];
@@ -1458,7 +1460,7 @@ void (^secondPasswordSuccess)(NSString *);
     [animation setType:kCATransitionFade];
 
     [animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
-    [[app.window layer] addAnimation:animation forKey:ANIMATION_KEY_HIDE_MODAL];
+    [[[UIApplication sharedApplication].keyWindow layer] addAnimation:animation forKey:ANIMATION_KEY_HIDE_MODAL];
 
     if (self.modalView.onDismiss) {
         self.modalView.onDismiss();
@@ -1501,7 +1503,7 @@ void (^secondPasswordSuccess)(NSString *);
     }
 
     [animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
-    [[app.window layer] addAnimation:animation forKey:ANIMATION_KEY_HIDE_MODAL];
+    [[[UIApplication sharedApplication].keyWindow layer] addAnimation:animation forKey:ANIMATION_KEY_HIDE_MODAL];
 
     if (self.modalView.onDismiss) {
         self.modalView.onDismiss();
@@ -1511,11 +1513,11 @@ void (^secondPasswordSuccess)(NSString *);
     if ([self.modalChain count] > 0) {
         BCModalView * previousModalView = [self.modalChain objectAtIndex:[self.modalChain count]-1];
 
-        [app.window.rootViewController.view addSubview:previousModalView];
+        [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:previousModalView];
 
-        [app.window.rootViewController.view bringSubviewToFront:busyView];
+        [[UIApplication sharedApplication].keyWindow.rootViewController.view bringSubviewToFront:busyView];
 
-        [app.window.rootViewController.view endEditing:TRUE];
+        [[UIApplication sharedApplication].keyWindow.rootViewController.view endEditing:TRUE];
 
         if (self.modalView.onResume) {
             self.modalView.onResume();
@@ -1574,8 +1576,8 @@ void (^secondPasswordSuccess)(NSString *);
 
     contentView.frame = CGRectMake(0, 0, modalView.myHolderView.frame.size.width, modalView.myHolderView.frame.size.height);
 
-    [app.window.rootViewController.view addSubview:modalView];
-    [app.window.rootViewController.view endEditing:TRUE];
+    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:modalView];
+    [[UIApplication sharedApplication].keyWindow.rootViewController.view endEditing:TRUE];
 
     @try {
         CATransition *animation = [CATransition animation];
@@ -1590,7 +1592,7 @@ void (^secondPasswordSuccess)(NSString *);
         }
 
         [animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
-        [[app.window.rootViewController.view layer] addAnimation:animation forKey:ANIMATION_KEY_SHOW_MODAL];
+        [[[UIApplication sharedApplication].keyWindow.rootViewController.view layer] addAnimation:animation forKey:ANIMATION_KEY_SHOW_MODAL];
     } @catch (NSException * e) {
         DLog(@"Animation Exception %@", e);
     }
@@ -1678,7 +1680,7 @@ void (^secondPasswordSuccess)(NSString *);
     if (self.topViewControllerDelegate) {
         [self.topViewControllerDelegate presentViewController:reader animated:YES completion:nil];
     } else {
-        [app.window.rootViewController presentViewController:reader animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:reader animated:YES completion:nil];
     }
 
     app.wallet.lastScannedWatchOnlyAddress = address;
@@ -1697,7 +1699,7 @@ void (^secondPasswordSuccess)(NSString *);
     if (self.topViewControllerDelegate) {
         [self.topViewControllerDelegate presentViewController:alertToWarnAboutWatchOnly animated:YES completion:nil];
     } else {
-        [app.window.rootViewController presentViewController:alertToWarnAboutWatchOnly animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertToWarnAboutWatchOnly animated:YES completion:nil];
     }
 }
 
@@ -1800,7 +1802,7 @@ void (^secondPasswordSuccess)(NSString *);
             [self.topViewControllerDelegate presentAlertController:alert];
         }
     } else {
-        [app.window.rootViewController presentViewController:alert animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
     }
 }
 
@@ -1826,7 +1828,7 @@ void (^secondPasswordSuccess)(NSString *);
             [self.topViewControllerDelegate presentAlertController:alert];
         }
     } else {
-        [app.window.rootViewController presentViewController:alert animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
     }
 }
 
@@ -1850,7 +1852,7 @@ void (^secondPasswordSuccess)(NSString *);
             [self.topViewControllerDelegate presentAlertController:alert];
         }
     } else {
-        [app.window.rootViewController presentViewController:alert animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
     }
 }
 
@@ -1880,7 +1882,7 @@ void (^secondPasswordSuccess)(NSString *);
             [self.topViewControllerDelegate presentAlertController:errorAlert];
         }
     } else {
-        [app.window.rootViewController presentViewController:errorAlert animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:errorAlert animated:YES completion:nil];
     }
 }
 
@@ -1912,7 +1914,7 @@ void (^secondPasswordSuccess)(NSString *);
             [self.topViewControllerDelegate presentAlertController:errorAlert];
         }
     } else {
-        [app.window.rootViewController presentViewController:errorAlert animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:errorAlert animated:YES completion:nil];
     }
 }
 
@@ -2627,10 +2629,10 @@ void (^secondPasswordSuccess)(NSString *);
         [app performSelector:@selector(suspend)];
     }]];
 
-    if (app.window.rootViewController.presentedViewController) {
-        [app.window.rootViewController.presentedViewController presentViewController:alert animated:YES completion:nil];
+    if ([UIApplication sharedApplication].keyWindow.rootViewController.presentedViewController) {
+        [[UIApplication sharedApplication].keyWindow.rootViewController.presentedViewController presentViewController:alert animated:YES completion:nil];
     } else {
-        [app.window.rootViewController presentViewController:alert animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
     }
 }
 
@@ -2712,15 +2714,15 @@ void (^secondPasswordSuccess)(NSString *);
     [self.tabControllerManager showSendCoinsAnimated:YES];
 }
 
-- (void)showDebugMenu:(int)presenter
-{
-    DebugTableViewController *debugViewController = [[DebugTableViewController alloc] init];
-    debugViewController.presenter = presenter;
-
-    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:debugViewController];
-
-    [self.window.rootViewController presentViewController:navigationController animated:YES completion:nil];
-}
+//- (void)showDebugMenu:(int)presenter
+//{
+//    DebugTableViewController *debugViewController = [[DebugTableViewController alloc] init];
+//    debugViewController.presenter = presenter;
+//
+//    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:debugViewController];
+//
+//    [self.window.rootViewController presentViewController:navigationController animated:YES completion:nil];
+//}
 
 - (void)showPinModalAsView:(BOOL)asView
 {
@@ -2736,7 +2738,7 @@ void (^secondPasswordSuccess)(NSString *);
     [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:YES];
 
     // Don't show a new one if we already show it
-    if ([self.pinEntryViewController.view isDescendantOfView:app.window.rootViewController.view] ||
+    if ([self.pinEntryViewController.view isDescendantOfView:[UIApplication sharedApplication].keyWindow.rootViewController.view] ||
         (self.tabControllerManager.tabViewController.presentedViewController != nil && self.tabControllerManager.tabViewController.presentedViewController == self.pinEntryViewController && !_pinEntryViewController.isBeingDismissed)) {
         return;
     }
@@ -2757,10 +2759,10 @@ void (^secondPasswordSuccess)(NSString *);
     if (asView) {
         if ([_settingsNavigationController isBeingPresented]) {
             // Immediately after enabling touch ID, backgrounding the app while the Settings scren is still being presented results in failure to add the PIN screen back. Using a delay to allow animation to complete fixes this
-            [app.window.rootViewController.view performSelector:@selector(addSubview:) withObject:self.pinEntryViewController.view afterDelay:DELAY_KEYBOARD_DISMISSAL];
+            [[UIApplication sharedApplication].keyWindow.rootViewController.view performSelector:@selector(addSubview:) withObject:self.pinEntryViewController.view afterDelay:DELAY_KEYBOARD_DISMISSAL];
             [self performSelector:@selector(showStatusBar) withObject:nil afterDelay:DELAY_KEYBOARD_DISMISSAL];
         } else {
-            [app.window.rootViewController.view addSubview:self.pinEntryViewController.view];
+            [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:self.pinEntryViewController.view];
         }
     }
     else {
@@ -3010,7 +3012,7 @@ void (^secondPasswordSuccess)(NSString *);
         [self showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
     }
 
-    [app.window.rootViewController.view addSubview:self.pinEntryViewController.view];
+    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:self.pinEntryViewController.view];
 
     [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
 }
@@ -3030,7 +3032,7 @@ void (^secondPasswordSuccess)(NSString *);
     peViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     [self.tabControllerManager.tabViewController dismissViewControllerAnimated:YES completion:nil];
 
-    [app.window.rootViewController.view addSubview:self.pinEntryViewController.view];
+    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:self.pinEntryViewController.view];
 
     [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
 }
@@ -3049,7 +3051,7 @@ void (^secondPasswordSuccess)(NSString *);
 - (void)closePINModal:(BOOL)animated
 {
     // There are two different ways the pinModal is displayed: as a subview of tabViewController (on start) and as a viewController. This checks which one it is and dismisses accordingly
-    if ([self.pinEntryViewController.view isDescendantOfView:app.window.rootViewController.view]) {
+    if ([self.pinEntryViewController.view isDescendantOfView:[UIApplication sharedApplication].keyWindow.rootViewController.view]) {
 
         [self.pinEntryViewController.view removeFromSuperview];
 
@@ -3079,7 +3081,7 @@ void (^secondPasswordSuccess)(NSString *);
 
     [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:nil]];
 
-    [app.window.rootViewController presentViewController:alert animated:YES completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)logoutAndShowPasswordModal
@@ -3116,13 +3118,13 @@ void (^secondPasswordSuccess)(NSString *);
         [mainPasswordTextField resignFirstResponder];
         [self performSelector:@selector(presentViewControllerAnimated:) withObject:forgetWalletAlert afterDelay:DELAY_KEYBOARD_DISMISSAL];
     } else {
-        [app.window.rootViewController presentViewController:forgetWalletAlert animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:forgetWalletAlert animated:YES completion:nil];
     }
 }
 
 - (void)presentViewControllerAnimated:(UIViewController *)viewController
 {
-    [app.window.rootViewController presentViewController:viewController animated:YES completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:viewController animated:YES completion:nil];
 }
 
 - (IBAction)webLoginClicked:(id)sender
@@ -3628,7 +3630,7 @@ void (^secondPasswordSuccess)(NSString *);
         self.pinEntryViewController.inSettings = YES;
     }
 
-    [app.window.rootViewController.view addSubview:self.pinEntryViewController.view];
+    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:self.pinEntryViewController.view];
 }
 
 - (void)didPutPinSuccess:(NSDictionary*)dictionary
@@ -3775,7 +3777,7 @@ void (^secondPasswordSuccess)(NSString *);
         [app performSelector:@selector(suspend)];
     }]];
 
-    [app.window.rootViewController presentViewController:alert animated:YES completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
 }
 
 #pragma mark - Setup Delegate
@@ -3932,7 +3934,7 @@ void (^secondPasswordSuccess)(NSString *);
             } else if (self.topViewControllerDelegate) {
                 [self.topViewControllerDelegate presentViewController:alert animated:YES completion:nil];
             } else {
-                [app.window.rootViewController presentViewController:alert animated:YES completion:nil];
+                [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
             }
         }
     }

--- a/Blockchain/RootServiceSwift.swift
+++ b/Blockchain/RootServiceSwift.swift
@@ -15,9 +15,6 @@ final class RootServiceSwift {
 
     // MARK: - Properties
 
-    /// Grants the Root Service access to the application delegate
-    fileprivate let appDelegate: AppDelegate!
-
     /// Flag used to indicate whether the device is prompting for biometric authentication.
     @objc public private(set) var isPromptingForBiometricAuthentication = false
 
@@ -58,10 +55,6 @@ final class RootServiceSwift {
 
     //: Prevent outside objects from creating their own instances of this class.
     private init() {
-        guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
-            fatalError("No application delegate found!")
-        }
-        appDelegate = delegate
     }
 
     // MARK: - Application Lifecycle
@@ -102,6 +95,8 @@ final class RootServiceSwift {
         let simulateSurgeKey = UserDefaults.DebugKeys.simulateSurge.rawValue
         UserDefaults.standard.set(false, forKey: simulateSurgeKey)
         #endif
+
+        AppCoordinator.shared.start()
 
         //: ...
 
@@ -165,7 +160,7 @@ final class RootServiceSwift {
             let action = UIAlertAction(title: LCStringOK, style: .default, handler: nil)
             alert.addAction(action)
             DispatchQueue.main.async {
-                app.window.rootViewController?.present(alert, animated: true, completion: nil)
+                UIApplication.shared.keyWindow?.rootViewController?.present(alert, animated: true, completion: nil)
             }
         }
     }
@@ -187,7 +182,7 @@ final class RootServiceSwift {
 
     func showPrivacyScreen() {
         privacyScreen?.alpha = 1
-        app.window.addSubview(privacyScreen!)
+        UIApplication.shared.keyWindow?.addSubview(privacyScreen!)
     }
 
     func failedToObtainValuesFromKeychain() {
@@ -197,7 +192,7 @@ final class RootServiceSwift {
             // perform suspend selector
         })
         alert.addAction(action)
-        app.window.rootViewController?.present(alert, animated: true, completion: nil)
+        UIApplication.shared.keyWindow?.rootViewController?.present(alert, animated: true, completion: nil)
     }
 
     func showVerifyingBusyView(withTimeout seconds: Int) {

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -573,12 +573,12 @@ BOOL displayingLocalSymbolSend;
                              [[NSUserDefaults standardUserDefaults] setBool:YES forKey:USER_DEFAULTS_KEY_HIDE_APP_REVIEW_PROMPT];
                          }]];
 
-                         [app.window.rootViewController presentViewController:appReviewAlert animated:YES completion:nil];
+                         [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:appReviewAlert animated:YES completion:nil];
                      }
                  }
              }]];
              
-             [app.window.rootViewController presentViewController:paymentSentAlert animated:YES completion:nil];
+             [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:paymentSentAlert animated:YES completion:nil];
              
              [sendProgressActivityIndicator stopAnimating];
              
@@ -840,7 +840,7 @@ BOOL displayingLocalSymbolSend;
                                                       surge:surgePresent];
         }
         
-        self.confirmPaymentView = [[BCConfirmPaymentView alloc] initWithWindow:app.window viewModel:confirmPaymentViewModel sendButtonFrame:continuePaymentButton.frame];
+        self.confirmPaymentView = [[BCConfirmPaymentView alloc] initWithWindow:[UIApplication sharedApplication].keyWindow viewModel:confirmPaymentViewModel sendButtonFrame:continuePaymentButton.frame];
         
         self.confirmPaymentView.confirmDelegate = self;
         
@@ -1396,7 +1396,7 @@ BOOL displayingLocalSymbolSend;
             [app.wallet sendCancellation:self.contactTransaction];
         }
     }]];
-    [app.window.rootViewController presentViewController:alert animated:YES completion:nil];
+    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
 }
 
 #pragma mark - Asset Agnostic Methods
@@ -2204,7 +2204,7 @@ BOOL displayingLocalSymbolSend;
 
 - (IBAction)feeOptionsClicked:(UIButton *)sender
 {
-    BCFeeSelectionView *feeSelectionView = [[BCFeeSelectionView alloc] initWithFrame:app.window.frame];
+    BCFeeSelectionView *feeSelectionView = [[BCFeeSelectionView alloc] initWithFrame:[UIApplication sharedApplication].keyWindow.frame];
     feeSelectionView.delegate = self;
     [app showModalWithContent:feeSelectionView closeType:ModalCloseTypeBack headerText:BC_STRING_FEE];
 }

--- a/Blockchain/SettingsChangePasswordViewController.m
+++ b/Blockchain/SettingsChangePasswordViewController.m
@@ -29,7 +29,7 @@
     [super viewDidLoad];
     
     UIButton *createButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    createButton.frame = CGRectMake(0, 0, app.window.frame.size.width, 46);
+    createButton.frame = CGRectMake(0, 0, [UIApplication sharedApplication].keyWindow.frame.size.width, 46);
     createButton.backgroundColor = COLOR_BLOCKCHAIN_LIGHT_BLUE;
     [createButton setTitle:BC_STRING_CONTINUE forState:UIControlStateNormal];
     [createButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
@@ -132,7 +132,7 @@
         [app closeSideMenu];
         [app showPasswordModal];
         app.changedPassword = YES;
-        [app.window.rootViewController presentViewController:alertForChangePasswordSuccess animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertForChangePasswordSuccess animated:YES completion:nil];
     }];
 
     [self clearTextFields];

--- a/Blockchain/SettingsNavigationController.m
+++ b/Blockchain/SettingsNavigationController.m
@@ -19,7 +19,7 @@
 {
     [super viewDidLoad];
     
-    self.view.frame = CGRectMake(0, 0, app.window.frame.size.width, app.window.frame.size.height);
+    self.view.frame = CGRectMake(0, 0, [UIApplication sharedApplication].keyWindow.frame.size.width, [UIApplication sharedApplication].keyWindow.frame.size.height);
     
     UIView *topBar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_HEADER_HEIGHT)];
     topBar.backgroundColor = COLOR_BLOCKCHAIN_BLUE;
@@ -45,7 +45,7 @@
     [topBar addSubview:backButton];
     self.backButton = backButton;
     
-    BCFadeView *busyView = [[BCFadeView alloc] initWithFrame:app.window.rootViewController.view.frame];
+    BCFadeView *busyView = [[BCFadeView alloc] initWithFrame:[UIApplication sharedApplication].keyWindow.rootViewController.view.frame];
     busyView.backgroundColor = [UIColor colorWithRed:0.0 green:0.0 blue:0.0 alpha:0.5];
     UIView *textWithSpinnerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 250, 110)];
     textWithSpinnerView.backgroundColor = [UIColor whiteColor];

--- a/Blockchain/SideMenuViewController.m
+++ b/Blockchain/SideMenuViewController.m
@@ -17,6 +17,7 @@
 #import "PrivateKeyReader.h"
 #import "UIViewController+AutoDismiss.h"
 #import <JavaScriptCore/JavaScriptCore.h>
+#import "Blockchain-Swift.h"
 
 @interface SideMenuViewController ()
 
@@ -48,7 +49,7 @@ int accountEntries = 0;
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    sideMenu = app.slidingViewController;
+    sideMenu = [AppCoordinator sharedInstance].slidingViewController;
     
     self.tableView = ({
         UITableView *tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width - sideMenu.anchorLeftPeekAmount, MENU_ENTRY_HEIGHT * self.menuEntriesCount) style:UITableViewStylePlain];
@@ -152,7 +153,7 @@ int accountEntries = 0;
     
     // Enable Pan gesture and tap gesture to close sideMenu
     [tabViewController.activeViewController.view setUserInteractionEnabled:YES];
-    ECSlidingViewController *sideMenu = app.slidingViewController;
+    ECSlidingViewController *sideMenu = [AppCoordinator sharedInstance].slidingViewController;
     [tabViewController.activeViewController.view addGestureRecognizer:sideMenu.panGesture];
     
     [tabViewController.activeViewController.view addGestureRecognizer:tapToCloseGestureRecognizerViewController];
@@ -160,7 +161,7 @@ int accountEntries = 0;
     [tabViewController addTapGestureRecognizerToTabBar:tapToCloseGestureRecognizerTabBar];
     
     // Show shadow on current viewController in tabBarView
-    UIView *castsShadowView = app.slidingViewController.topViewController.view;
+    UIView *castsShadowView = [AppCoordinator sharedInstance].slidingViewController.topViewController.view;
     castsShadowView.layer.shadowOpacity = 0.3f;
     castsShadowView.layer.shadowRadius = 10.0f;
     castsShadowView.layer.shadowColor = [UIColor blackColor].CGColor;

--- a/Blockchain/TabViewController.m
+++ b/Blockchain/TabViewController.m
@@ -9,6 +9,7 @@
 #import "TabViewController.h"
 #import "RootService.h"
 #import "UIView+ChangeFrameAttribute.h"
+#import "Blockchain-Swift.h"
 
 @interface TabViewcontroller () <AssetSelectorViewDelegate>
 @end
@@ -46,7 +47,7 @@
     if (!_menuSwipeRecognizerView) {
         _menuSwipeRecognizerView = [[UIView alloc] initWithFrame:CGRectMake(0, DEFAULT_HEADER_HEIGHT, 20, self.view.frame.size.height)];
         
-        ECSlidingViewController *sideMenu = app.slidingViewController;
+        ECSlidingViewController *sideMenu = [AppCoordinator sharedInstance].slidingViewController;
         [_menuSwipeRecognizerView addGestureRecognizer:sideMenu.panGesture];
         
         [self.view addSubview:_menuSwipeRecognizerView];

--- a/Blockchain/TransactionEtherTableViewCell.m
+++ b/Blockchain/TransactionEtherTableViewCell.m
@@ -98,7 +98,7 @@
     if (app.topViewControllerDelegate) {
         [app.topViewControllerDelegate presentViewController:navigationController animated:YES completion:nil];
     } else {
-        [app.window.rootViewController presentViewController:navigationController animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navigationController animated:YES completion:nil];
     }
 }
 

--- a/Blockchain/TransactionTableCell.m
+++ b/Blockchain/TransactionTableCell.m
@@ -134,7 +134,7 @@
     if (app.topViewControllerDelegate) {
         [app.topViewControllerDelegate presentViewController:navigationController animated:YES completion:nil];
     } else {
-        [app.window.rootViewController presentViewController:navigationController animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navigationController animated:YES completion:nil];
     }
 }
 
@@ -156,7 +156,7 @@
     if (app.topViewControllerDelegate) {
         [app.topViewControllerDelegate presentViewController:navigationController animated:YES completion:nil];
     } else {
-        [app.window.rootViewController presentViewController:navigationController animated:YES completion:nil];
+        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navigationController animated:YES completion:nil];
     }
 }
 

--- a/Blockchain/WebLoginViewController.m
+++ b/Blockchain/WebLoginViewController.m
@@ -42,7 +42,7 @@ const float qrSize = 230;
 {
     [super viewDidLoad];
 
-    CGSize size = app.window.frame.size;
+    CGSize size = [UIApplication sharedApplication].keyWindow.frame.size;
     self.view.frame = CGRectMake(0, DEFAULT_HEADER_HEIGHT, size.width, size.height - DEFAULT_HEADER_HEIGHT);
     self.view.backgroundColor = [UIColor whiteColor];
     

--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -28,6 +28,7 @@
 #import "KeychainItemWrapper+SwipeAddresses.h"
 #import "BCSwipeAddressViewModel.h"
 #import "UIView+ChangeFrameAttribute.h"
+#import "Blockchain-Swift.h"
 
 #define PS_VERIFY	0
 #define PS_ENTER1	1
@@ -336,7 +337,7 @@ static PEViewController *VerifyController()
 - (void)handleLongPress:(UILongPressGestureRecognizer *)longPress
 {
     if (longPress.state == UIGestureRecognizerStateBegan) {
-        [app showDebugMenu:DEBUG_PRESENTER_PIN_VERIFY];
+        [[AppCoordinator sharedInstance] showDebugViewWithPresenter:DEBUG_PRESENTER_PIN_VERIFY];
     }
 }
 


### PR DESCRIPTION
Design doc for coordinator pattern: https://docs.google.com/document/d/1a8ING4q7EjTbzs9mZMep-6TivuodDRBK-RXBWXPbIWI/edit?usp=sharing

Summary of changes:
* Added `AppCoordinator` - this coordinator (you can read more about the coordinator pattern [here](https://will.townsend.io/2016/an-ios-coordinator-pattern)) is in charge of deciding which views/view controller to display when the app comes to foreground/background (i.e. the main wallet/dashboard view, if the user is logged in, or the welcome view, if the user is logged out). This coordinator also contains the key window of the application.
* Refactored all `app.window` references to `[UIApplication sharedApplication].keyWindow`

Note:
* Please merge/review #99 before merging/reviewing this.