### PR TITLE
refactor(LoadingPresenter): create LoadingPresenter.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -204,6 +204,8 @@
 		AAA3314E20893CE100BBD292 /* PairingInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */; };
 		AAA3315120893DCA00BBD292 /* PairingInstructionsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AAA3315020893DCA00BBD292 /* PairingInstructionsView.xib */; };
 		AAA3316B2089650B00BBD292 /* AlertViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */; };
+		AAA3316120895A9C00BBD292 /* LoadingViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */; };
+		AAA3316520895D0900BBD292 /* BCFadeView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AAA3316420895D0900BBD292 /* BCFadeView.xib */; };
 		AAA3333320880A2C0019AD55 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333220880A2B0019AD55 /* AppDelegate.swift */; };
 		AAA3333B2088115C0019AD55 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333A2088115C0019AD55 /* Coordinator.swift */; };
 		AAA3333D208813040019AD55 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333C208813040019AD55 /* OnboardingCoordinator.swift */; };
@@ -1116,6 +1118,8 @@
 		AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingInstructionsView.swift; sourceTree = "<group>"; };
 		AAA3315020893DCA00BBD292 /* PairingInstructionsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PairingInstructionsView.xib; sourceTree = "<group>"; };
 		AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewPresenter.swift; sourceTree = "<group>"; };
+		AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewPresenter.swift; sourceTree = "<group>"; };
+		AAA3316420895D0900BBD292 /* BCFadeView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BCFadeView.xib; sourceTree = "<group>"; };
 		AAA3333220880A2B0019AD55 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AAA3333A2088115C0019AD55 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		AAA3333C208813040019AD55 /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
@@ -1824,6 +1828,7 @@
 				5164E4D62059734800FC706A /* Config.swift */,
 				67D95A271B3DDC900012EBB1 /* Constants.swift */,
 				511646C7208129D800C43522 /* Environment.swift */,
+				AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */,
 				51E5C73020741A130000A7FD /* LocalizationConstants.swift */,
 				AAA3333E2088131D0019AD55 /* ModalPresenter.swift */,
 				51E5C72D20741A120000A7FD /* RootServiceSwift.swift */,
@@ -1834,6 +1839,7 @@
 				AAA33338208811460019AD55 /* Coordinators */,
 				510EA19620811FF100A63AB8 /* Extensions */,
 				9F0CBAAB15135DF200CD945D /* JavaScript */,
+				AAA3316320895CE600BBD292 /* Loading */,
 				9F765F3A14BC7C3100048EFB /* Models */,
 				AAA333402088450D0019AD55 /* Onboarding */,
 				C9D4B2AF193E023C00EDA9EA /* Resources */,
@@ -1986,6 +1992,14 @@
 				AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */,
 			);
 			path = Alerts;
+			sourceTree = "<group>";
+		};
+		AAA3316320895CE600BBD292 /* Loading */ = {
+			isa = PBXGroup;
+			children = (
+				AAA3316420895D0900BBD292 /* BCFadeView.xib */,
+			);
+			path = Loading;
 			sourceTree = "<group>";
 		};
 		AAA33338208811460019AD55 /* Coordinators */ = {
@@ -2514,6 +2528,7 @@
 				C9BE91891945D8F600FD516D /* PEPin-off.png in Resources */,
 				9F1831FD1517912900FB3D52 /* beep.wav in Resources */,
 				67EEE7721A8E547900288753 /* PEPin-on@2x.png in Resources */,
+				AAA3316520895D0900BBD292 /* BCFadeView.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2732,6 +2747,7 @@
 				C7559CBA1F573763005B2375 /* EtherTransaction.m in Sources */,
 				C76135641F9E55DF0029E159 /* ExchangeCreateViewController.m in Sources */,
 				67EE1DCD19E3325900DBBFC9 /* ECSlidingSegue.m in Sources */,
+				AAA3316120895A9C00BBD292 /* LoadingViewPresenter.swift in Sources */,
 				237356B91DF8B4EE003940A7 /* ContactDetailViewController.m in Sources */,
 				231FF2CD1B56F9F1009EEB02 /* SettingsWebViewController.m in Sources */,
 				C723F3461F61D35300A858A9 /* TransactionDetailViewModel.m in Sources */,

--- a/Blockchain/BCCreateWalletView.m
+++ b/Blockchain/BCCreateWalletView.m
@@ -173,8 +173,8 @@
     // Continue in walletJSReady callback
     app.wallet.delegate = self;
 
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_WALLET];
-
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_WALLET];
+ 
     // Load the JS without a wallet
     [app.wallet performSelector:@selector(loadBlankWallet) withObject:nil afterDelay:DELAY_KEYBOARD_DISMISSAL];
 }

--- a/Blockchain/BCEditAccountView.m
+++ b/Blockchain/BCEditAccountView.m
@@ -80,7 +80,7 @@
     [self.labelTextField resignFirstResponder];
     
     if (self.assetType == AssetTypeBitcoin) {
-        [app showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
     }
     
     [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];

--- a/Blockchain/BCEditAddressView.m
+++ b/Blockchain/BCEditAddressView.m
@@ -77,7 +77,7 @@
     [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
     
     if (app.wallet.isSyncing) {
-        [app showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
     }
 }
 

--- a/Blockchain/BCFadeView.h
+++ b/Blockchain/BCFadeView.h
@@ -28,8 +28,10 @@
 
 @interface BCFadeView : UIView
 
-@property (nonatomic, strong) IBOutlet UIView *containerView;
+@property (weak, nonatomic) IBOutlet UIView *containerView;
+@property (weak, nonatomic) IBOutlet UILabel *labelBusy;
 
++ (nonnull BCFadeView *)instanceFromNib;
 - (void)fadeIn;
 - (void)fadeOut;
 

--- a/Blockchain/BCFadeView.m
+++ b/Blockchain/BCFadeView.m
@@ -10,6 +10,18 @@
 
 @implementation BCFadeView
 
++ (nonnull BCFadeView *)instanceFromNib
+{
+    UINib *nib = [UINib nibWithNibName:@"BCFadeView" bundle:[NSBundle mainBundle]];
+    return (BCFadeView *) [[nib instantiateWithOwner:nil options:nil] objectAtIndex:0];
+}
+
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    self.labelBusy.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_SMALL_MEDIUM];
+}
+
 - (void)fadeIn {
     self.containerView.layer.cornerRadius = 5;
     

--- a/Blockchain/ContactDetailViewController.m
+++ b/Blockchain/ContactDetailViewController.m
@@ -322,7 +322,7 @@ const int maxFindAttempts = 2;
     
     [self.tableView reloadData];
     [self.transactionDetailViewController didGetHistory];
-    
+
     if (self.refreshControl && self.refreshControl.isRefreshing) {
         [self.refreshControl endRefreshing];
     }

--- a/Blockchain/ContactsViewController.m
+++ b/Blockchain/ContactsViewController.m
@@ -459,7 +459,7 @@ const int sectionContacts = 0;
     UIAlertAction *submitAction = [UIAlertAction actionWithTitle:BC_STRING_CONFIRM style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
         NSString *senderName = [[userNameAlert textFields] firstObject].text;
         if ([app checkInternetConnection]) {
-            [app showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_INVITATION];
+            [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_INVITATION];
             [app.wallet createContactWithName:senderName ID:contactName];
         }
     }];
@@ -669,7 +669,7 @@ const int sectionContacts = 0;
 
 - (void)didCreateInvitation:(NSDictionary *)invitationDict
 {
-    [app hideBusyView];
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
     
     self.lastCreatedInvitation = invitationDict;
     

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -53,8 +53,10 @@ import Foundation
         // Set rootViewController
         window.rootViewController = slidingViewController
         window.makeKeyAndVisible()
-
         tabControllerManager.dashBoardClicked(nil)
+
+        // Add busy view
+        LoadingViewPresenter.shared.initialize()
 
         // Display welcome screen if no wallet is authenticated
         if KeychainItemWrapper.guid() == nil || KeychainItemWrapper.sharedKey() == nil {

--- a/Blockchain/ExchangeOverviewViewController.m
+++ b/Blockchain/ExchangeOverviewViewController.m
@@ -15,7 +15,7 @@
 #import "BCLine.h"
 #import "ExchangeTableViewCell.h"
 #import "RootService.h"
-
+#import "Blockchain-Swift.h"
 #import "ExchangeDetailView.h"
 
 #define EXCHANGE_VIEW_HEIGHT 70
@@ -45,7 +45,7 @@
     if (availableStates.count > 0) {
         [self showStates:availableStates];
     } else {
-        [app showBusyViewWithLoadingText:BC_STRING_LOADING_EXCHANGE];
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_EXCHANGE];
         [app.wallet performSelector:@selector(getExchangeTrades) withObject:nil afterDelay:ANIMATION_DURATION];
     }
 }
@@ -180,7 +180,7 @@
 
 - (void)didGetExchangeTrades:(NSArray *)trades
 {
-    [app hideBusyView];
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
     
     BCNavigationController *navigationController = (BCNavigationController *)self.navigationController;
     [navigationController hideBusyView];

--- a/Blockchain/Loading/BCFadeView.xib
+++ b/Blockchain/Loading/BCFadeView.xib
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Montserrat-Regular.ttf">
+            <string>Montserrat-Regular</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="fXW-Xk-UDH" userLabel="Busy View" customClass="BCFadeView">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Es4-QC-d2V">
+                    <rect key="frame" x="35" y="185" width="250" height="110"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <subviews>
+                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" hidesWhenStopped="YES" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="tpy-Hd-Q9x">
+                            <rect key="frame" x="115" y="27" width="20" height="20"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                        </activityIndicatorView>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.75" contentMode="left" fixedFrame="YES" text="loading" textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="gNb-0s-dJc">
+                            <rect key="frame" x="6" y="53" width="238" height="31"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" red="0.95564913750000002" green="0.95562052730000002" blue="0.95563679930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </view>
+            </subviews>
+            <color key="backgroundColor" red="0.098039217289999994" green="0.098039217289999994" blue="0.098039217289999994" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="zhy-yW-dWA"/>
+            <connections>
+                <outlet property="containerView" destination="Es4-QC-d2V" id="3Mn-wx-o2f"/>
+                <outlet property="labelBusy" destination="gNb-0s-dJc" id="GRh-t0-ek6"/>
+            </connections>
+            <point key="canvasLocation" x="516" y="242"/>
+        </view>
+    </objects>
+</document>

--- a/Blockchain/LoadingViewPresenter.swift
+++ b/Blockchain/LoadingViewPresenter.swift
@@ -1,0 +1,101 @@
+//
+//  LoadingViewPresenter.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/19/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Presenter in charge of displaying a view that displays a loading screen
+@objc class LoadingViewPresenter: NSObject {
+
+    static let shared = LoadingViewPresenter()
+
+    private lazy var busyView: BCFadeView = {
+        let busyView = BCFadeView(frame: UIScreen.main.bounds)
+        busyView.alpha = 0.0
+        return busyView
+    }()
+
+    /// sharedInstance function declared so that the LoadingViewPresenter singleton can be accessed
+    /// from Obj-C. Should deprecate this once all Obj-c references have been removed.
+    @objc class func sharedInstance() -> LoadingViewPresenter { return shared }
+
+    private override init() {
+        super.init()
+    }
+
+    func initialize() {
+        UIApplication.shared.keyWindow?.rootViewController?.view.addSubview(busyView)
+    }
+
+    @objc func hideBusyView() {
+        let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
+
+        if let topViewController = topMostViewController as? TopViewController {
+            topViewController.hideBusyView?()
+            return
+        }
+
+        if busyView.alpha == 1.0 {
+            busyView.fadeOut()
+        }
+    }
+
+    @objc func showBusyView(withLoadingText text: String) {
+        let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
+
+        if let topViewController = topMostViewController as? TopViewController {
+            topViewController.showBusyView?(withLoadingText: text)
+            return
+        }
+
+        // TODO: state check for pinEntryViewController should not be here
+        if let pinEntryViewController = topMostViewController as? PEPinEntryController {
+            if pinEntryViewController.inSettings &&
+                text != LocalizationConstants.syncingWallet &&
+                text != LocalizationConstants.verifying {
+                print("Verify optional PIN view is presented - will not update busy views unless verifying or syncing")
+                return
+            }
+        }
+
+        if AppCoordinator.shared.tabControllerManager.isSending() && ModalPresenter.shared.modalView != nil {
+            print("Send progress modal is presented - will not show busy view")
+            return
+        }
+
+        busyView.labelBusy.text = text
+
+        UIApplication.shared.keyWindow?.rootViewController?.view.bringSubview(toFront: busyView)
+
+        if busyView.alpha < 1.0 {
+            busyView.fadeIn()
+        }
+    }
+
+    @objc func updateBusyViewLoadingText(text: String) {
+        let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
+
+        if let topViewController = topMostViewController as? TopViewController {
+            topViewController.updateBusyViewLoadingText?(text)
+            return
+        }
+
+        // TODO: state check for pinEntryViewController should not be here
+        if let pinEntryViewController = topMostViewController as? PEPinEntryController {
+            if pinEntryViewController.inSettings &&
+                text != LocalizationConstants.syncingWallet &&
+                text != LocalizationConstants.verifying {
+                print("Verify optional PIN view is presented - will not update busy views unless verifying or syncing")
+                return
+            }
+        }
+
+        if busyView.alpha == 1.0 {
+            busyView.labelBusy.text = text
+        }
+    }
+}

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -9,8 +9,6 @@
 
 import Foundation
 
-let LCStringLoadingVerifying = NSLocalizedString("Verifying", comment: "")
-
 //: Local Authentication - Face ID & Touch ID
 
 let LCStringAuthCancel = NSLocalizedString("Cancel", comment: "")
@@ -40,6 +38,8 @@ struct LocalizationConstants {
     static let ok = NSLocalizedString("OK", comment: "")
     static let warning = NSLocalizedString("Warning", comment: "")
     static let unsafeDeviceWarningMessage = NSLocalizedString("Your device appears to be jailbroken. The security of your wallet may be compromised.", comment: "")
+    static let syncingWallet = NSLocalizedString("Syncing Wallet", comment: "")
+    static let verifying = NSLocalizedString ("Verifying", comment: "")
 
     struct Onboarding {
         static let createNewWallet = NSLocalizedString("Create New Wallet", comment: "")

--- a/Blockchain/ModalPresenter.swift
+++ b/Blockchain/ModalPresenter.swift
@@ -15,7 +15,7 @@ typealias OnModalResumed = (() -> Void)
 @objc class ModalPresenter: NSObject {
     static let shared = ModalPresenter()
 
-    private var modalView: BCModalView?
+    private(set) var modalView: BCModalView?
 
     private var modalChain: [BCModalView] = []
 

--- a/Blockchain/PairingCodeParser.m
+++ b/Blockchain/PairingCodeParser.m
@@ -8,6 +8,7 @@
 
 #import "PairingCodeParser.h"
 #import "RootService.h"
+#import "Blockchain-Swift.h"
 
 @implementation PairingCodeParser
 
@@ -117,8 +118,7 @@
                 
                 [self dismissViewControllerAnimated:YES completion:nil];
 
-                [app showBusyViewWithLoadingText:BC_STRING_PARSING_PAIRING_CODE];
-                
+                [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_PARSING_PAIRING_CODE];
             });
             
             [app.wallet loadBlankWallet];
@@ -132,7 +132,7 @@
 
 - (void)errorParsingPairingCode:(NSString *)message
 {
-    [app hideBusyView];
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
 
     if (self.error) {
         if ([message containsString:ERROR_INVALID_PAIRING_VERSION_CODE]) {
@@ -147,7 +147,7 @@
 
 -(void)didParsePairingCode:(NSDictionary *)dict
 {
-    [app hideBusyView];
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
 
     if (self.success) {
         self.success(dict);

--- a/Blockchain/PrivateKeyReader.m
+++ b/Blockchain/PrivateKeyReader.m
@@ -131,8 +131,8 @@
             // Close the QR code reader
             dispatch_sync(dispatch_get_main_queue(), ^{
                 [self stopReadingQRCode];
-                
-                [app showBusyViewWithLoadingText:self.busyViewText];
+
+                [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:self.busyViewText];
             });
             
             // Check the format of the privateKey and if it's valid, pass it back via the success callback
@@ -150,7 +150,7 @@
                         self.success(scannedString);
                     }
                 } else {
-                    [app hideBusyView];
+                    [[LoadingViewPresenter sharedInstance] hideBusyView];
                     
                     if (self.acceptsPublicKeys) {
                         if ([app.wallet isValidAddress:scannedString assetType:self.assetType]) {

--- a/Blockchain/ReceiveBitcoinViewController.m
+++ b/Blockchain/ReceiveBitcoinViewController.m
@@ -634,7 +634,7 @@
     [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
     
     if (app.wallet.isSyncing) {
-        [app showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
     }
 }
 
@@ -889,8 +889,8 @@
             accountOrAddress = self.clickedAddress;
 
         }
-        
-        [app showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_REQUEST];
+
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_REQUEST];
         [app.wallet sendPaymentRequest:self.fromContact.identifier amount:amount requestId:nil note:self.view.note initiatorSource:accountOrAddress];
     } else {
         [self share];

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -92,7 +92,6 @@
 @property (strong, nonatomic) IBOutlet UIWindow *window;
 @property (strong, nonatomic) Wallet *wallet;
 @property (strong, nonatomic) MultiAddressResponse *latestResponse;
-@property (nonatomic, strong) NSString *loadingText;
 
 @property (strong, nonatomic) IBOutlet BCModalView *modalView;
 @property (strong, nonatomic) NSMutableArray *modalChain;
@@ -164,9 +163,9 @@
 //- (void)standardNotify:(NSString*)message title:(NSString*)title;
 
 // Busy view with loading text
-- (void)showBusyViewWithLoadingText:(NSString *)text;
-- (void)updateBusyViewLoadingText:(NSString *)text;
-- (void)hideBusyView;
+//- (void)showBusyViewWithLoadingText:(NSString *)text;
+//- (void)updateBusyViewLoadingText:(NSString *)text;
+//- (void)hideBusyView;
 
 // Request Second Password From User
 - (void)getSecondPassword:(void (^)(NSString *))success error:(void (^)(NSString *))error helperText:(NSString *)helperText;

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -191,8 +191,6 @@ void (^secondPasswordSuccess)(NSString *);
 
     [self disableUIWebViewCaching];
 
-    busyLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_SMALL_MEDIUM];
-
     // Allocate the global wallet
     self.wallet = [[Wallet alloc] init];
     self.wallet.delegate = self;
@@ -202,9 +200,9 @@ void (^secondPasswordSuccess)(NSString *);
     NSSetUncaughtExceptionHandler(&HandleException);
 #endif
 
-    [[NSNotificationCenter defaultCenter] addObserverForName:NOTIFICATION_KEY_LOADING_TEXT object:nil queue:nil usingBlock:^(NSNotification * notification) {
-        self.loadingText = [notification object];
-    }];
+//    [[NSNotificationCenter defaultCenter] addObserverForName:NOTIFICATION_KEY_LOADING_TEXT object:nil queue:nil usingBlock:^(NSNotification * notification) {
+//        self.loadingText = [notification object];
+//    }];
 
 //    app.window.backgroundColor = [UIColor whiteColor];
 //
@@ -215,11 +213,7 @@ void (^secondPasswordSuccess)(NSString *);
 //    [self.tabControllerManager dashBoardClicked:nil];
 
     // Add busy view to root vc
-    [app.window.rootViewController.view addSubview:busyView];
-
-    // Default view in TabViewController: dashboard
-    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:busyView];
-
+//    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:busyView];
 //    busyView.frame = app.window.frame;
 //    busyView.alpha = 0.0f;
 
@@ -773,55 +767,55 @@ void (^secondPasswordSuccess)(NSString *);
 
 - (void)showBusyViewWithLoadingText:(NSString *)text
 {
-    if (self.topViewControllerDelegate) {
-        if ([self.topViewControllerDelegate respondsToSelector:@selector(showBusyViewWithLoadingText:)]) {
-            [self.topViewControllerDelegate showBusyViewWithLoadingText:text];
-        }
-        return;
-    }
-
-    if (self.pinEntryViewController.inSettings &&
-        ![text isEqualToString:BC_STRING_LOADING_SYNCING_WALLET] &&
-        ![text isEqualToString:BC_STRING_LOADING_VERIFYING]) {
-        DLog(@"Verify optional PIN view is presented - will not update busy views unless verifying or syncing");
-        return;
-    }
-
-    if ([self.tabControllerManager isSending] && modalView) {
-        DLog(@"Send progress modal is presented - will not show busy view");
-        return;
-    }
-
-    [busyLabel setText:text];
-
-    [[UIApplication sharedApplication].keyWindow.rootViewController.view bringSubviewToFront:busyView];
-
-    if (busyView.alpha < 1.0) {
-        [busyView fadeIn];
-    }
+//    if (self.topViewControllerDelegate) {
+//        if ([self.topViewControllerDelegate respondsToSelector:@selector(showBusyViewWithLoadingText:)]) {
+//            [self.topViewControllerDelegate showBusyViewWithLoadingText:text];
+//        }
+//        return;
+//    }
+//
+//    if (self.pinEntryViewController.inSettings &&
+//        ![text isEqualToString:BC_STRING_LOADING_SYNCING_WALLET] &&
+//        ![text isEqualToString:BC_STRING_LOADING_VERIFYING]) {
+//        DLog(@"Verify optional PIN view is presented - will not update busy views unless verifying or syncing");
+//        return;
+//    }
+//
+//    if ([self.tabControllerManager isSending] && modalView) {
+//        DLog(@"Send progress modal is presented - will not show busy view");
+//        return;
+//    }
+//
+//    [busyLabel setText:text];
+//
+//    [[UIApplication sharedApplication].keyWindow.rootViewController.view bringSubviewToFront:busyView];
+//
+//    if (busyView.alpha < 1.0) {
+//        [busyView fadeIn];
+//    }
 }
 
 - (void)updateBusyViewLoadingText:(NSString *)text
 {
-    if (self.topViewControllerDelegate) {
-        if ([self.topViewControllerDelegate respondsToSelector:@selector(updateBusyViewLoadingText:)]) {
-            [self.topViewControllerDelegate updateBusyViewLoadingText:text];
-        }
-        return;
-    }
-
-    if (self.pinEntryViewController.inSettings &&
-        ![text isEqualToString:BC_STRING_LOADING_SYNCING_WALLET] &&
-        ![text isEqualToString:BC_STRING_LOADING_VERIFYING]) {
-        DLog(@"Verify optional PIN view is presented - will not update busy views unless verifying or syncing");
-        return;
-    }
-
-    if (busyView.alpha == 1.0) {
-        [UIView animateWithDuration:ANIMATION_DURATION animations:^{
-            [busyLabel setText:text];
-        }];
-    }
+//    if (self.topViewControllerDelegate) {
+//        if ([self.topViewControllerDelegate respondsToSelector:@selector(updateBusyViewLoadingText:)]) {
+//            [self.topViewControllerDelegate updateBusyViewLoadingText:text];
+//        }
+//        return;
+//    }
+//
+//    if (self.pinEntryViewController.inSettings &&
+//        ![text isEqualToString:BC_STRING_LOADING_SYNCING_WALLET] &&
+//        ![text isEqualToString:BC_STRING_LOADING_VERIFYING]) {
+//        DLog(@"Verify optional PIN view is presented - will not update busy views unless verifying or syncing");
+//        return;
+//    }
+//
+//    if (busyView.alpha == 1.0) {
+//        [UIView animateWithDuration:ANIMATION_DURATION animations:^{
+//            [busyLabel setText:text];
+//        }];
+//    }
 }
 
 - (void)showVerifyingBusyViewWithTimer:(NSInteger)timeInSeconds
@@ -843,15 +837,15 @@ void (^secondPasswordSuccess)(NSString *);
 
 - (void)hideBusyView
 {
-    if (self.topViewControllerDelegate) {
-        if ([self.topViewControllerDelegate respondsToSelector:@selector(hideBusyView)]) {
-            [self.topViewControllerDelegate hideBusyView];
-        }
-    }
-
-    if (busyView.alpha == 1.0) {
-        [busyView fadeOut];
-    }
+//    if (self.topViewControllerDelegate) {
+//        if ([self.topViewControllerDelegate respondsToSelector:@selector(hideBusyView)]) {
+//            [self.topViewControllerDelegate hideBusyView];
+//        }
+//    }
+//
+//    if (busyView.alpha == 1.0) {
+//        [busyView fadeOut];
+//    }
 }
 
 - (void)hideSendAndReceiveKeyboards
@@ -2384,7 +2378,7 @@ void (^secondPasswordSuccess)(NSString *);
 - (void)didSendPaymentRequest:(NSDictionary *)info amount:(uint64_t)amount name:(NSString *)name requestId:(NSString *)requestId
 {
     if (!requestId) {
-        [app hideBusyView];
+        [self hideBusyView];
         [self.tabControllerManager clearReceiveAmounts];
 
         UIImageView *imageView = [[UIImageView alloc] initWithImage:[[UIImage imageNamed:@"success_large"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
@@ -2405,7 +2399,7 @@ void (^secondPasswordSuccess)(NSString *);
 
 - (void)didRequestPaymentRequest:(NSDictionary *)info name:(NSString *)name
 {
-    [app hideBusyView];
+    [self hideBusyView];
 
     [self.tabControllerManager reloadSendController];
 

--- a/Blockchain/RootServiceSwift.swift
+++ b/Blockchain/RootServiceSwift.swift
@@ -196,7 +196,7 @@ final class RootServiceSwift {
     }
 
     func showVerifyingBusyView(withTimeout seconds: Int) {
-        app.showBusyView(withLoadingText: LCStringLoadingVerifying)
+        LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.verifying)
         // TODO: refactor showVerifyingBusyView with newer iOS 10+ method
         loginTimeout = Timer.scheduledTimer(
             timeInterval: TimeInterval(seconds),
@@ -207,7 +207,7 @@ final class RootServiceSwift {
         )
     }
     @objc func showErrorLoading() {
-        // TODO: complete showErrorLoading implementation
+        // TODO: put this in AuthenticationManager
         if let timer = loginTimeout {
             timer.invalidate()
         }

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -480,8 +480,8 @@ BOOL displayingLocalSymbolSend;
 - (void)getInfoForTransferAllFundsToDefaultAccount
 {
     app.topViewControllerDelegate = nil;
-    
-    [app showBusyViewWithLoadingText:BC_STRING_TRANSFER_ALL_PREPARING_TRANSFER];
+
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_TRANSFER_ALL_PREPARING_TRANSFER];
     
     [app.wallet getInfoForTransferAllFundsToAccount];
 }
@@ -1165,7 +1165,7 @@ BOOL displayingLocalSymbolSend;
     if ([addressesUsed count] == 0) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * ANIMATION_DURATION * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             [self showErrorBeforeSending:BC_STRING_NO_ADDRESSES_WITH_SPENDABLE_BALANCE_ABOVE_OR_EQUAL_TO_DUST];
-            [app hideBusyView];
+            [[LoadingViewPresenter sharedInstance] hideBusyView];
         });
         return;
     }
@@ -1173,7 +1173,7 @@ BOOL displayingLocalSymbolSend;
     if ([amount longLongValue] + [fee longLongValue] > [app.wallet getTotalBalanceForSpendableActiveLegacyAddresses]) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * ANIMATION_DURATION * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_SOME_FUNDS_CANNOT_BE_TRANSFERRED_AUTOMATICALLY title:BC_STRING_WARNING_TITLE];
-            [app hideBusyView];
+            [[LoadingViewPresenter sharedInstance] hideBusyView];
         });
     }
     
@@ -1195,7 +1195,7 @@ BOOL displayingLocalSymbolSend;
 
 - (void)showSummaryForTransferAll
 {
-    [app hideBusyView];
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
     
     [self showSummaryForTransferAllWithCustomFromLabel:selectAddressTextField.text];
     
@@ -1845,7 +1845,7 @@ BOOL displayingLocalSymbolSend;
 {
     DLog(@"Creating send request with reason: %@, amount: %lld", reason, amount);
     [textField resignFirstResponder];
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_REQUEST];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_REQUEST];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.45 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [app.wallet requestPaymentRequest:contact.identifier amount:amount requestId:nil note:reason initiatorSource:accountOrAddress];
     });
@@ -2104,7 +2104,7 @@ BOOL displayingLocalSymbolSend;
 
 - (void)archiveTransferredAddresses
 {
-    [app showBusyViewWithLoadingText:[NSString stringWithFormat:BC_STRING_ARCHIVING_ADDRESSES]];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[NSString stringWithFormat:BC_STRING_ARCHIVING_ADDRESSES]];
                                       
     [app.wallet archiveTransferredAddresses:self.transferAllPaymentBuilder.transferAllAddressesTransferred];
     

--- a/Blockchain/TransactionsBitcoinCashViewController.m
+++ b/Blockchain/TransactionsBitcoinCashViewController.m
@@ -128,7 +128,7 @@
 
 - (void)getHistoryAndRates
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
 
     [app.wallet performSelector:@selector(getBitcoinCashHistoryAndRates) withObject:nil afterDelay:0.1f];
 }

--- a/Blockchain/TransactionsBitcoinViewController.m
+++ b/Blockchain/TransactionsBitcoinViewController.m
@@ -474,7 +474,7 @@
         }
     }
 #else
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
     
     [app.wallet performSelector:@selector(getHistory) withObject:nil afterDelay:0.1f];
 #endif

--- a/Blockchain/TransactionsEtherViewController.m
+++ b/Blockchain/TransactionsEtherViewController.m
@@ -10,6 +10,7 @@
 #import "RootService.h"
 #import "TransactionEtherTableViewCell.h"
 #import "EtherTransaction.h"
+#import "Blockchain-Swift.h"
 
 @interface TransactionsViewController ()
 @property (nonatomic) UILabel *noTransactionsTitle;
@@ -98,7 +99,7 @@
 
 - (void)getHistory
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
     
     [app.wallet performSelector:@selector(getEthHistory) withObject:nil afterDelay:0.1f];
 }

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -2525,7 +2525,7 @@
 - (void)watchPendingTrades:(BOOL)shouldSync
 {
     if (shouldSync) {
-        [app showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
     }
     
     [self.context evaluateScript:[NSString stringWithFormat:@"MyWalletPhone.getPendingTrades(%d)", shouldSync]];
@@ -3250,73 +3250,73 @@
 
 - (void)loading_start_download_wallet
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_DOWNLOADING_WALLET];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_DOWNLOADING_WALLET];
 }
 
 - (void)loading_start_decrypt_wallet
 {
-    [app updateBusyViewLoadingText:BC_STRING_LOADING_DECRYPTING_WALLET];
+    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_DECRYPTING_WALLET];
 }
 
 - (void)loading_start_build_wallet
 {
-    [app updateBusyViewLoadingText:BC_STRING_LOADING_LOADING_BUILD_HD_WALLET];
+    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_BUILD_HD_WALLET];
 }
 
 - (void)loading_start_multiaddr
 {
-    [app updateBusyViewLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
 }
 
 - (void)loading_start_get_history
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
 }
 
 - (void)loading_start_get_wallet_and_history
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_CHECKING_WALLET_UPDATES];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CHECKING_WALLET_UPDATES];
 }
 
 - (void)loading_start_upgrade_to_hd
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_V3_WALLET];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_V3_WALLET];
 }
 
 - (void)loading_start_create_account
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING];
 }
 
 - (void)loading_start_new_account
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_WALLET];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_WALLET];
 }
 
 - (void)loading_start_create_new_address
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_NEW_ADDRESS];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_NEW_ADDRESS];
 }
 
 - (void)loading_start_generate_uuids
 {
-    [app updateBusyViewLoadingText:BC_STRING_LOADING_RECOVERY_CREATING_WALLET];
+    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_RECOVERY_CREATING_WALLET];
 }
 
 - (void)loading_start_recover_wallet
 {
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_RECOVERING_WALLET];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_RECOVERING_WALLET];
 }
 
 - (void)loading_start_transfer_all:(NSNumber *)addressIndex totalAddresses:(NSNumber *)totalAddresses
 {
-    [app showBusyViewWithLoadingText:[NSString stringWithFormat:BC_STRING_TRANSFER_ALL_CALCULATING_AMOUNTS_AND_FEES_ARGUMENT_OF_ARGUMENT, addressIndex, totalAddresses]];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[NSString stringWithFormat:BC_STRING_TRANSFER_ALL_CALCULATING_AMOUNTS_AND_FEES_ARGUMENT_OF_ARGUMENT, addressIndex, totalAddresses]];
 }
 
 - (void)loading_stop
 {
     DLog(@"Stop loading");
-    [app hideBusyView];
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
 }
 
 - (void)upgrade_success
@@ -3649,8 +3649,8 @@
 {
     DLog(@"on_add_private_key_start");
     self.isSyncing = YES;
-    
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_IMPORT_KEY];
+
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_IMPORT_KEY];
 }
 
 - (void)on_add_key:(NSString*)address
@@ -4086,8 +4086,8 @@
     DLog(@"on_add_new_account");
     
     [self subscribeToXPub:[self getXpubForAccount:[self getActiveAccountsCount:AssetTypeBitcoin] - 1 assetType:AssetTypeBitcoin] assetType:AssetTypeBitcoin];
-    
-    [app showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
+
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_SYNCING_WALLET];
 }
 
 - (void)on_error_add_new_account:(NSString*)error
@@ -4141,11 +4141,11 @@
     
     if ([totalReceived longLongValue] == 0) {
         self.emptyAccountIndex++;
-        [app updateBusyViewLoadingText:[NSString stringWithFormat:BC_STRING_LOADING_RECOVERING_WALLET_CHECKING_ARGUMENT_OF_ARGUMENT, self.emptyAccountIndex, self.emptyAccountIndex > RECOVERY_ACCOUNT_DEFAULT_NUMBER ? self.emptyAccountIndex : RECOVERY_ACCOUNT_DEFAULT_NUMBER]];
+        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:[NSString stringWithFormat:BC_STRING_LOADING_RECOVERING_WALLET_CHECKING_ARGUMENT_OF_ARGUMENT, self.emptyAccountIndex, self.emptyAccountIndex > RECOVERY_ACCOUNT_DEFAULT_NUMBER ? self.emptyAccountIndex : RECOVERY_ACCOUNT_DEFAULT_NUMBER]];
     } else {
         self.emptyAccountIndex = 0;
         self.recoveredAccountIndex++;
-        [app updateBusyViewLoadingText:[NSString stringWithFormat:BC_STRING_LOADING_RECOVERING_WALLET_ARGUMENT_FUNDS_ARGUMENT, self.recoveredAccountIndex, [NSNumberFormatter formatMoney:fundsInAccount]]];
+        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:[NSString stringWithFormat:BC_STRING_LOADING_RECOVERING_WALLET_ARGUMENT_FUNDS_ARGUMENT, self.recoveredAccountIndex, [NSNumberFormatter formatMoney:fundsInAccount]]];
     }
 }
 
@@ -4334,8 +4334,8 @@
 - (void)on_create_invitation_error:(JSValue *)error
 {
     DLog(@"on_create_invitation_error");
-    
-    [app hideBusyView];
+
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
 
     [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:[error toString] title:BC_STRING_ERROR];
 }
@@ -4431,8 +4431,8 @@
 - (void)on_send_payment_request_error:(JSValue *)error
 {
     DLog(@"on_send_payment_request_error");
-    
-    [app hideBusyView];
+
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
     
     NSString *message = [error toString];
     
@@ -4459,8 +4459,8 @@
 - (void)on_send_payment_request_response_error:(JSValue *)error
 {
     DLog(@"on_send_payment_request_response_error");
-    
-    [app hideBusyView];
+
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
     [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:[error toString] title:BC_STRING_ERROR];
 }
 
@@ -4786,8 +4786,8 @@
 
 - (void)on_shift_payment_error:(NSDictionary *)result
 {
-    [app hideBusyView];
-    
+    [[LoadingViewPresenter sharedInstance] hideBusyView];
+
     NSString *errorMessage = [result objectForKey:DICTIONARY_KEY_MESSAGE];
     [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:errorMessage title:BC_STRING_ERROR];
 }
@@ -5145,7 +5145,7 @@
 
 - (void)crypto_scrypt:(id)_password salt:(id)salt n:(NSNumber*)N r:(NSNumber*)r p:(NSNumber*)p dkLen:(NSNumber*)derivedKeyLen success:(JSValue *)_success error:(JSValue *)_error
 {
-    [app showBusyViewWithLoadingText:BC_STRING_DECRYPTING_PRIVATE_KEY];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_DECRYPTING_PRIVATE_KEY];
     
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSData * data = [self _internal_crypto_scrypt:_password salt:salt n:[N unsignedLongLongValue] r:[r unsignedIntValue] p:[p unsignedIntValue] dkLen:[derivedKeyLen unsignedIntValue]];
@@ -5154,7 +5154,7 @@
             if (data) {
                 [_success callWithArguments:@[[data hexadecimalString]]];
             } else {
-                [app hideBusyView];
+                [[LoadingViewPresenter sharedInstance] hideBusyView];
                 [_error callWithArguments:@[@"Scrypt Error"]];
             }
         });


### PR DESCRIPTION
Moving busy view presentation to `LoadingPresenter`. Note that this is simply a wrapper around the current way that an activity indicator is displayed to the user. This is just so that we can untangle this logic away from RootService. We'll need to come up with a better solution longer-term (sometime after RootService is fully deprecated).

Please review/merge #104 before this