### PR TITLE
fix(Dashboard): always show at least one integer digit for fiat balance

### DIFF
--- a/Blockchain/NSNumberFormatter+Currencies.m
+++ b/Blockchain/NSNumberFormatter+Currencies.m
@@ -269,6 +269,7 @@
 + (NSString *)fiatStringFromDouble:(double)fiatBalance
 {
     NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+    numberFormatter.minimumIntegerDigits = 1;
     NSUInteger decimalPlaces = 2;
     numberFormatter.minimumFractionDigits = decimalPlaces;
     numberFormatter.maximumFractionDigits = decimalPlaces;


### PR DESCRIPTION
To display `$0.00` instead of `$.00`