### PR TITLE
refactor(BCModalView): using ModalPresenter to show/close BCModalViews

### DIFF
--- a/Blockchain/AccountTableCell.m
+++ b/Blockchain/AccountTableCell.m
@@ -51,8 +51,8 @@
     
     editAccountView.accountIdx = self.accountIdx;
     editAccountView.labelTextField.text = [app.wallet getLabelForAccount:self.accountIdx assetType:self.assetType];
-    
-    [app showModalWithContent:editAccountView closeType:ModalCloseTypeClose headerText:BC_STRING_EDIT onDismiss:^{
+
+    [[ModalPresenter sharedInstance] showModalWithContent:editAccountView closeType:ModalCloseTypeClose showHeader:true headerText:BC_STRING_EDIT onDismiss:^{
         [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:YES];
     } onResume:^{
         [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:YES];

--- a/Blockchain/BCAddressSelectionView.m
+++ b/Blockchain/BCAddressSelectionView.m
@@ -12,6 +12,7 @@
 #import "ReceiveTableCell.h"
 #import "SendBitcoinViewController.h"
 #import "Contact.h"
+#import "Blockchain-Swift.h"
 
 #define DICTIONARY_KEY_ACCOUNTS @"accounts"
 #define DICTIONARY_KEY_ACCOUNT_LABELS @"accountLabels"
@@ -343,7 +344,7 @@ typedef enum {
     }
     
     if (shouldCloseModal && !app.topViewControllerDelegate) {
-        [app closeModalWithTransition:kCATransitionFromLeft];
+        [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFromLeft];
     }
 }
 

--- a/Blockchain/BCCreateAccountView.m
+++ b/Blockchain/BCCreateAccountView.m
@@ -76,8 +76,8 @@
         if (![app.wallet isAccountNameValid:label]) {
             return;
         }
-        
-        [app closeModalWithTransition:kCATransitionFade];
+
+        [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
         
         [app.wallet createAccountWithLabel:label];
     }

--- a/Blockchain/BCCreateWalletView.m
+++ b/Blockchain/BCCreateWalletView.m
@@ -122,8 +122,8 @@
     };
     
     [self hideKeyboard];
-    
-    [app showModalWithContent:self.recoveryPhraseView closeType:ModalCloseTypeBack headerText:BC_STRING_RECOVER_FUNDS onDismiss:^{
+
+    [[ModalPresenter sharedInstance] showModalWithContent:self.recoveryPhraseView closeType:ModalCloseTypeBack showHeader:true headerText:BC_STRING_RECOVER_FUNDS onDismiss:^{
         [self.createButton removeTarget:self action:@selector(recoverWalletClicked:) forControlEvents:UIControlEventTouchUpInside];
     } onResume:^{
         [self.recoveryPhraseView.recoveryPassphraseTextField performSelector:@selector(becomeFirstResponder) withObject:nil afterDelay:0.3f];

--- a/Blockchain/BCEditAccountView.m
+++ b/Blockchain/BCEditAccountView.m
@@ -83,7 +83,7 @@
         [app showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
     }
     
-    [app closeModalWithTransition:kCATransitionFade];
+    [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
     
     [self performSelector:@selector(changeAccountName:) withObject:label afterDelay:ANIMATION_DURATION];
 }

--- a/Blockchain/BCEditAddressView.m
+++ b/Blockchain/BCEditAddressView.m
@@ -74,7 +74,7 @@
     
     [self.labelTextField resignFirstResponder];
     
-    [app closeModalWithTransition:kCATransitionFade];
+    [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
     
     if (app.wallet.isSyncing) {
         [app showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];

--- a/Blockchain/BCModalView.m
+++ b/Blockchain/BCModalView.m
@@ -9,6 +9,7 @@
 #import "BCModalView.h"
 #import "RootService.h"
 #import "LocalizationConstants.h"
+#import "Blockchain-Swift.h"
 
 @implementation BCModalView
 
@@ -95,11 +96,11 @@
         }
         
         if (self.closeType == ModalCloseTypeBack) {
-            [app closeModalWithTransition:kCATransitionFromLeft];
+            [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFromLeft];
         }
         else {
             [self endEditing:YES];
-            [app closeModalWithTransition:kCATransitionFade];
+            [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
         }
     }
 }

--- a/Blockchain/BCModalViewController.m
+++ b/Blockchain/BCModalViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "BCModalViewController.h"
+#import "Blockchain-Swift.h"
 
 @interface BCModalViewController ()
 @property (nonatomic) UIView *modalView;
@@ -71,8 +72,8 @@
         }
 
     }
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(closeModalClicked) name:NOTIFICATION_KEY_MODAL_VIEW_DISMISSED object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(closeModalClicked) name:[ConstantsObjcBridge notificationKeyModalViewDismissed] object:nil];
     
     return self;
 }

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -284,6 +284,7 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 #define ERROR_FIRST_ARGUMENT_MUST_BE_STRING @"TypeError: First argument must be a string"
 #define ERROR_INVALID_PAIRING_VERSION_CODE @"Invalid Pairing Version Code"
 
+// TODO: Move these in Constants.NotificationKeys
 #define NOTIFICATION_KEY_RELOAD_TO_DISMISS_VIEWS @"reloadToDismissViews"
 #define NOTIFICATION_KEY_LOADING_TEXT @"SetLoadingText"
 #define NOTIFICATION_KEY_NEW_ADDRESS @"newAddress"
@@ -295,8 +296,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 #define NOTIFICATION_KEY_SHARE_CONTACT_LINK @"shareContactLink"
 
 #define NOTIFICATION_KEY_SYNC_ERROR @"syncError"
-
-#define NOTIFICATION_KEY_MODAL_VIEW_DISMISSED @"modalViewDismissed"
 
 // Notifications used in settings
 #define NOTIFICATION_KEY_RELOAD_SETTINGS @"reloadSettings"
@@ -389,9 +388,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 #define URL_INFORMATION_RECEIVE @"https://support.blockchain.com/hc/en-us/articles/210353663-Why-is-my-bitcoin-address-changing"
 
 #define SOUND_FORMAT @"wav"
-
-#define ANIMATION_KEY_HIDE_MODAL @"HideModal"
-#define ANIMATION_KEY_SHOW_MODAL @"ShowModal"
 
 #define TRANSACTION_FILTER_IMPORTED @"imported"
 

--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -9,6 +9,10 @@
 import UIKit
 
 struct Constants {
+    struct Animation {
+        static let duration = 0.2
+        static let durationLong = 0.5
+    }
     struct Colors {
         static let TextFieldBorderGray = UIColorFromRGB(0xcdcdcd)
         static let BlockchainBlue = UIColorFromRGB(0x004a7c)
@@ -46,6 +50,21 @@ struct Constants {
     }
     struct Booleans {
         static let IsUsingScreenSizeLargerThan5s = UIScreen.main.bounds.size.height > Measurements.ScreenHeightIphone5S
+    }
+    struct NotificationKeys {
+        static let modalViewDismissed = NSNotification.Name("modalViewDismissed")
+    }
+}
+
+/// Constant class wrapper so that Constants can be accessed from Obj-C. Should deprecate this
+/// once Obj-C is no longer using this
+@objc class ConstantsObjcBridge: NSObject {
+    @objc class func animationDuration() -> Double { return Constants.Animation.duration }
+
+    @objc class func animationDurationLong() -> Double { return Constants.Animation.durationLong }
+
+    @objc class func notificationKeyModalViewDismissed() -> String {
+        return Constants.NotificationKeys.modalViewDismissed.rawValue
     }
 }
 

--- a/Blockchain/QRCodeScannerSendViewController.m
+++ b/Blockchain/QRCodeScannerSendViewController.m
@@ -8,6 +8,7 @@
 
 #import "QRCodeScannerSendViewController.h"
 #import "RootService.h"
+#import "Blockchain-Swift.h"
 
 @interface QRCodeScannerSendViewController () <AVCaptureMetadataOutputObjectsDelegate>
 @property (nonatomic) AVCaptureSession *captureSession;
@@ -51,8 +52,8 @@
     
     UIView *view = [[UIView alloc] initWithFrame:frame];
     [view.layer addSublayer:_videoPreviewLayer];
-    
-    [app showModalWithContent:view closeType:ModalCloseTypeClose headerText:BC_STRING_SCAN_QR_CODE onDismiss:^{
+
+    [[ModalPresenter sharedInstance] showModalWithContent:view closeType:ModalCloseTypeClose showHeader:YES headerText:BC_STRING_SCAN_QR_CODE onDismiss:^{
         [_captureSession stopRunning];
         _captureSession = nil;
         [_videoPreviewLayer removeFromSuperlayer];
@@ -65,7 +66,7 @@
 
 - (void)stopReadingQRCode
 {
-    [app closeModalWithTransition:kCATransitionFade];
+    [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
     
     // Go to the send screen if we are not already on it
     [app showSendCoins];

--- a/Blockchain/ReceiveBitcoinViewController.m
+++ b/Blockchain/ReceiveBitcoinViewController.m
@@ -23,6 +23,7 @@
 #import "BCDescriptionView.h"
 #import "BCAmountInputView.h"
 #import "UILabel+Animations.h"
+#import "Blockchain-Swift.h"
 
 #ifdef ENABLE_CONTACTS
 #define BOTTOM_CONTAINER_HEIGHT_PARTIAL 151
@@ -630,7 +631,7 @@
     
     [self reload];
     
-    [app closeModalWithTransition:kCATransitionFade];
+    [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
     
     if (app.wallet.isSyncing) {
         [app showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
@@ -671,7 +672,7 @@
     else {
         // Need at least one active address
         if (activeKeys.count == 1 && ![app.wallet hasAccount]) {
-            [app closeModalWithTransition:kCATransitionFade];
+            [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
             
             [app standardNotifyAutoDismissingController:BC_STRING_AT_LEAST_ONE_ACTIVE_ADDRESS];
             
@@ -683,7 +684,7 @@
     
     [self reload];
     
-    [app closeModalWithTransition:kCATransitionFade];
+    [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
 }
 
 - (void)hideKeyboardForced
@@ -725,12 +726,12 @@
     UIAlertController *alertForWatchOnly = [UIAlertController alertControllerWithTitle:BC_STRING_WARNING_TITLE message:BC_STRING_WATCH_ONLY_RECEIVE_WARNING preferredStyle:UIAlertControllerStyleAlert];
     [alertForWatchOnly addAction:[UIAlertAction actionWithTitle:BC_STRING_CONTINUE style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
         [self didSelectFromAddress:address];
-        [app closeModalWithTransition:kCATransitionFromLeft];
+        [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFromLeft];
     }]];
     [alertForWatchOnly addAction:[UIAlertAction actionWithTitle:BC_STRING_DONT_SHOW_AGAIN style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:USER_DEFAULTS_KEY_HIDE_WATCH_ONLY_RECEIVE_WARNING];
         [self didSelectFromAddress:address];
-        [app closeModalWithTransition:kCATransitionFromLeft];
+        [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFromLeft];
     }]];
     [alertForWatchOnly addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:nil]];
     
@@ -785,8 +786,8 @@
     SelectMode selectMode = self.fromContact ? SelectModeReceiveFromContact : SelectModeReceiveTo;
     
     BCAddressSelectionView *addressSelectionView = [[BCAddressSelectionView alloc] initWithWallet:app.wallet selectMode:selectMode delegate:self];
-    
-    [app showModalWithContent:addressSelectionView closeType:ModalCloseTypeBack showHeader:YES headerText:BC_STRING_RECEIVE_TO onDismiss:nil onResume:nil];
+
+    [[ModalPresenter sharedInstance] showModalWithContent:addressSelectionView closeType:ModalCloseTypeBack showHeader:true headerText:BC_STRING_RECEIVE_TO onDismiss:nil onResume:nil];
 }
 
 - (void)whatsThisButtonClicked
@@ -866,8 +867,8 @@
     BCAddressSelectionView *addressSelectionView = [[BCAddressSelectionView alloc] initWithWallet:app.wallet selectMode:SelectModeContact delegate:self];
     addressSelectionView.previouslySelectedContact = self.fromContact;
     [addressSelectionView reloadTableView];
-    
-    [app showModalWithContent:addressSelectionView closeType:ModalCloseTypeBack showHeader:YES headerText:BC_STRING_REQUEST_FROM onDismiss:nil onResume:nil];
+
+    [[ModalPresenter sharedInstance] showModalWithContent:addressSelectionView closeType:ModalCloseTypeBack showHeader:true headerText:BC_STRING_REQUEST_FROM onDismiss:nil onResume:nil];
 }
 
 - (void)requestButtonClicked
@@ -1185,7 +1186,7 @@
         [self changeTopView:YES];
         
     } else {
-        [app closeAllModals];
+        [[ModalPresenter sharedInstance] closeAllModals];
         
         self.descriptionField.placeholder = [NSString stringWithFormat:BC_STRING_SHARED_WITH_CONTACT_NAME_ARGUMENT, contact.name];
         self.fromContact = contact;

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -145,11 +145,11 @@
 - (void)swipeRight;
 
 // BC Modal
-- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType headerText:(NSString *)headerText;
-- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType headerText:(NSString *)headerText onDismiss:(void (^)())onDismiss onResume:(void (^)())onResume;
-- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType showHeader:(BOOL)showHeader headerText:(NSString *)headerText onDismiss:(void (^)())onDismiss onResume:(void (^)())onResume;
-- (void)closeModalWithTransition:(NSString *)transition;
-- (void)closeAllModals;
+//- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType headerText:(NSString *)headerText;
+//- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType headerText:(NSString *)headerText onDismiss:(void (^)())onDismiss onResume:(void (^)())onResume;
+//- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType showHeader:(BOOL)showHeader headerText:(NSString *)headerText onDismiss:(void (^)())onDismiss onResume:(void (^)())onResume;
+//- (void)closeModalWithTransition:(NSString *)transition;
+//- (void)closeAllModals;
 
 - (NSDictionary*)parseURI:(NSString*)urlString prefix:(NSString *)urlPrefix;
 

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -1444,92 +1444,93 @@ void (^secondPasswordSuccess)(NSString *);
 
 - (void)closeAllModals
 {
-    [self hideBusyView];
-
-    secondPasswordSuccess = nil;
-    secondPasswordTextField.text = nil;
-
-    self.wallet.isSyncing = NO;
-
-    [modalView endEditing:YES];
-
-    [modalView removeFromSuperview];
-
-    CATransition *animation = [CATransition animation];
-    [animation setDuration:ANIMATION_DURATION];
-    [animation setType:kCATransitionFade];
-
-    [animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
-    [[[UIApplication sharedApplication].keyWindow layer] addAnimation:animation forKey:ANIMATION_KEY_HIDE_MODAL];
-
-    if (self.modalView.onDismiss) {
-        self.modalView.onDismiss();
-        self.modalView.onDismiss = nil;
-    }
-
-    self.modalView = nil;
-
-    for (BCModalView *modalChainView in self.modalChain) {
-
-        for (UIView *subView in [modalChainView.myHolderView subviews]) {
-            [subView removeFromSuperview];
-        }
-
-        [modalChainView.myHolderView removeFromSuperview];
-
-        if (modalChainView.onDismiss) {
-            modalChainView.onDismiss();
-        }
-    }
-
-    [self.modalChain removeAllObjects];
+//    [self hideBusyView];
+//
+//    secondPasswordSuccess = nil;
+//    secondPasswordTextField.text = nil;
+//
+//    self.wallet.isSyncing = NO;
+//
+//    [modalView endEditing:YES];
+//
+//    [modalView removeFromSuperview];
+//
+//    CATransition *animation = [CATransition animation];
+//    [animation setDuration:ANIMATION_DURATION];
+//    [animation setType:kCATransitionFade];
+//
+//    [animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
+//
+//    [[[UIApplication sharedApplication].keyWindow layer] addAnimation:animation forKey:ANIMATION_KEY_HIDE_MODAL];
+//
+//    if (self.modalView.onDismiss) {
+//        self.modalView.onDismiss();
+//        self.modalView.onDismiss = nil;
+//    }
+//
+//    self.modalView = nil;
+//
+//    for (BCModalView *modalChainView in self.modalChain) {
+//
+//        for (UIView *subView in [modalChainView.myHolderView subviews]) {
+//            [subView removeFromSuperview];
+//        }
+//
+//        [modalChainView.myHolderView removeFromSuperview];
+//
+//        if (modalChainView.onDismiss) {
+//            modalChainView.onDismiss();
+//        }
+//    }
+//
+//    [self.modalChain removeAllObjects];
 }
 
 - (void)closeModalWithTransition:(NSString *)transition
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_KEY_MODAL_VIEW_DISMISSED object:nil];
-
-    [modalView removeFromSuperview];
-
-    CATransition *animation = [CATransition animation];
-    // There are two types of transitions: movement based and fade in/out. The movement based ones can have a subType to set which direction the movement is in. In case the transition parameter is a direction, we use the MoveIn transition and the transition parameter as the direction, otherwise we use the transition parameter as the transition type.
-    [animation setDuration:ANIMATION_DURATION];
-    if (transition != kCATransitionFade) {
-        [animation setType:kCATransitionMoveIn];
-        [animation setSubtype:transition];
-    }
-    else {
-        [animation setType:transition];
-    }
-
-    [animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
-    [[[UIApplication sharedApplication].keyWindow layer] addAnimation:animation forKey:ANIMATION_KEY_HIDE_MODAL];
-
-    if (self.modalView.onDismiss) {
-        self.modalView.onDismiss();
-        self.modalView.onDismiss = nil;
-    }
-
-    if ([self.modalChain count] > 0) {
-        BCModalView * previousModalView = [self.modalChain objectAtIndex:[self.modalChain count]-1];
-
-        [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:previousModalView];
-
-        [[UIApplication sharedApplication].keyWindow.rootViewController.view bringSubviewToFront:busyView];
-
-        [[UIApplication sharedApplication].keyWindow.rootViewController.view endEditing:TRUE];
-
-        if (self.modalView.onResume) {
-            self.modalView.onResume();
-        }
-
-        self.modalView = previousModalView;
-
-        [self.modalChain removeObjectAtIndex:[self.modalChain count]-1];
-    }
-    else {
-        self.modalView = nil;
-    }
+//    [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_KEY_MODAL_VIEW_DISMISSED object:nil];
+//
+//    [modalView removeFromSuperview];
+//
+//    CATransition *animation = [CATransition animation];
+//    // There are two types of transitions: movement based and fade in/out. The movement based ones can have a subType to set which direction the movement is in. In case the transition parameter is a direction, we use the MoveIn transition and the transition parameter as the direction, otherwise we use the transition parameter as the transition type.
+//    [animation setDuration:ANIMATION_DURATION];
+//    if (transition != kCATransitionFade) {
+//        [animation setType:kCATransitionMoveIn];
+//        [animation setSubtype:transition];
+//    }
+//    else {
+//        [animation setType:transition];
+//    }
+//
+//    [animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
+//    [[[UIApplication sharedApplication].keyWindow layer] addAnimation:animation forKey:ANIMATION_KEY_HIDE_MODAL];
+//
+//    if (self.modalView.onDismiss) {
+//        self.modalView.onDismiss();
+//        self.modalView.onDismiss = nil;
+//    }
+//
+//    if ([self.modalChain count] > 0) {
+//        BCModalView * previousModalView = [self.modalChain objectAtIndex:[self.modalChain count]-1];
+//
+//        [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:previousModalView];
+//
+//        [[UIApplication sharedApplication].keyWindow.rootViewController.view bringSubviewToFront:busyView];
+//
+//        [[UIApplication sharedApplication].keyWindow.rootViewController.view endEditing:TRUE];
+//
+//        if (self.modalView.onResume) {
+//            self.modalView.onResume();
+//        }
+//
+//        self.modalView = previousModalView;
+//
+//        [self.modalChain removeObjectAtIndex:[self.modalChain count]-1];
+//    }
+//    else {
+//        self.modalView = nil;
+//    }
 }
 
 - (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType headerText:(NSString *)headerText
@@ -1544,60 +1545,60 @@ void (^secondPasswordSuccess)(NSString *);
 
 - (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType showHeader:(BOOL)showHeader headerText:(NSString *)headerText onDismiss:(void (^)())onDismiss onResume:(void (^)())onResume
 {
-    // Remove the modal if we have one
-    if (modalView) {
-        [modalView removeFromSuperview];
-
-        if (modalView.closeType != ModalCloseTypeNone) {
-            if (modalView.onDismiss) {
-                modalView.onDismiss();
-                modalView.onDismiss = nil;
-            }
-        } else {
-            [self.modalChain addObject:modalView];
-        }
-
-        self.modalView = nil;
-    }
-
-    // Show modal
-    modalView = [[BCModalView alloc] initWithCloseType:closeType showHeader:showHeader headerText:headerText];
-    self.modalView.onDismiss = onDismiss;
-    self.modalView.onResume = onResume;
-    if (onResume) {
-        onResume();
-    }
-
-    if ([contentView respondsToSelector:@selector(prepareForModalPresentation)]) {
-        [(BCModalContentView *)contentView prepareForModalPresentation];
-    }
-
-    [modalView.myHolderView addSubview:contentView];
-
-    contentView.frame = CGRectMake(0, 0, modalView.myHolderView.frame.size.width, modalView.myHolderView.frame.size.height);
-
-    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:modalView];
-    [[UIApplication sharedApplication].keyWindow.rootViewController.view endEditing:TRUE];
-
-    @try {
-        CATransition *animation = [CATransition animation];
-        [animation setDuration:ANIMATION_DURATION];
-
-        if (closeType == ModalCloseTypeBack) {
-            [animation setType:kCATransitionMoveIn];
-            [animation setSubtype:kCATransitionFromRight];
-        }
-        else {
-            [animation setType:kCATransitionFade];
-        }
-
-        [animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
-        [[[UIApplication sharedApplication].keyWindow.rootViewController.view layer] addAnimation:animation forKey:ANIMATION_KEY_SHOW_MODAL];
-    } @catch (NSException * e) {
-        DLog(@"Animation Exception %@", e);
-    }
-
-    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
+//    // Remove the modal if we have one
+//    if (modalView) {
+//        [modalView removeFromSuperview];
+//
+//        if (modalView.closeType != ModalCloseTypeNone) {
+//            if (modalView.onDismiss) {
+//                modalView.onDismiss();
+//                modalView.onDismiss = nil;
+//            }
+//        } else {
+//            [self.modalChain addObject:modalView];
+//        }
+//
+//        self.modalView = nil;
+//    }
+//
+//    // Show modal
+//    modalView = [[BCModalView alloc] initWithCloseType:closeType showHeader:showHeader headerText:headerText];
+//    self.modalView.onDismiss = onDismiss;
+//    self.modalView.onResume = onResume;
+//    if (onResume) {
+//        onResume();
+//    }
+//
+//    if ([contentView respondsToSelector:@selector(prepareForModalPresentation)]) {
+//        [(BCModalContentView *)contentView prepareForModalPresentation];
+//    }
+//
+//    [modalView.myHolderView addSubview:contentView];
+//
+//    contentView.frame = CGRectMake(0, 0, modalView.myHolderView.frame.size.width, modalView.myHolderView.frame.size.height);
+//
+//    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:modalView];
+//    [[UIApplication sharedApplication].keyWindow.rootViewController.view endEditing:TRUE];
+//
+//    @try {
+//        CATransition *animation = [CATransition animation];
+//        [animation setDuration:ANIMATION_DURATION];
+//
+//        if (closeType == ModalCloseTypeBack) {
+//            [animation setType:kCATransitionMoveIn];
+//            [animation setSubtype:kCATransitionFromRight];
+//        }
+//        else {
+//            [animation setType:kCATransitionFade];
+//        }
+//
+//        [animation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
+//        [[[UIApplication sharedApplication].keyWindow.rootViewController.view layer] addAnimation:animation forKey:ANIMATION_KEY_SHOW_MODAL];
+//    } @catch (NSException * e) {
+//        DLog(@"Animation Exception %@", e);
+//    }
+//
+//    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
 }
 
 - (void)didFailBackupWallet

--- a/Blockchain/SendEtherViewController.m
+++ b/Blockchain/SendEtherViewController.m
@@ -375,8 +375,7 @@
         self.confirmPaymentView.confirmDelegate = self;
         
         [self.confirmPaymentView.reallyDoPaymentButton addTarget:self action:@selector(reallyDoPayment) forControlEvents:UIControlEventTouchUpInside];
-        
-        [app showModalWithContent:self.confirmPaymentView closeType:ModalCloseTypeBack headerText:BC_STRING_CONFIRM_PAYMENT];
+        [[ModalPresenter sharedInstance] showModalWithContent:self.confirmPaymentView closeType:ModalCloseTypeBack showHeader:true headerText:BC_STRING_CONFIRM_PAYMENT onDismiss:nil onResume:nil];
     }];
 }
 
@@ -421,8 +420,8 @@
     sendLabel.text = BC_STRING_SENDING;
     [sendView addSubview:sendLabel];
     
-    [app showModalWithContent:sendView closeType:ModalCloseTypeNone headerText:BC_STRING_SENDING_TRANSACTION];
-    
+    [[ModalPresenter sharedInstance] showModalWithContent:sendView closeType:ModalCloseTypeNone showHeader:true headerText:BC_STRING_SENDING_TRANSACTION onDismiss:nil onResume:nil];
+
     [app.wallet sendEtherPaymentWithNote:self.noteToSet];
 }
 

--- a/Blockchain/TabViewController.m
+++ b/Blockchain/TabViewController.m
@@ -246,7 +246,7 @@
 
 - (void)didSendEther
 {
-    [app closeAllModals];
+    [[ModalPresenter sharedInstance] closeAllModals];
     
     UIAlertController *successAlert = [UIAlertController alertControllerWithTitle:BC_STRING_SUCCESS message:BC_STRING_PAYMENT_SENT_ETHER preferredStyle:UIAlertControllerStyleAlert];
     [successAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:nil]];
@@ -255,7 +255,7 @@
 
 - (void)didErrorDuringEtherSend:(NSString *)error
 {
-    [app closeAllModals];
+    [[ModalPresenter sharedInstance] closeAllModals];
     
     UIAlertController *errorAlert = [UIAlertController alertControllerWithTitle:BC_STRING_ERROR message:error preferredStyle:UIAlertControllerStyleAlert];
     [errorAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:nil]];

--- a/Blockchain/TransactionsBitcoinCashViewController.m
+++ b/Blockchain/TransactionsBitcoinCashViewController.m
@@ -12,6 +12,7 @@
 #import "TransactionTableCell.h"
 #import "Transaction.h"
 #import "UIView+ChangeFrameAttribute.h"
+#import "Blockchain-Swift.h"
 
 @interface TransactionsViewController () <AddressSelectionDelegate>
 @property (nonatomic) UILabel *noTransactionsTitle;
@@ -221,7 +222,7 @@
 - (void)showFilterMenu
 {
     BCAddressSelectionView *filterView = [[BCAddressSelectionView alloc] initWithWallet:app.wallet selectMode:SelectModeFilter delegate:self];
-    [app showModalWithContent:filterView closeType:ModalCloseTypeBack headerText:BC_STRING_BALANCES];
+    [[ModalPresenter sharedInstance] showModalWithContent:filterView closeType:ModalCloseTypeBack showHeader:YES headerText:BC_STRING_BALANCES onDismiss:nil onResume:nil];
 }
 
 #pragma mark - Address Selection Delegate

--- a/Blockchain/TransactionsBitcoinViewController.m
+++ b/Blockchain/TransactionsBitcoinViewController.m
@@ -18,6 +18,7 @@
 #import "BCAddressSelectionView.h"
 #import "TransactionDetailNavigationController.h"
 #import "UIView+ChangeFrameAttribute.h"
+#import "Blockchain-Swift.h"
 
 @interface TransactionsViewController ()
 @property (nonatomic) UILabel *noTransactionsTitle;
@@ -723,7 +724,7 @@
 - (void)showFilterMenu
 {
     BCAddressSelectionView *filterView = [[BCAddressSelectionView alloc] initWithWallet:app.wallet selectMode:SelectModeFilter delegate:self];
-    [app showModalWithContent:filterView closeType:ModalCloseTypeBack headerText:BC_STRING_BALANCES];
+    [[ModalPresenter sharedInstance] showModalWithContent:filterView closeType:ModalCloseTypeBack showHeader:true headerText:BC_STRING_BALANCES onDismiss:nil onResume:nil];
 }
 
 #pragma mark - Address Selection Delegate


### PR DESCRIPTION
Summary of changes:

* Using ModalPresenter to show/close BCModalViews.
* Moving animation constants to `Constants.swift`.
* Created `ConstantsObjcBridge` so that values within `Constants.swift` can be accessed.
* Commented out show/close `BCModalView` related code in RootService.
* Added a few TODOs (busyView related), will address those in a separate PR.

Notes:
* Please review/merge #101 before reviewing this