### PR TITLE
 refactor(TopViewController): deprecate topViewControllerDelegate.

### DIFF
--- a/Blockchain/AccountsAndAddressesDetailViewController.m
+++ b/Blockchain/AccountsAndAddressesDetailViewController.m
@@ -155,8 +155,6 @@ typedef enum {
         [app closeSideMenu];
     }];
     
-    app.topViewControllerDelegate = nil;
-    
     [app closeSideMenu];
     
     [app showSendCoins];

--- a/Blockchain/AccountsAndAddressesNavigationController.m
+++ b/Blockchain/AccountsAndAddressesNavigationController.m
@@ -181,17 +181,6 @@
     self.busyView = busyView;
 }
 
-- (void)presentAlertController:(UIAlertController *)alertController
-{
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ANIMATION_DURATION_LONG * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (self.presentedViewController) {
-            [self.presentedViewController presentViewController:alertController animated:YES completion:nil];
-        } else {
-            [self presentViewController:alertController animated:YES completion:nil];
-        }
-    });
-}
-
 - (void)alertUserToTransferAllFunds:(BOOL)userClicked
 {
 #ifdef ENABLE_TRANSFER_FUNDS
@@ -233,7 +222,6 @@
 {
     if ([self.visibleViewController isMemberOfClass:[AccountsAndAddressesViewController class]]) {
         [self dismissViewControllerAnimated:YES completion:nil];
-        app.topViewControllerDelegate = nil;
     } else {
         [self popViewControllerAnimated:YES];
     }

--- a/Blockchain/BCAddressSelectionView.m
+++ b/Blockchain/BCAddressSelectionView.m
@@ -342,8 +342,9 @@ typedef enum {
             [delegate didSelectToAddress:[bchAddresses objectAtIndex:[indexPath row]]];
         }
     }
-    
-    if (shouldCloseModal && !app.topViewControllerDelegate) {
+
+    UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
+    if (shouldCloseModal && ![topViewController conformsToProtocol:@protocol(TopViewController)]) {
         [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFromLeft];
     }
 }

--- a/Blockchain/BCFadeView.h
+++ b/Blockchain/BCFadeView.h
@@ -23,7 +23,6 @@
 - (void)showBusyViewWithLoadingText:(NSString *)text;
 - (void)updateBusyViewLoadingText:(NSString *)text;
 - (void)hideBusyView;
-- (void)presentAlertController:(UIAlertController *)alertController;
 @end
 
 @interface BCFadeView : UIView

--- a/Blockchain/BCNavigationController.m
+++ b/Blockchain/BCNavigationController.m
@@ -29,8 +29,6 @@
     
     self.view.backgroundColor = [UIColor whiteColor];
     
-    app.topViewControllerDelegate = self;
-    
     self.topBar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_HEADER_HEIGHT)];
     self.topBar.backgroundColor = COLOR_BLOCKCHAIN_BLUE;
     [self.view addSubview:self.topBar];
@@ -141,7 +139,6 @@
 - (void)dismiss
 {
     [self dismissViewControllerAnimated:YES completion:nil];
-    app.topViewControllerDelegate = nil;
 }
 
 #pragma mark - Busy View Delegate
@@ -169,17 +166,6 @@
     if (self.busyView.alpha == 1.0 && self.shouldHideBusyView) {
         [self.busyView fadeOut];
     }
-}
-
-- (void)presentAlertController:(UIAlertController *)alertController
-{
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ANIMATION_DURATION_LONG * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (self.presentedViewController) {
-            [self.presentedViewController presentViewController:alertController animated:YES completion:nil];
-        } else {
-            [self presentViewController:alertController animated:YES completion:nil];
-        }
-    });
 }
 
 @end

--- a/Blockchain/BuyBitcoinViewController.m
+++ b/Blockchain/BuyBitcoinViewController.m
@@ -132,13 +132,7 @@ NSString* loginWithJsonScript(NSString* json, NSString* externalJson, NSString* 
         DLog(@"Ran script with result %@, error %@", result, error);
         if (error != nil) {
             
-            UIViewController *targetController;
-            
-            if (app.topViewControllerDelegate) {
-                targetController = app.topViewControllerDelegate;
-            } else {
-                targetController = [UIApplication sharedApplication].keyWindow.rootViewController;
-            }
+            UIViewController *targetController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
             
             UIAlertController *errorAlert = [UIAlertController alertControllerWithTitle:BC_STRING_ERROR message:BC_STRING_BUY_WEBVIEW_ERROR_MESSAGE preferredStyle:UIAlertControllerStyleAlert];
             [errorAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:nil]];
@@ -181,7 +175,6 @@ NSString* loginWithJsonScript(NSString* json, NSString* externalJson, NSString* 
 
     if ([message.name isEqual:WEBKIT_HANDLER_SHOW_TX]) {
         [self dismissViewControllerAnimated:YES completion:^(){
-            app.topViewControllerDelegate = nil;
             [self.delegate showCompletedTrade:message.body];
         }];
     }

--- a/Blockchain/ContactDetailViewController.m
+++ b/Blockchain/ContactDetailViewController.m
@@ -330,7 +330,7 @@ const int maxFindAttempts = 2;
 
 - (void)refreshControlActivated
 {
-    [app.topViewControllerDelegate showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
     [app.wallet performSelector:@selector(getHistory) withObject:nil afterDelay:0.1f];
 }
 

--- a/Blockchain/ContactTransactionTableViewCell.m
+++ b/Blockchain/ContactTransactionTableViewCell.m
@@ -15,6 +15,7 @@
 #import "TransactionDetailViewModel.h"
 #import "RootService.h"
 #import "UIView+ChangeFrameAttribute.h"
+#import "Blockchain-Swift.h"
 
 @interface ContactTransactionTableViewCell()
 @property (nonatomic) BOOL isSetup;
@@ -168,12 +169,9 @@
         };
         navigationController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
         app.tabControllerManager.transactionsBitcoinViewController.detailViewController = detailViewController;
-        
-        if (app.topViewControllerDelegate) {
-            [app.topViewControllerDelegate presentViewController:navigationController animated:YES completion:nil];
-        } else {
-            [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navigationController animated:YES completion:nil];
-        }
+
+        UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
+        [topViewController presentViewController:navigationController animated:YES completion:nil];
     }
 }
 

--- a/Blockchain/ContactsViewController.m
+++ b/Blockchain/ContactsViewController.m
@@ -119,8 +119,6 @@ const int sectionContacts = 0;
     self.invitationSentIdentifier = nil;
     
     self.lastCreatedInvitation = nil;
-    
-    app.topViewControllerDelegate = (BCNavigationController *)self.navigationController;
 }
 
 - (void)setContactsToDisplay:(NSArray *)contactsToDisplay
@@ -222,7 +220,7 @@ const int sectionContacts = 0;
 
 - (void)refreshControlActivated
 {
-    [app.topViewControllerDelegate showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
     [app.wallet performSelector:@selector(getHistory) withObject:nil afterDelay:0.1f];
 }
 

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -49,12 +49,12 @@
     IBOutlet BCModalContentView *pairingInstructionsView;
     IBOutlet BCManualPairView *manualPairView;
     
-    IBOutlet UIButton *scanPairingCodeButton;
-    IBOutlet UIButton *manualPairButton;
-    IBOutlet UITextView *manualPairStepOneTextView;
-    IBOutlet UITextView *manualPairStepTwoTextView;
-    IBOutlet UITextView *manualPairStepThreeTextView;
-    
+//    IBOutlet UIButton *scanPairingCodeButton;
+//    IBOutlet UIButton *manualPairButton;
+//    IBOutlet UITextView *manualPairStepOneTextView;
+//    IBOutlet UITextView *manualPairStepTwoTextView;
+//    IBOutlet UITextView *manualPairStepThreeTextView;
+
     BOOL validateSecondPassword;
     IBOutlet UILabel *secondPasswordDescriptionLabel;
     IBOutlet UIView *secondPasswordView;
@@ -74,7 +74,7 @@
     BOOL symbolLocal;
 }
 
-@property (nonatomic, weak) UIViewController <TopViewController> *topViewControllerDelegate;
+//@property (nonatomic, weak) UIViewController <TopViewController> *topViewControllerDelegate;
 
 @property (strong, nonatomic) IBOutlet ECSlidingViewController *slidingViewController;
 @property (nonatomic) TabControllerManager *tabControllerManager;

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -344,7 +344,7 @@ void (^secondPasswordSuccess)(NSString *);
     // Close all modals
     [app closeAllModals];
 
-    self.topViewControllerDelegate = nil;
+//    self.topViewControllerDelegate = nil;
 
     // Close screens that shouldn't be in the foreground when returning to the wallet
     if (_backupNavigationViewController) {
@@ -1054,7 +1054,8 @@ void (^secondPasswordSuccess)(NSString *);
 
     if ([BlockchainSettings sharedAppInstance].isPinSet) {
 
-        if (self.topViewControllerDelegate == self.settingsNavigationController && self.settingsNavigationController) return;
+        UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+        if (topViewController == self.settingsNavigationController && self.settingsNavigationController) return;
 
         [self showMobileNotice];
     }
@@ -1315,12 +1316,13 @@ void (^secondPasswordSuccess)(NSString *);
 
     secondPasswordDescriptionLabel.text = BC_STRING_PRIVATE_KEY_ENCRYPTED_DESCRIPTION;
 
-    if (self.topViewControllerDelegate) {
+    UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+    if (topViewController) {
         BCModalViewController *bcModalViewController = [[BCModalViewController alloc] initWithCloseType:ModalCloseTypeClose showHeader:YES headerText:BC_STRING_PASSWORD_REQUIRED view:secondPasswordView];
 
         addPrivateKeySuccess = success;
 
-        [self.topViewControllerDelegate presentViewController:bcModalViewController animated:YES completion:^{
+        [topViewController presentViewController:bcModalViewController animated:YES completion:^{
             UIButton *secondPasswordOverlayButton = [[UIButton alloc] initWithFrame:[secondPasswordView convertRect:secondPasswordButton.frame toView:bcModalViewController.view]];
             [bcModalViewController.view addSubview:secondPasswordOverlayButton];
             [secondPasswordOverlayButton addTarget:self action:@selector(privateKeyPasswordClicked) forControlEvents:UIControlEventTouchUpInside];
@@ -1398,10 +1400,11 @@ void (^secondPasswordSuccess)(NSString *);
 
     secondPasswordSuccess = success;
 
-    if (self.topViewControllerDelegate) {
+    UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+    if (topViewController) {
         BCModalViewController *bcModalViewController = [[BCModalViewController alloc] initWithCloseType:ModalCloseTypeClose showHeader:YES headerText:BC_STRING_SECOND_PASSWORD_REQUIRED view:secondPasswordView];
 
-        [self.topViewControllerDelegate presentViewController:bcModalViewController animated:YES completion:^{
+        [topViewController presentViewController:bcModalViewController animated:YES completion:^{
             UIButton *secondPasswordOverlayButton = [[UIButton alloc] initWithFrame:[secondPasswordView convertRect:secondPasswordButton.frame toView:bcModalViewController.view]];
             [bcModalViewController.view addSubview:secondPasswordOverlayButton];
             [secondPasswordOverlayButton addTarget:self action:@selector(secondPasswordClicked:) forControlEvents:UIControlEventTouchUpInside];
@@ -1664,11 +1667,8 @@ void (^secondPasswordSuccess)(NSString *);
 
     [[NSNotificationCenter defaultCenter] addObserver:reader selector:@selector(autoDismiss) name:NOTIFICATION_KEY_RELOAD_TO_DISMISS_VIEWS object:nil];
 
-    if (self.topViewControllerDelegate) {
-        [self.topViewControllerDelegate presentViewController:reader animated:YES completion:nil];
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:reader animated:YES completion:nil];
-    }
+    UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:reader animated:YES completion:nil];
 
     app.wallet.lastScannedWatchOnlyAddress = address;
 }
@@ -1683,11 +1683,8 @@ void (^secondPasswordSuccess)(NSString *);
     }]];
     [alertToWarnAboutWatchOnly addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:nil]];
 
-    if (self.topViewControllerDelegate) {
-        [self.topViewControllerDelegate presentViewController:alertToWarnAboutWatchOnly animated:YES completion:nil];
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertToWarnAboutWatchOnly animated:YES completion:nil];
-    }
+    UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:alertToWarnAboutWatchOnly animated:YES completion:nil];
 }
 
 - (void)logout
@@ -1784,13 +1781,9 @@ void (^secondPasswordSuccess)(NSString *);
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:BC_STRING_SUCCESS message:[NSString stringWithFormat:messageWithArgument, self.wallet.lastImportedAddress] preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:nil]];
     [[NSNotificationCenter defaultCenter] addObserver:alert selector:@selector(autoDismiss) name:UIApplicationDidEnterBackgroundNotification object:nil];
-    if (self.topViewControllerDelegate) {
-        if ([self.topViewControllerDelegate respondsToSelector:@selector(presentAlertController:)]) {
-            [self.topViewControllerDelegate presentAlertController:alert];
-        }
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
-    }
+
+    UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)didImportIncorrectPrivateKey:(NSString *)address
@@ -1810,13 +1803,8 @@ void (^secondPasswordSuccess)(NSString *);
     [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:nil]];
     [[NSNotificationCenter defaultCenter] addObserver:alert selector:@selector(autoDismiss) name:UIApplicationDidEnterBackgroundNotification object:nil];
 
-    if (self.topViewControllerDelegate) {
-        if ([self.topViewControllerDelegate respondsToSelector:@selector(presentAlertController:)]) {
-            [self.topViewControllerDelegate presentAlertController:alert];
-        }
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
-    }
+    UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)didImportPrivateKeyToLegacyAddress
@@ -1834,13 +1822,8 @@ void (^secondPasswordSuccess)(NSString *);
     [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:nil]];
     [[NSNotificationCenter defaultCenter] addObserver:alert selector:@selector(autoDismiss) name:UIApplicationDidEnterBackgroundNotification object:nil];
 
-    if (self.topViewControllerDelegate) {
-        if ([self.topViewControllerDelegate respondsToSelector:@selector(presentAlertController:)]) {
-            [self.topViewControllerDelegate presentAlertController:alert];
-        }
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
-    }
+    UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)didFailToImportPrivateKey:(NSString *)error
@@ -1864,13 +1847,8 @@ void (^secondPasswordSuccess)(NSString *);
     [errorAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:nil]];
     [[NSNotificationCenter defaultCenter] addObserver:errorAlert selector:@selector(autoDismiss) name:UIApplicationDidEnterBackgroundNotification object:nil];
 
-    if (self.topViewControllerDelegate) {
-        if ([self.topViewControllerDelegate respondsToSelector:@selector(presentAlertController:)]) {
-            [self.topViewControllerDelegate presentAlertController:errorAlert];
-        }
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:errorAlert animated:YES completion:nil];
-    }
+    UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:errorAlert animated:YES completion:nil];
 }
 
 - (void)didFailToImportPrivateKeyForWatchOnlyAddress:(NSString *)error
@@ -1896,13 +1874,8 @@ void (^secondPasswordSuccess)(NSString *);
 
     [[NSNotificationCenter defaultCenter] addObserver:errorAlert selector:@selector(autoDismiss) name:UIApplicationDidEnterBackgroundNotification object:nil];
 
-    if (self.topViewControllerDelegate) {
-        if ([self.topViewControllerDelegate respondsToSelector:@selector(presentAlertController:)]) {
-            [self.topViewControllerDelegate presentAlertController:errorAlert];
-        }
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:errorAlert animated:YES completion:nil];
-    }
+    UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:errorAlert animated:YES completion:nil];
 }
 
 - (void)didFailRecovery
@@ -2156,7 +2129,8 @@ void (^secondPasswordSuccess)(NSString *);
 
             UIAlertController *alert;
 
-            if (self.topViewControllerDelegate) {
+            UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController.topMostViewController;
+            if ([topViewController conformsToProtocol:@protocol(TopViewController)]) {
 
                 if (self.contactsViewController.view.window) {
 
@@ -2211,11 +2185,7 @@ void (^secondPasswordSuccess)(NSString *);
                 }
 
                 if (alert) {
-                    if (self.topViewControllerDelegate && [self.topViewControllerDelegate respondsToSelector:@selector(presentAlertController:)]) {
-                        [self.topViewControllerDelegate presentAlertController:alert];
-                    } else {
-                        [self.tabControllerManager.tabViewController presentViewController:alert animated:YES completion:nil];
-                    }
+                    [topViewController presentViewController:alert animated:YES completion:nil];
                 }
 
             } else if (self.pinEntryViewController) {
@@ -2318,11 +2288,8 @@ void (^secondPasswordSuccess)(NSString *);
         [self.tabControllerManager showTransactionDetailForHash:hash];
     }]];
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (app.topViewControllerDelegate) {
-            [app.topViewControllerDelegate presentViewController:alert animated:YES completion:nil];
-        } else {
-            [app.tabControllerManager.tabViewController presentViewController:alert animated:YES completion:nil];
-        }
+        UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
+        [topViewController presentViewController:alert animated:YES completion:nil];
     });
 }
 
@@ -2630,7 +2597,7 @@ void (^secondPasswordSuccess)(NSString *);
 
     BCNavigationController *navigationController = [[BCNavigationController alloc] initWithRootViewController:self.contactsViewController title:BC_STRING_CONTACTS];
 
-    self.topViewControllerDelegate = navigationController;
+//    self.topViewControllerDelegate = navigationController;
     navigationController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
 
     [self.tabControllerManager.tabViewController presentViewController:navigationController animated:YES completion:nil];
@@ -2643,7 +2610,7 @@ void (^secondPasswordSuccess)(NSString *);
         self.accountsAndAddressesNavigationController = [storyboard instantiateViewControllerWithIdentifier:NAVIGATION_CONTROLLER_NAME_ACCOUNTS_AND_ADDRESSES];
     }
 
-    self.topViewControllerDelegate = self.accountsAndAddressesNavigationController;
+//    self.topViewControllerDelegate = self.accountsAndAddressesNavigationController;
     self.accountsAndAddressesNavigationController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
 
     [self.tabControllerManager.tabViewController presentViewController:self.accountsAndAddressesNavigationController animated:YES completion:^{
@@ -2669,7 +2636,7 @@ void (^secondPasswordSuccess)(NSString *);
         self.settingsNavigationController = [storyboard instantiateViewControllerWithIdentifier:NAVIGATION_CONTROLLER_NAME_SETTINGS];
     }
 
-    self.topViewControllerDelegate = self.settingsNavigationController;
+//    self.topViewControllerDelegate = self.settingsNavigationController;
     [self.settingsNavigationController showSettings];
 
     self.settingsNavigationController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
@@ -2887,7 +2854,7 @@ void (^secondPasswordSuccess)(NSString *);
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:STORYBOARD_NAME_UPGRADE bundle: nil];
     UpgradeViewController *upgradeViewController = [storyboard instantiateViewControllerWithIdentifier:VIEW_CONTROLLER_NAME_UPGRADE];
     upgradeViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
-    app.topViewControllerDelegate = upgradeViewController;
+//    app.topViewControllerDelegate = upgradeViewController;
     [self.tabControllerManager.tabViewController presentViewController:upgradeViewController animated:YES completion:nil];
 }
 
@@ -3128,7 +3095,7 @@ void (^secondPasswordSuccess)(NSString *);
 - (void)setupTransferAllFunds
 {
     self.transferAllFundsModalController = nil;
-    app.topViewControllerDelegate = nil;
+//    app.topViewControllerDelegate = nil;
 
     [self.tabControllerManager setupTransferAllFunds];
 }
@@ -3430,13 +3397,8 @@ void (^secondPasswordSuccess)(NSString *);
         [self.pinEntryViewController reset];
     }]];
 
-    if (self.topViewControllerDelegate) {
-        if ([self.topViewControllerDelegate respondsToSelector:@selector(presentAlertController:)]) {
-            [self.topViewControllerDelegate presentAlertController:alert];
-        }
-    } else {
-        [self.window.rootViewController presentViewController:alert animated:YES completion:nil];
-    }
+    UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)askIfUserWantsToResetPIN
@@ -3911,10 +3873,8 @@ void (^secondPasswordSuccess)(NSString *);
 
             if (viewController) {
                 [viewController presentViewController:alert animated:YES completion:nil];
-            } else if (self.topViewControllerDelegate) {
-                [self.topViewControllerDelegate presentViewController:alert animated:YES completion:nil];
             } else {
-                [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alert animated:YES completion:nil];
+                [UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController presentViewController:alert animated:YES completion:nil];
             }
         }
     }

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -479,8 +479,6 @@ BOOL displayingLocalSymbolSend;
 
 - (void)getInfoForTransferAllFundsToDefaultAccount
 {
-    app.topViewControllerDelegate = nil;
-
     [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_TRANSFER_ALL_PREPARING_TRANSFER];
     
     [app.wallet getInfoForTransferAllFundsToAccount];

--- a/Blockchain/SettingsNavigationController.m
+++ b/Blockchain/SettingsNavigationController.m
@@ -100,7 +100,6 @@
 {
     if ([self.visibleViewController isMemberOfClass:[SettingsTableViewController class]]) {
         [self dismissViewControllerAnimated:YES completion:nil];
-        app.topViewControllerDelegate = nil;
     } else {
         [self popViewControllerAnimated:YES];
     }
@@ -163,11 +162,6 @@
 {
     //TODO: use this delegate method instead of handling busy views manually from view controllers
     return;
-}
-
-- (void)presentAlertController:(UIAlertController *)alertController
-{
-    [self.visibleViewController presentViewController:alertController animated:YES completion:nil];
 }
 
 - (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion

--- a/Blockchain/TransactionEtherTableViewCell.m
+++ b/Blockchain/TransactionEtherTableViewCell.m
@@ -12,6 +12,7 @@
 #import "TransactionDetailViewController.h"
 #import "TransactionDetailNavigationController.h"
 #import "RootService.h"
+#import "Blockchain-Swift.h"
 
 @implementation TransactionEtherTableViewCell
 
@@ -94,12 +95,9 @@
     };
     navigationController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     app.tabControllerManager.transactionsEtherViewController.detailViewController = detailViewController;
-    
-    if (app.topViewControllerDelegate) {
-        [app.topViewControllerDelegate presentViewController:navigationController animated:YES completion:nil];
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navigationController animated:YES completion:nil];
-    }
+
+    UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:navigationController animated:YES completion:nil];
 }
 
 - (void)ethButtonClicked

--- a/Blockchain/TransactionTableCell.m
+++ b/Blockchain/TransactionTableCell.m
@@ -13,6 +13,7 @@
 #import "TransactionDetailViewController.h"
 #import "TransactionDetailNavigationController.h"
 #import "NSDateFormatter+TimeAgoString.h"
+#import "Blockchain-Swift.h"
 
 @implementation TransactionTableCell
 
@@ -130,12 +131,9 @@
     };
     navigationController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     app.tabControllerManager.transactionsBitcoinViewController.detailViewController = detailViewController;
-    
-    if (app.topViewControllerDelegate) {
-        [app.topViewControllerDelegate presentViewController:navigationController animated:YES completion:nil];
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navigationController animated:YES completion:nil];
-    }
+
+    UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:navigationController animated:YES completion:nil];
 }
 
 - (void)bitcoinCashTransactionClicked
@@ -152,12 +150,9 @@
     };
     navigationController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     app.tabControllerManager.transactionsBitcoinCashViewController.detailViewController = detailViewController;
-    
-    if (app.topViewControllerDelegate) {
-        [app.topViewControllerDelegate presentViewController:navigationController animated:YES completion:nil];
-    } else {
-        [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navigationController animated:YES completion:nil];
-    }
+
+    UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:navigationController animated:YES completion:nil];
 }
 
 - (IBAction)btcbuttonclicked:(id)sender

--- a/Blockchain/TransactionsBitcoinViewController.m
+++ b/Blockchain/TransactionsBitcoinViewController.m
@@ -529,12 +529,9 @@
     };
     navigationController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     app.tabControllerManager.transactionsBitcoinViewController.detailViewController = detailViewController;
-    
-    if (app.topViewControllerDelegate) {
-        [app.topViewControllerDelegate presentViewController:navigationController animated:YES completion:nil];
-    } else {
-        [app.tabControllerManager.tabViewController presentViewController:navigationController animated:YES completion:nil];
-    }
+
+    UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
+    [topViewController presentViewController:navigationController animated:YES completion:nil];
 }
 
 - (uint64_t)getBalance

--- a/Blockchain/UpgradeViewController.m
+++ b/Blockchain/UpgradeViewController.m
@@ -37,8 +37,6 @@
         return;
     }
     
-    app.topViewControllerDelegate = nil;
-    
     [app.wallet loading_start_upgrade_to_hd];
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * ANIMATION_DURATION * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -160,7 +158,6 @@
 {
     [super viewWillDisappear:animated];
     [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent animated:YES];
-    app.topViewControllerDelegate = nil;
 }
 
 - (void)viewDidLayoutSubviews
@@ -219,13 +216,6 @@
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
     [self setTextForCaptionLabel];
-}
-
-#pragma mark Top View Delegate
-
-- (void)presentAlertController:(UIAlertController *)alertController
-{
-    [self presentViewController:alertController animated:YES completion:nil];
 }
 
 @end


### PR DESCRIPTION
Deprecate `topViewControllerDelegate` in RootService. This field can now be obtained through:
```
UIApplication.shared.keyWindow.rootViewController.topMostViewController
```

If you need to check if it is of type `TopViewController`, just check the type of that field.

Longer-term note: this is again a work-around with the current approach of how `UIViewController`s are presented in the app. It's much better to present a `UIViewController` from the instance that needs to present it. This can be tied in to the coordinator pattern, too.

Please review/merge #106 before reviewing this.