### PR TITLE
refactor(PushNotificationManager): creating PushNotificationManager.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -227,6 +227,8 @@
 		AAA3333F2088131D0019AD55 /* ModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333E2088131D0019AD55 /* ModalPresenter.swift */; };
 		AAA33345208846110019AD55 /* BCCreateWalletView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AAA33344208846110019AD55 /* BCCreateWalletView.xib */; };
 		AABDED40208A6E8D002D8BAC /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED3F208A6E8D002D8BAC /* UIViewController.swift */; };
+		AACE31572091680B00B7B806 /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED68208EB4FB002D8BAC /* PushNotificationManager.swift */; };
+		AACE31582091681100B7B806 /* WalletManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED6B208EC330002D8BAC /* WalletManager.swift */; };
 		C70FF55E1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = C70FF55D1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m */; };
 		C70FF5661E7B051C00AC7F8B /* ContactTransactionTableCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C70FF5651E7B051C00AC7F8B /* ContactTransactionTableCell.xib */; };
 		C71859471F3E227D00745A87 /* BCDescriptionView.m in Sources */ = {isa = PBXBuildFile; fileRef = C71859461F3E227C00745A87 /* BCDescriptionView.m */; };
@@ -1143,6 +1145,8 @@
 		AAA3333E2088131D0019AD55 /* ModalPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalPresenter.swift; sourceTree = "<group>"; };
 		AAA33344208846110019AD55 /* BCCreateWalletView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BCCreateWalletView.xib; sourceTree = "<group>"; };
 		AABDED3F208A6E8D002D8BAC /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
+		AABDED68208EB4FB002D8BAC /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
+		AABDED6B208EC330002D8BAC /* WalletManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletManager.swift; sourceTree = "<group>"; };
 		C70FF55C1E76D5C600AC7F8B /* BuyBitcoinNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BuyBitcoinNavigationController.h; sourceTree = "<group>"; };
 		C70FF55D1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BuyBitcoinNavigationController.m; sourceTree = "<group>"; };
 		C70FF5651E7B051C00AC7F8B /* ContactTransactionTableCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ContactTransactionTableCell.xib; sourceTree = "<group>"; };
@@ -1873,12 +1877,14 @@
 				AAA3316320895CE600BBD292 /* Loading */,
 				9F765F3A14BC7C3100048EFB /* Models */,
 				51A7348B20891EB3009727D5 /* Network */,
+				AABDED66208EB4EA002D8BAC /* Notifications */,
 				AAA333402088450D0019AD55 /* Onboarding */,
 				C9D4B2AF193E023C00EDA9EA /* Resources */,
 				AA69F65C2086A7330054EFCE /* Settings */,
 				9FB3637C14B60128004BEA02 /* Supporting Files */,
 				9FCA4D18151494A300ECDFBE /* View Controllers */,
 				C9D4B2B2193E032200EDA9EA /* Views */,
+				AABDED6A208EC320002D8BAC /* Wallet */,
 			);
 			path = Blockchain;
 			sourceTree = "<group>";
@@ -2060,6 +2066,22 @@
 				AAA3315020893DCA00BBD292 /* PairingInstructionsView.xib */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		AABDED66208EB4EA002D8BAC /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				AABDED68208EB4FB002D8BAC /* PushNotificationManager.swift */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
+		AABDED6A208EC320002D8BAC /* Wallet */ = {
+			isa = PBXGroup;
+			children = (
+				AABDED6B208EC330002D8BAC /* WalletManager.swift */,
+			);
+			path = Wallet;
 			sourceTree = "<group>";
 		};
 		C790E0F91E5205620063D141 /* Fonts */ = {
@@ -2641,6 +2663,7 @@
 				5185E11C208E7F7C00A26B64 /* BlockchainSettings.swift in Sources */,
 				519435B1208E62F6001EF882 /* BlockchainAPI+URL.swift in Sources */,
 				519435B4208E630F001EF882 /* UserDefaults.swift in Sources */,
+				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
 				519435B8208E6366001EF882 /* LocalizationConstants.swift in Sources */,
 				519435B7208E6364001EF882 /* Environment.swift in Sources */,
 				519435B6208E635A001EF882 /* AssetType.swift in Sources */,
@@ -2648,6 +2671,7 @@
 				519435AE208E62E3001EF882 /* BlockchainAPI.swift in Sources */,
 				5185E12B208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */,
 				519435B9208E63CA001EF882 /* AuthenticationError.swift in Sources */,
+				AACE3132209121B300B7B806 /* PushNotificationManager.swift in Sources */,
 				519435AC208E6279001EF882 /* CertificatePinnerTests.swift in Sources */,
 				519435BC208E64E0001EF882 /* Constants.swift in Sources */,
 				516546F9208FCF800019EE63 /* Enum+Enumeratable.swift in Sources */,
@@ -2658,6 +2682,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AACE31582091681100B7B806 /* WalletManager.swift in Sources */,
+				AACE31572091680B00B7B806 /* PushNotificationManager.swift in Sources */,
 				2343E4031CB434BC008DC7D1 /* NSArray+EncodedJSONString.m in Sources */,
 				511646DF20851BC600C43522 /* Bundle.swift in Sources */,
 				237C9E901C482132000754F7 /* AccountsAndAddressesDetailViewController.m in Sources */,

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -91,6 +91,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         AppCoordinator.shared.start()
 
+        if #available(iOS 10.0, *) {
+            PushNotificationManager.shared.requestAuthorization()
+        } else {
+            LegacyPushNotificationManager.shared.requestAuthorization()
+        }
+
         return true
     }
 

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -23,7 +23,6 @@
 #define APP_STORE_LINK_PREFIX @"itms-apps://itunes.apple.com/app/"
 #define APP_STORE_ID @"id493253309"
 
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 #define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 
 #pragma mark - Colors

--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -64,6 +64,12 @@ struct Constants {
     struct NotificationKeys {
         static let modalViewDismissed = NSNotification.Name("modalViewDismissed")
     }
+    struct PushNotificationKeys {
+        static let userInfoType = "type"
+        static let userInfoId = "id"
+        static let typePayment = "payment"
+        static let typeContactRequest = "contact_request"
+    }
 }
 
 /// Constant class wrapper so that Constants can be accessed from Obj-C. Should deprecate this

--- a/Blockchain/Extensions/UIDevice.swift
+++ b/Blockchain/Extensions/UIDevice.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public extension UIDevice {
     var modelName: String {

--- a/Blockchain/Notifications/PushNotificationManager.swift
+++ b/Blockchain/Notifications/PushNotificationManager.swift
@@ -1,0 +1,94 @@
+//
+//  NotificationManager.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/23/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Manager object for push notifications for iOS versions < 10.0.
+ */
+class LegacyPushNotificationManager {
+    static let shared = LegacyPushNotificationManager()
+
+    func requestAuthorization() {
+        let notificationSettings = UIUserNotificationSettings(types: [.sound, .alert, .badge], categories: nil)
+        UIApplication.shared.registerUserNotificationSettings(notificationSettings)
+    }
+}
+
+/**
+ Manager object for push notifications
+ */
+@available(iOS 10.0, *)
+@objc
+class PushNotificationManager: NSObject {
+
+    static let shared = PushNotificationManager()
+
+    @objc class func sharedInstace() -> PushNotificationManager {
+        return shared
+    }
+
+    /// UNNotification that is to be presented to the user
+    @objc var presentingPushNotification: UNNotification?
+
+    /// Requests permission from the user to grant access to receive push notifications
+    func requestAuthorization() {
+        let userNotificationCenter = UNUserNotificationCenter.current()
+        userNotificationCenter.delegate = self
+        userNotificationCenter.requestAuthorization(options: [.sound, .alert, .badge]) { _, error in
+            guard error == nil else {
+                print("Push registration FAILED")
+                print("ERROR: \(error!.localizedDescription)")
+                return
+            }
+
+            print("Push registration success.")
+            DispatchQueue.main.async {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+        }
+    }
+}
+
+@available(iOS 10.0, *)
+extension PushNotificationManager: UNUserNotificationCenterDelegate {
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+
+        presentingPushNotification = notification
+
+        WalletManager.shared.wallet.getMessages()
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+
+        print("User received remote notification")
+
+        let notificationContent = response.notification.request.content
+        let type = notificationContent.userInfo[Constants.PushNotificationKeys.userInfoType] as? String
+        let invitationSent = notificationContent.userInfo[Constants.PushNotificationKeys.userInfoId] as? String
+
+        if type == Constants.PushNotificationKeys.typeContactRequest {
+            // TODO set show type & initialize ContactsViewController
+            //    showType = ShowTypeNewContact;
+            //    _contactsViewController = [[ContactsViewController alloc] initWithAcceptedInvitation:invitationSent];
+        } else if type == Constants.PushNotificationKeys.typePayment {
+            // TODO set show type
+            //    showType = ShowTypeNewPayment;
+            AppCoordinator.shared.tabControllerManager.setTransactionsViewControllerMessageIdentifier(invitationSent)
+        }
+    }
+}

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -34,7 +34,7 @@
 
 @class TransactionsBitcoinViewController, BCFadeView, ReceiveCoinsViewController, SendBitcoinViewController, BCCreateWalletView, BCManualPairView, MultiAddressResponse, PairingCodeParser, BCWebViewController, BackupNavigationViewController, ContactsViewController, ContactTransaction, BuyBitcoinViewController;
 
-@interface RootService : NSObject <UIApplicationDelegate, WalletDelegate, PEPinEntryControllerDelegate, MFMailComposeViewControllerDelegate, UNUserNotificationCenterDelegate, ReminderModalDelegate, SetupDelegate, TabControllerDelegate> {
+@interface RootService : NSObject <UIApplicationDelegate, WalletDelegate, PEPinEntryControllerDelegate, MFMailComposeViewControllerDelegate, ReminderModalDelegate, SetupDelegate, TabControllerDelegate> {
 
     Wallet *wallet;
     

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -78,7 +78,7 @@ ShowReminderType showReminderType;
 
 SideMenuViewController *sideMenuViewController;
 
-UNNotification *pushNotificationPendingAction;
+//UNNotification *pushNotificationPendingAction;
 
 void (^addPrivateKeySuccess)(NSString *);
 void (^secondPasswordSuccess)(NSString *);
@@ -220,7 +220,7 @@ void (^secondPasswordSuccess)(NSString *);
 
 //    [self showWelcomeOrPinScreen];
 
-    [self requestAuthorizationForPushNotifications];
+//    [self requestAuthorizationForPushNotifications];
 
     // TODO: Set Montserrat font globally
     app.mainTitleLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_TOP_BAR_TEXT];
@@ -476,27 +476,27 @@ void (^secondPasswordSuccess)(NSString *);
     return YES;
 }
 
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
-{
-    pushNotificationPendingAction = notification;
+//- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
+//{
+//    pushNotificationPendingAction = notification;
+//
+//    [self.wallet getMessages];
+//}
 
-    [self.wallet getMessages];
-}
-
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)())completionHandler
-{
-    DLog(@"User received remote notification");
-    NSString *type = [response.notification.request.content.userInfo objectForKey:DICTIONARY_KEY_TYPE];
-    NSString *invitationSent = [response.notification.request.content.userInfo objectForKey:DICTIONARY_KEY_ID];
-
-    if ([type isEqualToString:PUSH_NOTIFICATION_TYPE_CONTACT_REQUEST]) {
-        showType = ShowTypeNewContact;
-        _contactsViewController = [[ContactsViewController alloc] initWithAcceptedInvitation:invitationSent];
-    } else if ([type isEqualToString:PUSH_NOTIFICATION_TYPE_PAYMENT]) {
-        showType = ShowTypeNewPayment;
-        [self.tabControllerManager setTransactionsViewControllerMessageIdentifier:invitationSent];
-    }
-}
+//- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)())completionHandler
+//{
+//    DLog(@"User received remote notification");
+//    NSString *type = [response.notification.request.content.userInfo objectForKey:DICTIONARY_KEY_TYPE];
+//    NSString *invitationSent = [response.notification.request.content.userInfo objectForKey:DICTIONARY_KEY_ID];
+//
+//    if ([type isEqualToString:PUSH_NOTIFICATION_TYPE_CONTACT_REQUEST]) {
+//        showType = ShowTypeNewContact;
+//        _contactsViewController = [[ContactsViewController alloc] initWithAcceptedInvitation:invitationSent];
+//    } else if ([type isEqualToString:PUSH_NOTIFICATION_TYPE_PAYMENT]) {
+//        showType = ShowTypeNewPayment;
+//        [self.tabControllerManager setTransactionsViewControllerMessageIdentifier:invitationSent];
+//    }
+//}
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
@@ -538,28 +538,28 @@ void (^secondPasswordSuccess)(NSString *);
 //    return _tabControllerManager;
 }
 
-- (void)requestAuthorizationForPushNotifications
-{
-    if (SYSTEM_VERSION_LESS_THAN(@"10.0")) {
-        [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:(UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge) categories:nil]];
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-    } else {
-        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        center.delegate = self;
-        [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error) {
-             if (!error) {
-                 dispatch_async(dispatch_get_main_queue(), ^{
-                     [[UIApplication sharedApplication] registerForRemoteNotifications];
-                 });
-                 DLog( @"Push registration success." );
-             } else {
-                 DLog( @"Push registration FAILED" );
-                 DLog( @"ERROR: %@ - %@", error.localizedFailureReason, error.localizedDescription );
-                 DLog( @"SUGGESTIONS: %@ - %@", error.localizedRecoveryOptions, error.localizedRecoverySuggestion );
-             }
-         }];
-    }
-}
+//- (void)requestAuthorizationForPushNotifications
+//{
+//    if (SYSTEM_VERSION_LESS_THAN(@"10.0")) {
+//        [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:(UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge) categories:nil]];
+//        [[UIApplication sharedApplication] registerForRemoteNotifications];
+//    } else {
+//        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+//        center.delegate = self;
+//        [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error) {
+//             if (!error) {
+//                 dispatch_async(dispatch_get_main_queue(), ^{
+//                     [[UIApplication sharedApplication] registerForRemoteNotifications];
+//                 });
+//                 DLog( @"Push registration success." );
+//             } else {
+//                 DLog( @"Push registration FAILED" );
+//                 DLog( @"ERROR: %@ - %@", error.localizedFailureReason, error.localizedDescription );
+//                 DLog( @"SUGGESTIONS: %@ - %@", error.localizedRecoveryOptions, error.localizedRecoverySuggestion );
+//             }
+//         }];
+//    }
+//}
 
 - (void)registerDeviceForPushNotifications
 {
@@ -2111,6 +2111,7 @@ void (^secondPasswordSuccess)(NSString *);
 
 - (void)didGetNewMessages:(NSArray *)newMessages
 {
+    UNNotification *pushNotificationPendingAction = PushNotificationManager.sharedInstace.presentingPushNotification;
     if (pushNotificationPendingAction) {
 
         NSString *type = [pushNotificationPendingAction.request.content.userInfo objectForKey:DICTIONARY_KEY_TYPE];
@@ -2261,7 +2262,7 @@ void (^secondPasswordSuccess)(NSString *);
         }
     }
 
-    pushNotificationPendingAction = nil;
+    PushNotificationManager.sharedInstace.presentingPushNotification = nil;
 
     [self reloadMessageViews];
 }

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -1,0 +1,30 @@
+//
+//  WalletManager.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/23/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Manager object for operations to the Blockchain Wallet.
+ */
+@objc
+class WalletManager: NSObject {
+    static let shared = WalletManager()
+
+    // TODO: Replace this with asset-specific wallet architecture
+    let wallet: Wallet
+
+    private override init() {
+        wallet = Wallet()!
+        super.init()
+        wallet.delegate = self
+    }
+}
+
+extension WalletManager: WalletDelegate {
+    // TODO: Move all WalletDelegate methods from RootService to here
+}


### PR DESCRIPTION
Created `PushNotificationManager` which manages everything related to push notifications (i.e. encapsulates the method for requesting for push permission and it sets itself as a `UNUserNotificationDelegate`).

Please review #109 first

----
**Feedback need for the following:** This PR also contains a `WalletManager` object which contains the `Wallet` instance (currently in `RootService`). It also sets itself as the `WalletDelegate` to that instance. Having wallet in `RootService` is currently blocking further refactoring of `RootService` as wallet is referenced in many different places—moving it to `WalletManager` will unblock that. 

Once we get started on an asset-based wallet architecture, we can then remove that instance from `WalletManager`. But, I do think it will remain to be a `WalletDelegate`.

----
**Side-note:** I think we should deprecate the concept of a `WalletDelegate`. Instead of having a single delegate to wallet calls, operations performed on a wallet should either: (1) accept callbacks, or (2) return Promises or a similar async construct (Observables, etc.). Deprecating this is a pretty large effort so let's stick to the current design for now until we have more time to address this.