### PR TITLE
Refactor

### DIFF
--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -563,7 +563,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 #define USER_DEFAULTS_KEY_HIDE_APP_REVIEW_PROMPT @"hideAppReviewPrompt"
 #define USER_DEFAULTS_KEY_SHARED_KEY @"sharedKey"
 #define USER_DEFAULTS_KEY_GUID @"guid"
-#define USER_DEFAULTS_KEY_SYMBOL_LOCAL @"symbolLocal"
 #define USER_DEFAULTS_KEY_PASSWORD @"password"
 #define USER_DEFAULTS_KEY_PIN @"pin"
 #define USER_DEFAULTS_KEY_PASSWORD_PART_HASH @"passwordPartHash"

--- a/Blockchain/Extensions/UserDefaults.swift
+++ b/Blockchain/Extensions/UserDefaults.swift
@@ -5,6 +5,7 @@
 //  Created by Maurice A. on 4/13/18.
 //  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
 //
+// Please keep the keys sorted alphabetically (:
 
 import Foundation
 
@@ -20,11 +21,12 @@ extension UserDefaults {
 
     enum Keys: String {
         case assetType = "assetType"
+        case encryptedPinPassword = "encryptedPINPassword"
         case environment = "environment"
         case firstRun = "firstRun"
         case hasSeenUpgradeToHdScreen = "hasSeenUpgradeToHdScreen"
         case swipeToReceiveEnabled = "swipeToReceive"
+        case symbolLocal = "symbolLocal"
         case pinKey = "pinKey"
-        case encryptedPinPassword = "encryptedPINPassword"
     }
 }

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -185,9 +185,9 @@ void (^secondPasswordSuccess)(NSString *);
 
 //    [self checkForNewInstall];
 
-    [self persistServerSessionIDForNewUIWebViews];
+//    [self persistServerSessionIDForNewUIWebViews];
 
-    [self disableUIWebViewCaching];
+//    [self disableUIWebViewCaching];
 
     // Allocate the global wallet
     self.wallet = [[Wallet alloc] init];
@@ -601,17 +601,17 @@ void (^secondPasswordSuccess)(NSString *);
     [_localCurrencyFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
 }
 
-- (void)persistServerSessionIDForNewUIWebViews
-{
-    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    [cookieStorage setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
-}
+//- (void)persistServerSessionIDForNewUIWebViews
+//{
+//    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+//    [cookieStorage setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
+//}
 
-- (void)disableUIWebViewCaching
-{
-    NSURLCache *sharedCache = [[NSURLCache alloc] initWithMemoryCapacity:0 diskCapacity:0 diskPath:nil];
-    [NSURLCache setSharedURLCache:sharedCache];
-}
+//- (void)disableUIWebViewCaching
+//{
+//    NSURLCache *sharedCache = [[NSURLCache alloc] initWithMemoryCapacity:0 diskCapacity:0 diskPath:nil];
+//    [NSURLCache setSharedURLCache:sharedCache];
+//}
 
 //- (void)setupSideMenu
 //{

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -216,7 +216,7 @@ void (^secondPasswordSuccess)(NSString *);
 //    busyView.alpha = 0.0f;
 
     // Load settings
-    symbolLocal = [[NSUserDefaults standardUserDefaults] boolForKey:USER_DEFAULTS_KEY_SYMBOL_LOCAL];
+//    symbolLocal = [[NSUserDefaults standardUserDefaults] boolForKey:USER_DEFAULTS_KEY_SYMBOL_LOCAL];
 
 //    [self showWelcomeOrPinScreen];
 
@@ -718,16 +718,16 @@ void (^secondPasswordSuccess)(NSString *);
     [sideMenuViewController reloadTableView];
 }
 
-- (void)toggleSymbol
-{
-    symbolLocal = !symbolLocal;
-
-    // Save this setting here and load it on start
-    [[NSUserDefaults standardUserDefaults] setBool:symbolLocal forKey:USER_DEFAULTS_KEY_SYMBOL_LOCAL];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-
-    [self reloadSymbols];
-}
+//- (void)toggleSymbol
+//{
+//    symbolLocal = !symbolLocal;
+//
+//    // Save this setting here and load it on start
+//    [[NSUserDefaults standardUserDefaults] setBool:symbolLocal forKey:USER_DEFAULTS_KEY_SYMBOL_LOCAL];
+//    [[NSUserDefaults standardUserDefaults] synchronize];
+//
+//    [self reloadSymbols];
+//}
 
 - (NSInteger)filterIndex
 {
@@ -754,14 +754,14 @@ void (^secondPasswordSuccess)(NSString *);
     [self.wallet reloadFilter];
 }
 
-- (void)reloadSymbols
-{
-    [self.tabControllerManager reloadSymbols];
-
-    [_contactsViewController reloadSymbols];
-    [_accountsAndAddressesNavigationController reload];
-    [sideMenuViewController reload];
-}
+//- (void)reloadSymbols
+//{
+//    [self.tabControllerManager reloadSymbols];
+//
+//    [_contactsViewController reloadSymbols];
+//    [_accountsAndAddressesNavigationController reload];
+//    [sideMenuViewController reload];
+//}
 
 - (void)showBusyViewWithLoadingText:(NSString *)text
 {

--- a/Blockchain/RootServiceSwift.swift
+++ b/Blockchain/RootServiceSwift.swift
@@ -100,6 +100,10 @@ final class RootServiceSwift {
 
         checkForNewInstall()
 
+        persistServerSessionIDForNewUIWebViews()
+
+        disableUIWebViewCaching()
+
         AppCoordinator.shared.start()
 
         //: ...
@@ -245,5 +249,14 @@ final class RootServiceSwift {
 
     func alertUserAskingToUseOldKeychain() {
         // TODO: implement alertUserAskingToUseOldKeychain
+    }
+
+    func persistServerSessionIDForNewUIWebViews() {
+        let cookieStorage = HTTPCookieStorage.shared
+        cookieStorage.cookieAcceptPolicy = .always
+    }
+
+    func disableUIWebViewCaching() {
+        URLCache.shared = URLCache(memoryCapacity: 0, diskCapacity: 0, diskPath: nil)
     }
 }

--- a/Blockchain/RootServiceSwift.swift
+++ b/Blockchain/RootServiceSwift.swift
@@ -106,8 +106,6 @@ final class RootServiceSwift {
 
         AppCoordinator.shared.start()
 
-        //: ...
-
         return true
     }
 
@@ -228,6 +226,21 @@ final class RootServiceSwift {
 //        }
     }
 
+    // TODO: move to appropriate module
+    func toggleSymbol() {
+        let symbolLocal = BlockchainSettings.App.shared.symbolLocal
+        BlockchainSettings.App.shared.symbolLocal = !symbolLocal
+        reloadSymbols()
+    }
+
+    // TODO: don't keep a reference to each contoller, instead allow them to subscribe to value changes
+    func reloadSymbols() {
+//    [self.tabControllerManager reloadSymbols];
+//    [_contactsViewController reloadSymbols];
+//    [_accountsAndAddressesNavigationController reload];
+//    [sideMenuViewController reload];
+    }
+
     // MARK: - State Checks
 
     // TODO: move to BlockchainSettings
@@ -251,11 +264,13 @@ final class RootServiceSwift {
         // TODO: implement alertUserAskingToUseOldKeychain
     }
 
+    // TODO: move to web view wrapper
     func persistServerSessionIDForNewUIWebViews() {
         let cookieStorage = HTTPCookieStorage.shared
         cookieStorage.cookieAcceptPolicy = .always
     }
 
+    // TODO: move to web view wrapper
     func disableUIWebViewCaching() {
         URLCache.shared = URLCache(memoryCapacity: 0, diskCapacity: 0, diskPath: nil)
     }

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -74,6 +74,15 @@ final class BlockchainSettings: NSObject {
             }
         }
 
+        @objc var symbolLocal: Bool {
+            get {
+                return defaults.bool(forKey: UserDefaults.Keys.symbolLocal.rawValue)
+            }
+            set {
+                defaults.set(newValue, forKey: UserDefaults.Keys.symbolLocal.rawValue)
+            }
+        }
+
         private override init() {
             // Private initializer so that `shared` and `sharedInstance` are the only ways to
             // access an instance of this class.


### PR DESCRIPTION
This PR continues to refactor the root service by migrating `symbolLocal` to BlockchainSettings and porting over `persistServerSessionIDForNewUIWebViews` and `disableUIWebViewCaching` to Swift.

These  two functions should be moved into a future web view wrapper. Also note that `toggleSymbol` and `reloadSymbols` are only partially ported at this time.