### PR TITLE
Fix eth balance

### DIFF
--- a/Blockchain/BCPriceMarker.swift
+++ b/Blockchain/BCPriceMarker.swift
@@ -108,7 +108,8 @@ open class BCPriceMarker: MarkerImage {
                 fatalError("Chart data entry has bad data")
         }
         guard let number = NumberFormatter.fiatString(from: entry.y) else {
-            fatalError("Could not generate number string from chart data entry")
+            print("Could not generate number string from chart data entry")
+            return
         }
         let labelText = String(format: "%@\n%@%@", currency, symbol, number)
         setLabel(labelText)

--- a/Blockchain/BCPriceMarker.swift
+++ b/Blockchain/BCPriceMarker.swift
@@ -107,7 +107,10 @@ open class BCPriceMarker: MarkerImage {
             let symbol = data["symbol"] as? String else {
                 fatalError("Chart data entry has bad data")
         }
-        let labelText = String(format: "%@\n%@%@", currency, symbol, String(entry.y))
+        guard let number = NumberFormatter.fiatString(from: entry.y) else {
+            fatalError("Could not generate number string from chart data entry")
+        }
+        let labelText = String(format: "%@\n%@%@", currency, symbol, number)
         setLabel(labelText)
     }
 

--- a/Blockchain/BCPriceMarker.swift
+++ b/Blockchain/BCPriceMarker.swift
@@ -109,6 +109,7 @@ open class BCPriceMarker: MarkerImage {
         }
         guard let number = NumberFormatter.fiatString(from: entry.y) else {
             print("Could not generate number string from chart data entry")
+            setLabel(currency)
             return
         }
         let labelText = String(format: "%@\n%@%@", currency, symbol, number)

--- a/Blockchain/Blockchain-Bridging-Header.h
+++ b/Blockchain/Blockchain-Bridging-Header.h
@@ -9,3 +9,4 @@
 #import "UIViewController+AutoDismiss.h"
 #import "TransferAllFundsViewController.h"
 #import "BCNavigationController.h"
+#import "NSNumberFormatter+Currencies.h"

--- a/Blockchain/DashboardViewController.m
+++ b/Blockchain/DashboardViewController.m
@@ -355,7 +355,10 @@
 
 - (double)getEthBalance
 {
-    return [self doubleFromString:[NSNumberFormatter formatEthToFiat:[app.wallet getEthBalance] exchangeRate:app.wallet.latestEthExchangeRate]];
+    app.localCurrencyFormatter.usesGroupingSeparator = NO;
+    double result = [self doubleFromString:[NSNumberFormatter formatEthToFiat:[app.wallet getEthBalance] exchangeRate:app.wallet.latestEthExchangeRate]];
+    app.localCurrencyFormatter.usesGroupingSeparator = YES;
+    return result;
 }
 
 - (double)getBchBalance

--- a/Blockchain/DashboardViewController.m
+++ b/Blockchain/DashboardViewController.m
@@ -149,7 +149,7 @@
         [self.balancesChartView updateBitcoinFiatBalance:btcBalance];
         [self.balancesChartView updateEtherFiatBalance:ethBalance];
         [self.balancesChartView updateBitcoinCashFiatBalance:bchBalance];
-        [self.balancesChartView updateTotalFiatBalance:[NSNumberFormatter appendStringToFiatSymbol:[NSString stringWithFormat:@"%.2f", totalFiatBalance]]];
+        [self.balancesChartView updateTotalFiatBalance:[NSNumberFormatter appendStringToFiatSymbol:[NSNumberFormatter fiatStringFromDouble:totalFiatBalance]]];
         // Balances
         [self.balancesChartView updateBitcoinBalance:[NSNumberFormatter formatAmount:[app.wallet getTotalActiveBalance] localCurrency:NO]];
         [self.balancesChartView updateEtherBalance:[app.wallet getEthBalanceTruncated]];

--- a/Blockchain/NSNumberFormatter+Currencies.m
+++ b/Blockchain/NSNumberFormatter+Currencies.m
@@ -269,10 +269,12 @@
 + (NSString *)fiatStringFromDouble:(double)fiatBalance
 {
     NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+    numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
     numberFormatter.minimumIntegerDigits = 1;
     NSUInteger decimalPlaces = 2;
     numberFormatter.minimumFractionDigits = decimalPlaces;
     numberFormatter.maximumFractionDigits = decimalPlaces;
+    numberFormatter.usesGroupingSeparator = YES;
     return [numberFormatter stringFromNumber:[NSNumber numberWithDouble:fiatBalance]];
 }
 


### PR DESCRIPTION
Currently `dev` returns 0 fiat balance for ETH because of comma grouping separators. This branch fixes that and adds grouping separators (e.g. thousands separator) to other fiat labels in the pie chart and legend keys. Grouping separators for crypto values should wait until a further release.