### PR TITLE
refactor(BlockchainSettings): moving guid and sharedKey to BlockchainSettings.Wallet

### DIFF
--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -216,7 +216,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // TODO: move to BlockchainSettings
     func checkForNewInstall() {
         if !BlockchainSettings.App.shared.firstRun {
-            if KeychainItemWrapper.guid() != nil && KeychainItemWrapper.sharedKey() != nil && !BlockchainSettings.sharedAppInstance().isPinSet {
+            if BlockchainSettings.App.shared.guid != nil &&
+                BlockchainSettings.App.shared.sharedKey != nil &&
+                !BlockchainSettings.sharedAppInstance().isPinSet {
                 alertUserAskingToUseOldKeychain()
             }
             BlockchainSettings.App.shared.firstRun = true

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -59,7 +59,7 @@ import Foundation
         LoadingViewPresenter.shared.initialize()
 
         // Display welcome screen if no wallet is authenticated
-        if KeychainItemWrapper.guid() == nil || KeychainItemWrapper.sharedKey() == nil {
+        if BlockchainSettings.App.shared.guid == nil || BlockchainSettings.App.shared.sharedKey == nil {
             OnboardingCoordinator.shared.start()
         } else {
             // TODO otherwise, show pin screen

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -101,6 +101,24 @@ final class BlockchainSettings: NSObject {
             }
         }
 
+        @objc var guid: String? {
+            get {
+                return KeychainItemWrapper.guid()
+            }
+            set {
+                KeychainItemWrapper.setGuidInKeychain(newValue)
+            }
+        }
+
+        @objc var sharedKey: String? {
+            get {
+                return KeychainItemWrapper.sharedKey()
+            }
+            set {
+                KeychainItemWrapper.setSharedKeyInKeychain(newValue)
+            }
+        }
+
         private override init() {
             // Private initializer so that `shared` and `sharedInstance` are the only ways to
             // access an instance of this class.

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -93,9 +93,8 @@ extension WalletManager: WalletDelegate {
             return
         }
 
-        // TODO put this in BlockchainSettings
-        KeychainItemWrapper.setGuidInKeychain(guid)
-        KeychainItemWrapper.setSharedKeyInKeychain(sharedKey)
+        BlockchainSettings.App.shared.guid = guid
+        BlockchainSettings.App.shared.sharedKey = sharedKey
 
         //Becuase we are not storing the password on the device. We record the first few letters of the hashed password.
         //With the hash prefix we can then figure out if the password changed


### PR DESCRIPTION
So that the application-level never has to interface with the keychain.

Also, should we put other properties that are currently in `BlockchainSettings.App` in here (e.g. `passwordPartHash`)?