### PR TITLE
refactor(AuthenticationCoordinator): Move pin entry flow to AuthenticationCoordinator.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -114,30 +114,15 @@
 		516546F5208FCF710019EE63 /* NetworkManager+UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516546F4208FCF710019EE63 /* NetworkManager+UserAgent.swift */; };
 		516546F6208FCF710019EE63 /* NetworkManager+UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516546F4208FCF710019EE63 /* NetworkManager+UserAgent.swift */; };
 		516546F8208FCF800019EE63 /* Enum+Enumeratable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516546F7208FCF800019EE63 /* Enum+Enumeratable.swift */; };
-		516546F9208FCF800019EE63 /* Enum+Enumeratable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516546F7208FCF800019EE63 /* Enum+Enumeratable.swift */; };
 		5185B18A208697F1003C9AC2 /* BCPriceMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5185B189208697F1003C9AC2 /* BCPriceMarker.swift */; };
 		5185E11C208E7F7C00A26B64 /* BlockchainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */; };
 		5185E124208F6E5E00A26B64 /* Enum+RawValued.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5185E123208F6E5E00A26B64 /* Enum+RawValued.swift */; };
-		5185E125208F6E5E00A26B64 /* Enum+RawValued.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5185E123208F6E5E00A26B64 /* Enum+RawValued.swift */; };
 		5185E12A208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5185E129208F7ACA00A26B64 /* BlockchainAPI+URI.swift */; };
 		5185E12B208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5185E129208F7ACA00A26B64 /* BlockchainAPI+URI.swift */; };
 		51943596208E3005001EF882 /* BlockchainAPI+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51943595208E3005001EF882 /* BlockchainAPI+URL.swift */; };
 		519435A1208E61F3001EF882 /* BlockchainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519435A0208E61F3001EF882 /* BlockchainTests.swift */; };
 		519435AC208E6279001EF882 /* CertificatePinnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519435AB208E6279001EF882 /* CertificatePinnerTests.swift */; };
-		519435AD208E62E0001EF882 /* CertificatePinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7348C20891EB3009727D5 /* CertificatePinner.swift */; };
-		519435AE208E62E3001EF882 /* BlockchainAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7349020891EB3009727D5 /* BlockchainAPI.swift */; };
-		519435AF208E62E8001EF882 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7348D20891EB3009727D5 /* NetworkManager.swift */; };
 		519435B1208E62F6001EF882 /* BlockchainAPI+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51943595208E3005001EF882 /* BlockchainAPI+URL.swift */; };
-		519435B2208E630A001EF882 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646DE20851BC600C43522 /* Bundle.swift */; };
-		519435B3208E630C001EF882 /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646E1208523E300C43522 /* UIDevice.swift */; };
-		519435B4208E630F001EF882 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513913EF2081206C002578FD /* UserDefaults.swift */; };
-		519435B5208E6356001EF882 /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E5C72F20741A130000A7FD /* AuthenticationManager.swift */; };
-		519435B6208E635A001EF882 /* AssetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C4208124E200C43522 /* AssetType.swift */; };
-		519435B7208E6364001EF882 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C7208129D800C43522 /* Environment.swift */; };
-		519435B8208E6366001EF882 /* LocalizationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E5C73020741A130000A7FD /* LocalizationConstants.swift */; };
-		519435B9208E63CA001EF882 /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A665C62080EBD80040EE7C /* AuthenticationError.swift */; };
-		519435BA208E63CE001EF882 /* Passcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510EA16F2080F16100A63AB8 /* Passcode.swift */; };
-		519435BC208E64E0001EF882 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D95A271B3DDC900012EBB1 /* Constants.swift */; };
 		51A665C72080EBD80040EE7C /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A665C62080EBD80040EE7C /* AuthenticationError.swift */; };
 		51A7349120891EB3009727D5 /* CertificatePinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7348C20891EB3009727D5 /* CertificatePinner.swift */; };
 		51A7349320891EB3009727D5 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7348D20891EB3009727D5 /* NetworkManager.swift */; };
@@ -147,12 +132,9 @@
 		51A862D520921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D420921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift */; };
 		51A862D620921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D420921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift */; };
 		51A862D920921E7600B338E0 /* BitcoinAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D820921E7600B338E0 /* BitcoinAddress.swift */; };
-		51A862DA20921E7600B338E0 /* BitcoinAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D820921E7600B338E0 /* BitcoinAddress.swift */; };
 		51A862DC20921EBD00B338E0 /* BitcoinCashAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862DB20921EBD00B338E0 /* BitcoinCashAddress.swift */; };
-		51A862DD20921EBD00B338E0 /* BitcoinCashAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862DB20921EBD00B338E0 /* BitcoinCashAddress.swift */; };
 		51A862DF20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862DE20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift */; };
 		51A862E12092506600B338E0 /* AssetAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862E02092506600B338E0 /* AssetAddress.swift */; };
-		51A862E22092506600B338E0 /* AssetAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862E02092506600B338E0 /* AssetAddress.swift */; };
 		51A862E42092686300B338E0 /* CheckForUnusedAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862E32092686300B338E0 /* CheckForUnusedAddressTests.swift */; };
 		51A862E7209268D300B338E0 /* sample-unused-address.json in Resources */ = {isa = PBXBuildFile; fileRef = 51A862E6209268D300B338E0 /* sample-unused-address.json */; };
 		51E5C73220741A130000A7FD /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E5C72F20741A130000A7FD /* AuthenticationManager.swift */; };
@@ -238,9 +220,48 @@
 		AABDED70208FACB9002D8BAC /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED6F208FACB9002D8BAC /* Reachability.swift */; };
 		AABDED92208FDFE3002D8BAC /* HTTPCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED91208FDFE3002D8BAC /* HTTPCookieStorage.swift */; };
 		AACE31222091004A00B7B806 /* UIApplication+Suspend.m in Sources */ = {isa = PBXBuildFile; fileRef = AACE31212091004A00B7B806 /* UIApplication+Suspend.m */; };
+		AACE3132209121B300B7B806 /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED68208EB4FB002D8BAC /* PushNotificationManager.swift */; };
+		AACE3134209121B800B7B806 /* WalletManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED6B208EC330002D8BAC /* WalletManager.swift */; };
 		AACE31382091220300B7B806 /* HTTPCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED91208FDFE3002D8BAC /* HTTPCookieStorage.swift */; };
 		AACE31572091680B00B7B806 /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED68208EB4FB002D8BAC /* PushNotificationManager.swift */; };
 		AACE31582091681100B7B806 /* WalletManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED6B208EC330002D8BAC /* WalletManager.swift */; };
+		AACE31482091430900B7B806 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE31472091430900B7B806 /* AuthenticationCoordinator.swift */; };
+		AACE314C209152D800B7B806 /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE314B209152D800B7B806 /* UIApplication.swift */; };
+		AACE31572091680B00B7B806 /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED68208EB4FB002D8BAC /* PushNotificationManager.swift */; };
+		AACE31582091681100B7B806 /* WalletManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED6B208EC330002D8BAC /* WalletManager.swift */; };
+		AACE31812092794D00B7B806 /* Pin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE31802092794D00B7B806 /* Pin.swift */; };
+		AACE31822092858600B7B806 /* Pin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE31802092794D00B7B806 /* Pin.swift */; };
+		AACE31B82092A87900B7B806 /* PinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE31B72092A87900B7B806 /* PinTests.swift */; };
+		AACE31C32092A99B00B7B806 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333220880A2B0019AD55 /* AppDelegate.swift */; };
+		AACE31C42092A99B00B7B806 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D95A271B3DDC900012EBB1 /* Constants.swift */; };
+		AACE31C52092A99B00B7B806 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C7208129D800C43522 /* Environment.swift */; };
+		AACE31C62092A99B00B7B806 /* LoadingViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */; };
+		AACE31C72092A99B00B7B806 /* LocalizationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E5C73020741A130000A7FD /* LocalizationConstants.swift */; };
+		AACE31C82092A99B00B7B806 /* ModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333E2088131D0019AD55 /* ModalPresenter.swift */; };
+		AACE31C92092A99B00B7B806 /* AlertViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */; };
+		AACE31CA2092A99B00B7B806 /* AssetAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862E02092506600B338E0 /* AssetAddress.swift */; };
+		AACE31CB2092A99B00B7B806 /* AssetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C4208124E200C43522 /* AssetType.swift */; };
+		AACE31CC2092A99B00B7B806 /* BitcoinAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D820921E7600B338E0 /* BitcoinAddress.swift */; };
+		AACE31CD2092A99B00B7B806 /* BitcoinCashAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862DB20921EBD00B338E0 /* BitcoinCashAddress.swift */; };
+		AACE31CE2092A99B00B7B806 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE31472091430900B7B806 /* AuthenticationCoordinator.swift */; };
+		AACE31CF2092A99B00B7B806 /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E5C72F20741A130000A7FD /* AuthenticationManager.swift */; };
+		AACE31D02092A99B00B7B806 /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A665C62080EBD80040EE7C /* AuthenticationError.swift */; };
+		AACE31D12092A99B00B7B806 /* Passcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510EA16F2080F16100A63AB8 /* Passcode.swift */; };
+		AACE31D22092A99B00B7B806 /* UINavigationController+PopToRootWithCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232E17F81C29F0EF0044942E /* UINavigationController+PopToRootWithCompletion.swift */; };
+		AACE31D32092A99B00B7B806 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333C208813040019AD55 /* OnboardingCoordinator.swift */; };
+		AACE31D42092A99B00B7B806 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F6582086A2720054EFCE /* AppCoordinator.swift */; };
+		AACE31D52092A99B00B7B806 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333A2088115C0019AD55 /* Coordinator.swift */; };
+		AACE31D62092A99B00B7B806 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646DE20851BC600C43522 /* Bundle.swift */; };
+		AACE31D72092A99B00B7B806 /* Enum+Enumeratable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516546F7208FCF800019EE63 /* Enum+Enumeratable.swift */; };
+		AACE31D82092A99B00B7B806 /* Enum+RawValued.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5185E123208F6E5E00A26B64 /* Enum+RawValued.swift */; };
+		AACE31D92092A99B00B7B806 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED6F208FACB9002D8BAC /* Reachability.swift */; };
+		AACE31DA2092A99B00B7B806 /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE314B209152D800B7B806 /* UIApplication.swift */; };
+		AACE31DB2092A99B00B7B806 /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646E1208523E300C43522 /* UIDevice.swift */; };
+		AACE31DC2092A99B00B7B806 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED3F208A6E8D002D8BAC /* UIViewController.swift */; };
+		AACE31DD2092A99B00B7B806 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513913EF2081206C002578FD /* UserDefaults.swift */; };
+		AACE31DE2092A99B00B7B806 /* BlockchainAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7349020891EB3009727D5 /* BlockchainAPI.swift */; };
+		AACE31DF2092A99B00B7B806 /* CertificatePinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7348C20891EB3009727D5 /* CertificatePinner.swift */; };
+		AACE31E02092A99B00B7B806 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7348D20891EB3009727D5 /* NetworkManager.swift */; };
 		C70FF55E1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = C70FF55D1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m */; };
 		C70FF5661E7B051C00AC7F8B /* ContactTransactionTableCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C70FF5651E7B051C00AC7F8B /* ContactTransactionTableCell.xib */; };
 		C71859471F3E227D00745A87 /* BCDescriptionView.m in Sources */ = {isa = PBXBuildFile; fileRef = C71859461F3E227C00745A87 /* BCDescriptionView.m */; };
@@ -1159,6 +1180,10 @@
 		AABDED91208FDFE3002D8BAC /* HTTPCookieStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPCookieStorage.swift; sourceTree = "<group>"; };
 		AACE31202091004900B7B806 /* UIApplication+Suspend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIApplication+Suspend.h"; path = "Extensions/UIApplication+Suspend.h"; sourceTree = "<group>"; };
 		AACE31212091004A00B7B806 /* UIApplication+Suspend.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIApplication+Suspend.m"; path = "Extensions/UIApplication+Suspend.m"; sourceTree = "<group>"; };
+		AACE31472091430900B7B806 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinator.swift; sourceTree = "<group>"; };
+		AACE314B209152D800B7B806 /* UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIApplication.swift; path = Extensions/UIApplication.swift; sourceTree = "<group>"; };
+		AACE31802092794D00B7B806 /* Pin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pin.swift; sourceTree = "<group>"; };
+		AACE31B72092A87900B7B806 /* PinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinTests.swift; sourceTree = "<group>"; };
 		C70FF55C1E76D5C600AC7F8B /* BuyBitcoinNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BuyBitcoinNavigationController.h; sourceTree = "<group>"; };
 		C70FF55D1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BuyBitcoinNavigationController.m; sourceTree = "<group>"; };
 		C70FF5651E7B051C00AC7F8B /* ContactTransactionTableCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ContactTransactionTableCell.xib; sourceTree = "<group>"; };
@@ -1511,6 +1536,7 @@
 		510EA1732080F58700A63AB8 /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
+				AACE31472091430900B7B806 /* AuthenticationCoordinator.swift */,
 				51E5C72F20741A130000A7FD /* AuthenticationManager.swift */,
 				510EA1742080F59C00A63AB8 /* Models */,
 			);
@@ -1535,6 +1561,7 @@
 				516546F7208FCF800019EE63 /* Enum+Enumeratable.swift */,
 				5185E123208F6E5E00A26B64 /* Enum+RawValued.swift */,
 				AABDED6F208FACB9002D8BAC /* Reachability.swift */,
+				AACE314B209152D800B7B806 /* UIApplication.swift */,
 				511646E1208523E300C43522 /* UIDevice.swift */,
 				AABDED3F208A6E8D002D8BAC /* UIViewController.swift */,
 				513913EF2081206C002578FD /* UserDefaults.swift */,
@@ -1608,6 +1635,7 @@
 				51A862DE20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift */,
 				51A862E32092686300B338E0 /* CheckForUnusedAddressTests.swift */,
 				C74FEA2520979259007CAB5D /* JSContextWithDOMTests.swift */,
+				AACE31B72092A87900B7B806 /* PinTests.swift */,
 			);
 			path = BlockchainTests;
 			sourceTree = "<group>";
@@ -1903,6 +1931,7 @@
 				51A7348B20891EB3009727D5 /* Network */,
 				AABDED66208EB4EA002D8BAC /* Notifications */,
 				AAA333402088450D0019AD55 /* Onboarding */,
+				AACE317E2092793300B7B806 /* Pin */,
 				C9D4B2AF193E023C00EDA9EA /* Resources */,
 				AA69F65C2086A7330054EFCE /* Settings */,
 				9FB3637C14B60128004BEA02 /* Supporting Files */,
@@ -2101,6 +2130,14 @@
 				AABDED6B208EC330002D8BAC /* WalletManager.swift */,
 			);
 			path = Wallet;
+			sourceTree = "<group>";
+		};
+		AACE317E2092793300B7B806 /* Pin */ = {
+			isa = PBXGroup;
+			children = (
+				AACE31802092794D00B7B806 /* Pin.swift */,
+			);
+			path = Pin;
 			sourceTree = "<group>";
 		};
 		C790E0F91E5205620063D141 /* Fonts */ = {
@@ -2666,23 +2703,37 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51A862DD20921EBD00B338E0 /* BitcoinCashAddress.swift in Sources */,
-				51A862BD2090DD4500B338E0 /* UIViewController.swift in Sources */,
-				519435AD208E62E0001EF882 /* CertificatePinner.swift in Sources */,
+				AACE31DA2092A99B00B7B806 /* UIApplication.swift in Sources */,
+				AACE31D42092A99B00B7B806 /* AppCoordinator.swift in Sources */,
+				AACE31D02092A99B00B7B806 /* AuthenticationError.swift in Sources */,
+				AACE31D92092A99B00B7B806 /* Reachability.swift in Sources */,
+				AACE31DE2092A99B00B7B806 /* BlockchainAPI.swift in Sources */,
 				516546F6208FCF710019EE63 /* NetworkManager+UserAgent.swift in Sources */,
-				5185E125208F6E5E00A26B64 /* Enum+RawValued.swift in Sources */,
-				51A862DA20921E7600B338E0 /* BitcoinAddress.swift in Sources */,
-				519435B3208E630C001EF882 /* UIDevice.swift in Sources */,
+				AACE31C42092A99B00B7B806 /* Constants.swift in Sources */,
 				AACE31382091220300B7B806 /* HTTPCookieStorage.swift in Sources */,
 				51A862BE2090DD6400B338E0 /* PairingInstructionsView.swift in Sources */,
+				AACE31CD2092A99B00B7B806 /* BitcoinCashAddress.swift in Sources */,
 				51A862E42092686300B338E0 /* CheckForUnusedAddressTests.swift in Sources */,
-				519435B5208E6356001EF882 /* AuthenticationManager.swift in Sources */,
+				AACE31D62092A99B00B7B806 /* Bundle.swift in Sources */,
+				AACE31DC2092A99B00B7B806 /* UIViewController.swift in Sources */,
 				51A862DF20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift in Sources */,
-				519435B2208E630A001EF882 /* Bundle.swift in Sources */,
-				51A862E22092506600B338E0 /* AssetAddress.swift in Sources */,
 				519435A1208E61F3001EF882 /* BlockchainTests.swift in Sources */,
-				519435AF208E62E8001EF882 /* NetworkManager.swift in Sources */,
+				AACE31D52092A99B00B7B806 /* Coordinator.swift in Sources */,
 				5185E11C208E7F7C00A26B64 /* BlockchainSettings.swift in Sources */,
+				AACE31DB2092A99B00B7B806 /* UIDevice.swift in Sources */,
+				AACE31CF2092A99B00B7B806 /* AuthenticationManager.swift in Sources */,
+				AACE31CA2092A99B00B7B806 /* AssetAddress.swift in Sources */,
+				AACE31B82092A87900B7B806 /* PinTests.swift in Sources */,
+				AACE31C82092A99B00B7B806 /* ModalPresenter.swift in Sources */,
+				AACE31C32092A99B00B7B806 /* AppDelegate.swift in Sources */,
+				AACE31822092858600B7B806 /* Pin.swift in Sources */,
+				AACE31D72092A99B00B7B806 /* Enum+Enumeratable.swift in Sources */,
+				AACE31D82092A99B00B7B806 /* Enum+RawValued.swift in Sources */,
+				AACE31C92092A99B00B7B806 /* AlertViewPresenter.swift in Sources */,
+				AACE31E02092A99B00B7B806 /* NetworkManager.swift in Sources */,
+				AACE31DD2092A99B00B7B806 /* UserDefaults.swift in Sources */,
+				AACE31CE2092A99B00B7B806 /* AuthenticationCoordinator.swift in Sources */,
+				AACE31DF2092A99B00B7B806 /* CertificatePinner.swift in Sources */,
 				519435B1208E62F6001EF882 /* BlockchainAPI+URL.swift in Sources */,
 				519435B4208E630F001EF882 /* UserDefaults.swift in Sources */,
 				519435B8208E6366001EF882 /* LocalizationConstants.swift in Sources */,
@@ -2690,13 +2741,20 @@
 				519435B6208E635A001EF882 /* AssetType.swift in Sources */,
 				519435BA208E63CE001EF882 /* Passcode.swift in Sources */,
 				C74FEA2620979259007CAB5D /* JSContextWithDOMTests.swift in Sources */,
+				AACE31C72092A99B00B7B806 /* LocalizationConstants.swift in Sources */,
+				AACE31CC2092A99B00B7B806 /* BitcoinAddress.swift in Sources */,
+				AACE31D12092A99B00B7B806 /* Passcode.swift in Sources */,
+				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
+				AACE31C52092A99B00B7B806 /* Environment.swift in Sources */,
 				51A862D620921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */,
-				519435AE208E62E3001EF882 /* BlockchainAPI.swift in Sources */,
 				5185E12B208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */,
 				519435B9208E63CA001EF882 /* AuthenticationError.swift in Sources */,
+				AACE31CB2092A99B00B7B806 /* AssetType.swift in Sources */,
+				AACE31C62092A99B00B7B806 /* LoadingViewPresenter.swift in Sources */,
+				AACE31D22092A99B00B7B806 /* UINavigationController+PopToRootWithCompletion.swift in Sources */,
+				AACE31D32092A99B00B7B806 /* OnboardingCoordinator.swift in Sources */,
+				AACE3132209121B300B7B806 /* PushNotificationManager.swift in Sources */,
 				519435AC208E6279001EF882 /* CertificatePinnerTests.swift in Sources */,
-				519435BC208E64E0001EF882 /* Constants.swift in Sources */,
-				516546F9208FCF800019EE63 /* Enum+Enumeratable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2740,6 +2798,7 @@
 				23E2FC081C7F60E7004CFF79 /* BCInsetLabel.m in Sources */,
 				23444F871DCD217E00573C8C /* BTCNetwork.m in Sources */,
 				C9BE917D1945D8F600FD516D /* PEViewController.m in Sources */,
+				AACE31482091430900B7B806 /* AuthenticationCoordinator.swift in Sources */,
 				674709EC19D1D14300757D46 /* BCWelcomeView.m in Sources */,
 				67D95A281B3DDC900012EBB1 /* Constants.swift in Sources */,
 				9F765F3214BC622E00048EFB /* TransactionsBitcoinViewController.m in Sources */,
@@ -2752,6 +2811,7 @@
 				676250821A2DDF360052B63F /* AccountTableCell.m in Sources */,
 				67EE1DCF19E3325900DBBFC9 /* UIViewController+ECSlidingViewController.m in Sources */,
 				C9BE917B1945D8F600FD516D /* PENumpadView.m in Sources */,
+				AACE314C209152D800B7B806 /* UIApplication.swift in Sources */,
 				C7EEB8451EA95505002F28B9 /* UIView+ChangeFrameAttribute.m in Sources */,
 				C74E21C12024BA1C00A9FBB1 /* BCBalanceChartLegendKeyView.m in Sources */,
 				516546F5208FCF710019EE63 /* NetworkManager+UserAgent.swift in Sources */,
@@ -2818,6 +2878,7 @@
 				23FB5C0D1D9ABB650008C6AB /* TransactionDetailFromCell.m in Sources */,
 				2322DCBA1D771831000E5AC1 /* SRConstants.m in Sources */,
 				A2599BA71B0B726900C2EA81 /* BackupVerifyViewController.swift in Sources */,
+				AACE31812092794D00B7B806 /* Pin.swift in Sources */,
 				23107F831BBEF0AC00A6A9D4 /* BCConfirmPaymentView.m in Sources */,
 				23FB5C131D9ABB8B0008C6AB /* TransactionDetailStatusCell.m in Sources */,
 				CFA0671F1E65D426008456C1 /* WebLoginViewController.m in Sources */,

--- a/Blockchain/Alerts/AlertViewPresenter.swift
+++ b/Blockchain/Alerts/AlertViewPresenter.swift
@@ -24,13 +24,16 @@ import Foundation
             return
         }
         AlertViewPresenter.shared.standardNotify(
-            message: LocalizationConstants.warning,
-            title: LocalizationConstants.unsafeDeviceWarningMessage
+            message: LocalizationConstants.Errors.warning,
+            title: LocalizationConstants.Errors.unsafeDeviceWarningMessage
         )
     }
 
     @objc func showNoInternetConnectionAlert() {
-        standardNotify(message: LocalizationConstants.noInternetConnection, title: LocalizationConstants.error) { _ in
+        standardNotify(
+        message: LocalizationConstants.Errors.noInternetConnection,
+        title: LocalizationConstants.Errors.error
+        ) { _ in
             LoadingViewPresenter.shared.hideBusyView()
             // TODO: this should not be in here. Figure out all areas where pin
             // should be reset and explicitly reset pin entry there
@@ -40,7 +43,7 @@ import Foundation
 
     @objc func standardNotify(
         message: String,
-        title: String = LocalizationConstants.error,
+        title: String = LocalizationConstants.Errors.error,
         handler: AlertConfirmHandler? = nil
     ) {
         DispatchQueue.main.async {

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -19,8 +19,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// Flag used to indicate whether the device is prompting for biometric authentication.
     @objc public private(set) var isPromptingForBiometricAuthentication = false
 
-    fileprivate var loginTimeout: Timer?
-
     lazy var busyView: BCFadeView? = {
         guard let windowFrame = UIApplication.shared.keyWindow?.frame else {
             return BCFadeView(frame: UIScreen.main.bounds)
@@ -140,7 +138,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             if authenticated {
                 DispatchQueue.main.async {
-                    self.showVerifyingBusyView(withTimeout: 30)
+                    // TODO move this method to AuthenticatioCoordinator
+//                    self.showVerifyingBusyView(withTimeout: 30)
                 }
                 guard let pinKey = BlockchainSettings.App.shared.pinKey,
                     let pin = KeychainItemWrapper.pinFromKeychain() else {
@@ -154,7 +153,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // TODO: migrate to the responsible controller that prompts for authentication
     func handleBiometricAuthenticationError(with error: AuthenticationError) {
         if let description = error.description {
-            let alert = UIAlertController(title: LocalizationConstants.error, message: description, preferredStyle: .alert)
+            let alert = UIAlertController(title: LocalizationConstants.Errors.error, message: description, preferredStyle: .alert)
             let action = UIAlertAction(title: LocalizationConstants.ok, style: .default, handler: nil)
             alert.addAction(action)
             DispatchQueue.main.async {
@@ -171,29 +170,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
         // TODO: migrate code from RootService.m...
         return false
-    }
-
-    func showVerifyingBusyView(withTimeout seconds: Int) {
-        LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.verifying)
-        // TODO: refactor showVerifyingBusyView with newer iOS 10+ method
-        loginTimeout = Timer.scheduledTimer(
-            timeInterval: TimeInterval(seconds),
-            target: self,
-            selector: #selector(showErrorLoading),
-            userInfo: nil,
-            repeats: false
-        )
-    }
-    @objc func showErrorLoading() {
-        // TODO: put this in AuthenticationManager
-        if let timer = loginTimeout {
-            timer.invalidate()
-        }
-        //        if (!self.wallet.guid && busyView.alpha == 1.0 && [busyLabel.text isEqualToString:BC_STRING_LOADING_VERIFYING]) {
-        //            [self.pinEntryViewController reset];
-        //            [self hideBusyView];
-        //            [self standardNotifyAutoDismissingController:BC_STRING_ERROR_LOADING_WALLET];
-        //        }
     }
 
     // TODO: move to appropriate module

--- a/Blockchain/AuthenticationCoordinator.swift
+++ b/Blockchain/AuthenticationCoordinator.swift
@@ -1,0 +1,307 @@
+//
+//  AuthenticationCoordinator.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/25/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+@objc class AuthenticationCoordinator: NSObject, Coordinator {
+
+    @objc static let shared = AuthenticationCoordinator()
+
+    var lastEnteredPIN: Pin?
+
+    private(set) var pinEntryViewController: PEPinEntryController?
+
+    // TODO: loginTimout is never invalidated after a successful login
+    private var loginTimeout: Timer?
+
+    private var pinViewControllerCallback: ((Bool) -> Void)?
+
+    private var isPinEntryModalPresented: Bool {
+        let rootViewController = UIApplication.shared.keyWindow!.rootViewController!
+        let tabControllerManager = AppCoordinator.shared.tabControllerManager
+        return !(pinEntryViewController == nil ||
+            pinEntryViewController!.isBeingDismissed ||
+            !pinEntryViewController!.view.isDescendant(of: rootViewController.view) ||
+            tabControllerManager.tabViewController.presentedViewController != pinEntryViewController)
+    }
+
+    // MARK: - Public
+
+    @objc func start() {
+        if WalletManager.shared.wallet.isNew {
+            startNewWalletSetUp()
+        } else {
+            showPinEntryView(asModal: false)
+        }
+    }
+
+    @objc func startNewWalletSetUp() {
+        let setUpWalletViewController = WalletSetupViewController(setupDelegate: self)!
+        let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
+        topMostViewController?.present(setUpWalletViewController, animated: false) { [weak self] in
+            self?.showPinEntryView(asModal: false)
+        }
+    }
+
+    // Closes the pin entry modal, if presented
+    @objc func closePinEntryView(animated: Bool) {
+        guard let pinEntryViewController = pinEntryViewController else {
+             return
+        }
+
+        // There are two different ways the pinModal is displayed: as a subview of tabViewController (on start)
+        // and as a viewController. This checks which one it is and dismisses accordingly
+        let rootViewController = UIApplication.shared.keyWindow!.rootViewController!
+        if pinEntryViewController.view.isDescendant(of: rootViewController.view) {
+            pinEntryViewController.view.removeFromSuperview()
+        } else {
+            pinEntryViewController.dismiss(animated: true)
+        }
+
+        self.pinEntryViewController = nil
+
+        UIApplication.shared.setStatusBarStyle(.lightContent, animated: true)
+    }
+
+    @objc func showPinEntryView(asModal: Bool) {
+
+        guard !WalletManager.shared.didChangePassword else {
+            showPasswordModal()
+            return
+        }
+
+        // Don't show pin entry if it is already in view hierarchy
+        guard !isPinEntryModalPresented else {
+            return
+        }
+
+        // Backgrounding from resetting PIN screen hides the status bar
+        UIApplication.shared.setStatusBarHidden(false, with: .none)
+
+        let pinViewController: PEPinEntryController
+        if BlockchainSettings.App.shared.isPinSet {
+            // if pin exists - verify
+            pinViewController = PEPinEntryController.pinVerify()
+        } else {
+            // no pin - create
+            pinViewController = PEPinEntryController.pinCreate()
+        }
+        pinViewController.isNavigationBarHidden = true
+        pinViewController.pinDelegate = self
+
+        // asView inserts the modal's view into the rootViewController as a view -
+        // this is only used in didFinishLaunching so there is no delay when showing the PIN on start
+        let rootViewController = UIApplication.shared.keyWindow!.rootViewController!
+        if asModal {
+
+            // TODO handle settings navigation controller
+//            if ([_settingsNavigationController isBeingPresented]) {
+//                // Immediately after enabling touch ID, backgrounding the app while the Settings scren is still
+            // being presented results in failure to add the PIN screen back. Using a delay to allow animation to complete fixes this
+//                [[UIApplication sharedApplication].keyWindow.rootViewController.view
+            // performSelector:@selector(addSubview:) withObject:self.pinEntryViewController.view afterDelay:DELAY_KEYBOARD_DISMISSAL];
+//                [self performSelector:@selector(showStatusBar) withObject:nil afterDelay:DELAY_KEYBOARD_DISMISSAL];
+//            } else {
+            rootViewController.view.addSubview(pinViewController.view)
+//            }
+        } else {
+            let topMostViewController = rootViewController.topMostViewController
+            topMostViewController?.present(pinViewController, animated: true) { [weak self] in
+                guard self != nil else { return }
+
+                if WalletManager.shared.wallet.isNew {
+                    AlertViewPresenter.shared.standardNotify(
+                        message: LocalizationConstants.Authentication.didCreateNewWalletMessage,
+                        title: LocalizationConstants.Authentication.didCreateNewWalletTitle
+                    )
+                    return
+                }
+
+                if WalletManager.shared.wallet.didPairAutomatically {
+                    AlertViewPresenter.shared.standardNotify(
+                        message: LocalizationConstants.Authentication.walletPairedSuccessfullyMessage,
+                        title: LocalizationConstants.Authentication.walletPairedSuccessfullyTitle
+                    )
+                    return
+                }
+            }
+        }
+        self.pinEntryViewController = pinViewController
+
+        WalletManager.shared.wallet.didPairAutomatically = false
+
+        LoadingViewPresenter.shared.hideBusyView()
+
+        UIApplication.shared.setStatusBarStyle(.default, animated: false)
+    }
+
+    // MARK: - Private
+
+    private func showPasswordModal() {
+        // TODO migrate this from RootService
+    }
+
+    private func showVerifyingBusyView(withTimeout seconds: Int) {
+        LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.verifying)
+
+        // TODO: this timeout approach should be deprecated in favor of checking actual success/error responses
+        if #available(iOS 10.0, *) {
+            loginTimeout = Timer.scheduledTimer(withTimeInterval: TimeInterval(seconds), repeats: false) { [weak self] _ in
+                self?.showLoginError()
+            }
+        } else {
+            loginTimeout = Timer.scheduledTimer(
+                timeInterval: TimeInterval(seconds),
+                target: self,
+                selector: #selector(showLoginError),
+                userInfo: nil,
+                repeats: false
+            )
+        }
+    }
+
+    @objc private func showLoginError() {
+        loginTimeout?.invalidate()
+        loginTimeout = nil
+
+        guard WalletManager.shared.wallet.guid == nil else {
+            return
+        }
+        pinEntryViewController?.reset()
+        LoadingViewPresenter.shared.hideBusyView()
+        AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Errors.errorLoadingWallet)
+    }
+}
+
+extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
+    func pinEntryController(
+        _ pinEntryController: PEPinEntryController!,
+        shouldAcceptPin pinInt: UInt,
+        callback: ((Bool) -> Void)!
+    ) {
+        let pin = Pin(code: pinInt)
+        self.lastEnteredPIN = pin
+
+        // Check if we have an internet connection
+        // This only checks if a network interface is up. All other errors (including timeouts)
+        // are handled by JavaScript callbacks in Wallet.m
+        guard Reachability.hasInternetConnection() else {
+            AlertViewPresenter.shared.showNoInternetConnectionAlert()
+            return
+        }
+
+        showVerifyingBusyView(withTimeout: 30)
+
+
+        let pinKey = BlockchainSettings.App.shared.pinKey
+        let pinString = pin.toString
+
+        // TODO: Handle touch ID
+//        #ifdef ENABLE_TOUCH_ID
+//        if (self.pinEntryViewController.verifyOptional) {
+//            [KeychainItemWrapper setPINInKeychain:pin];
+//        }
+//        #endif
+
+        // TODO: migrate check for maintenance
+
+//        dispatch_async(dispatch_get_main_queue(), ^{
+//            [self checkForMaintenanceWithPinKey:pinKey pin:pin];
+//        });
+
+        self.pinViewControllerCallback = callback
+    }
+
+    func pinEntryController(_ pinEntryController: PEPinEntryController!, changedPin pinInt: UInt) {
+        let pin = Pin(code: pinInt)
+        self.lastEnteredPIN = pin
+
+        guard WalletManager.shared.wallet.isInitialized() || WalletManager.shared.wallet.password != nil else {
+            // TODO: migrate pin errors
+            // [self didFailPutPin:BC_STRING_CANNOT_SAVE_PIN_CODE_WHILE];
+            return
+        }
+
+        LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.verifying)
+
+        try? pin.save()
+    }
+
+    func pinEntryController(_ pinEntryController: PEPinEntryController!, willChangeToNewPin pinInt: UInt) {
+        let pin = Pin(code: pinInt)
+
+        // Check that the selected pin passes checks
+
+        guard pin.isValid else {
+            AlertViewPresenter.shared.standardNotify(
+                message: LocalizationConstants.Authentication.chooseAnotherPin,
+                title: LocalizationConstants.Errors.error
+            ) { [unowned self] _ in
+                self.reopenChangePin()
+            }
+            return
+        }
+
+        guard pin != self.lastEnteredPIN else {
+            AlertViewPresenter.shared.standardNotify(
+                message: LocalizationConstants.Authentication.newPinMustBeDifferent,
+                title: LocalizationConstants.Errors.error
+            ) { [unowned self] _ in
+                self.reopenChangePin()
+            }
+            return
+        }
+
+        guard !pin.isCommon else {
+            let alert = UIAlertController(
+                title: LocalizationConstants.Errors.warning,
+                message: LocalizationConstants.Authentication.pinCodeCommonMessage,
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: LocalizationConstants.continueString, style: .default))
+            alert.addAction(
+                UIAlertAction(title: LocalizationConstants.tryAgain, style: .cancel) {  [unowned self] _ in
+                    self.reopenChangePin()
+                }
+            )
+            pinEntryController.present(alert, animated: true)
+            return
+        }
+    }
+
+    func pinEntryControllerDidCancel(_ pinEntryController: PEPinEntryController!) {
+        print("Pin change cancelled!")
+        closePinEntryView(animated: true)
+    }
+
+    private func reopenChangePin() {
+        closePinEntryView(animated: false)
+
+        guard let pinViewController = PEPinEntryController.pinCreate() else {
+            return
+        }
+
+        pinViewController.isNavigationBarHidden = true
+        pinViewController.pinDelegate = self
+
+        if BlockchainSettings.App.shared.isPinSet {
+            pinViewController.inSettings = true
+        }
+
+        UIApplication.shared.keyWindow?.rootViewController?.view.addSubview(pinViewController.view)
+
+        pinEntryViewController = pinViewController
+    }
+}
+
+extension AuthenticationCoordinator: SetupDelegate {
+    func enableTouchIDClicked() -> Bool {
+        // TODO: handle touch ID
+        return false
+    }
+}

--- a/Blockchain/Blockchain-Bridging-Header.h
+++ b/Blockchain/Blockchain-Bridging-Header.h
@@ -11,6 +11,7 @@
 #import "KeychainItemWrapper+Credentials.h"
 #import "KeychainItemWrapper+SwipeAddresses.h"
 #import "KeychainItemWrapper.h"
+#import "NSData+Hex.h"
 #import "NSString+SHA256.h"
 #import "PEPinEntryController.h"
 #import "Reachability.h"

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -682,13 +682,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 #define PIN_API_STATUS_UNKNOWN 3
 #define PIN_API_STATUS_DUPLICATE_KEY 4
 
-#define PIN_COMMON_CODE_1 1234
-#define PIN_COMMON_CODE_2 1111
-#define PIN_COMMON_CODE_3 1212
-#define PIN_COMMON_CODE_4 7777
-#define PIN_COMMON_CODE_5 1004
-#define PIN_INVALID_CODE 0000
-
 // Most common pin codes: http://datagenetics.com/blog/september32012/index.html
 
 #define NUMBER_OF_TRANSACTIONS_REQUIRED_FOR_FOR_APP_STORE_REVIEW_PROMPT 3

--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -71,6 +71,9 @@ struct Constants {
         static let userInfoId = "id"
         static let typePayment = "payment"
     }
+    struct Schemas {
+        static let mail = "message://"
+    }
 }
 
 /// Constant class wrapper so that Constants can be accessed from Obj-C. Should deprecate this

--- a/Blockchain/Extensions/UIApplication.swift
+++ b/Blockchain/Extensions/UIApplication.swift
@@ -1,0 +1,26 @@
+//
+//  UIApplication.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/25/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+extension UIApplication {
+
+    // Opens the mail application, if possible, otherwise, displays an error
+    @objc func openMailApplication() {
+        guard let mailURL = URL(string: Constants.Schemas.mail), canOpenURL(mailURL) else {
+            AlertViewPresenter.shared.standardNotify(
+                message: NSString(
+                    format: LocalizationConstants.Errors.cannotOpenURLArg as NSString,
+                    Constants.Schemas.mail
+                ) as String
+            )
+            return
+        }
+        openURL(mailURL)
+    }
+}

--- a/Blockchain/LocalizationConstants.h
+++ b/Blockchain/LocalizationConstants.h
@@ -96,8 +96,6 @@
 #define BC_STRING_PLEASE_VERIFY_EMAIL_ADDRESS_FIRST NSLocalizedString(@"Please verify your email address first.", nil)
 #define BC_STRING_PLEASE_VERIFY_MOBILE_NUMBER_FIRST NSLocalizedString(@"Please verify your mobile number first.", nil)
 #define BC_STRING_INVALID_EMAIL_ADDRESS NSLocalizedString(@"Invalid email address.", nil)
-#define BC_STRING_DID_CREATE_NEW_WALLET_DETAIL NSLocalizedString(@"Before accessing your wallet, please choose a pin number to use to unlock your wallet. It's important you remember this pin as it cannot be reset or changed without first unlocking the app.", nil)
-#define BC_STRING_DID_CREATE_NEW_WALLET_TITLE NSLocalizedString(@"Your wallet was successfully created.", nil)
 #define BC_STRING_MY_BITCOIN_WALLET NSLocalizedString(@"My Bitcoin Wallet", nil)
 #define BC_STRING_PASSWORD_STRENGTH_WEAK NSLocalizedString(@"Weak", nil)
 #define BC_STRING_PASSWORD_STRENGTH_REGULAR NSLocalizedString(@"Regular", nil)
@@ -115,7 +113,6 @@
 #define BC_STRING_ERROR NSLocalizedString(@"Error", nil)
 #define BC_STRING_INVALID_AUTHENTICATION_TYPE NSLocalizedString(@"Invalid two-factor authentication type", nil)
 #define BC_STRING_ERROR_LOADING_WALLET_IDENTIFIER_FROM_KEYCHAIN NSLocalizedString(@"An error was encountered retrieving your wallet identifier from the keychain. Please close the application and try again.", nil)
-#define BC_STRING_ERROR_LOADING_WALLET NSLocalizedString(@"Unable to load wallet due to no server response. You may be offline or Blockchain is experiencing difficulties. Please try again later.", nil)
 
 #define BC_STRING_INFORMATION NSLocalizedString(@"Information", nil)
 #define BC_STRING_LEARN_MORE NSLocalizedString(@"Learn More", nil)
@@ -134,7 +131,6 @@
 #define BC_STRING_OK NSLocalizedString(@"OK", nil)
 #define BC_STRING_OPEN_MAIL_APP NSLocalizedString(@"Open Mail App", nil)
 #define BC_STRING_CANNOT_OPEN_MAIL_APP NSLocalizedString(@"Cannot open Mail App", nil)
-#define BC_STRING_CANNOT_OPEN_MAIL_APP_URL_ARGUMENT NSLocalizedString(@"Cannot open URL %@", nil)
 #define BC_STRING_FAILED_TO_LOAD_WALLET_TITLE NSLocalizedString(@"Failed To Load Wallet", nil)
 
 #define BC_STRING_FAILED_VALIDATION_CERTIFICATE_TITLE NSLocalizedString(@"Failed to validate server certificate", nil)
@@ -164,8 +160,6 @@
 #define BC_STRING_INVALID_IDENTIFIER NSLocalizedString(@"Invalid Identifier", nil)
 
 #define BC_STRING_DISABLE_TWO_FACTOR NSLocalizedString(@"You must have two-factor authentication disabled to pair manually.", nil)
-#define BC_STRING_WALLET_PAIRED_SUCCESSFULLY_DETAIL NSLocalizedString(@"Before accessing your wallet, please choose a pin number to use to unlock your wallet. It's important you remember this pin as it cannot be reset or changed without first unlocking the app.", nil)
-#define BC_STRING_WALLET_PAIRED_SUCCESSFULLY_TITLE NSLocalizedString(@"Wallet Paired Successfully.", nil)
 #define BC_STRING_WATCH_ONLY NSLocalizedString(@"Watch Only", nil)
 #define BC_STRING_WATCH_ONLY_RECEIVE_WARNING NSLocalizedString(@"You are about to receive bitcoin to a watch-only address. You can only spend these funds if you have access to the private key. Continue?", nil)
 #define BC_STRING_USER_DECLINED NSLocalizedString(@"User Declined", nil)
@@ -195,8 +189,6 @@
 #define BC_STRING_MANUALLY NSLocalizedString(@"Manually", nil)
 #define BC_STRING_AUTOMATICALLY NSLocalizedString(@"Automatically", nil)
 #define BC_STRING_PIN_VALIDATION_ERROR NSLocalizedString(@"PIN Validation Error", nil)
-#define BC_STRING_PLEASE_CHOOSE_ANOTHER_PIN NSLocalizedString(@"Please choose another PIN", nil)
-#define BC_STRING_NEW_PIN_MUST_BE_DIFFERENT NSLocalizedString(@"New PIN must be different", nil)
 #define BC_PIN_NO_MATCH NSLocalizedString(@"PINs do not match", nil)
 
 #define BC_STRING_PIN_VALIDATION_ERROR_DETAIL NSLocalizedString(@"An error occurred validating your PIN code with the remote server. You may be offline or Blockchain may be experiencing difficulties. Would you like retry validation or instead enter your password manually?", nil)
@@ -215,8 +207,6 @@
 #define BC_STRING_PIN_RESPONSE_OBJECT_KEY_OR_VALUE_LENGTH_0 NSLocalizedString(@"PIN Response Object key or value length 0", nil)
 #define BC_STRING_PIN_ENCRYPTED_STRING_IS_NIL NSLocalizedString(@"PIN Encrypted String is nil", nil)
 #define BC_STRING_WARNING_TITLE NSLocalizedString(@"Warning", nil)
-#define BC_STRING_PIN_COMMON_CODE_WARNING_MESSAGE NSLocalizedString(@"The PIN you have selected is extremely common and may be easily guessed by someone with access to your phone within 3 tries. Would you like to use this PIN anyway?", nil)
-#define BC_STRING_TRY_AGAIN NSLocalizedString(@"Try again", nil)
 
 #define BC_STRING_PAYMENT_REQUEST_BITCOIN_ARGUMENT_ARGUMENT NSLocalizedString(@"Please send %@ to bitcoin address.\n%@", nil)
 #define BC_STRING_PAYMENT_REQUEST_BITCOIN_CASH_ARGUMENT NSLocalizedString(@"Please send BCH to the Bitcoin Cash address\n%@", nil)

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -34,17 +34,30 @@ let LCStringAuthBiometryNotAvailable = NSLocalizedString("Unable to Authenticate
 struct LocalizationConstants {
     static let cancel = NSLocalizedString("Cancel", comment: "")
     static let continueString = NSLocalizedString("Continue", comment: "")
-    static let error = NSLocalizedString("Error", comment: "")
     static let ok = NSLocalizedString("OK", comment: "")
-    static let warning = NSLocalizedString("Warning", comment: "")
-    static let unsafeDeviceWarningMessage = NSLocalizedString("Your device appears to be jailbroken. The security of your wallet may be compromised.", comment: "")
     static let syncingWallet = NSLocalizedString("Syncing Wallet", comment: "")
+    static let tryAgain = NSLocalizedString("Try again", comment: "")
     static let verifying = NSLocalizedString ("Verifying", comment: "")
-    static let noInternetConnection = NSLocalizedString("No internet connection.", comment: "")
+
+    struct Errors {
+        static let error = NSLocalizedString("Error", comment: "")
+        static let errorLoadingWallet = NSLocalizedString("Unable to load wallet due to no server response. You may be offline or Blockchain is experiencing difficulties. Please try again later.", comment: "")
+        static let cannotOpenURLArg = NSLocalizedString("Cannot open URL %@", comment: "")
+        static let unsafeDeviceWarningMessage = NSLocalizedString("Your device appears to be jailbroken. The security of your wallet may be compromised.", comment: "")
+        static let noInternetConnection = NSLocalizedString("No internet connection.", comment: "")
+        static let warning = NSLocalizedString("Warning", comment: "")
+    }
 
     struct Authentication {
         static let errorDecryptingWallet = NSLocalizedString("An error occurred due to interruptions during PIN verification. Please close the app and try again.", comment: "")
         static let invalidSharedKey = NSLocalizedString("Invalid Shared Key", comment: "")
+        static let didCreateNewWalletTitle = NSLocalizedString("Your wallet was successfully created.", comment: "")
+        static let didCreateNewWalletMessage = NSLocalizedString("Before accessing your wallet, please choose a pin number to use to unlock your wallet. It's important you remember this pin as it cannot be reset or changed without first unlocking the app.", comment: "")
+        static let walletPairedSuccessfullyTitle = NSLocalizedString("Wallet Paired Successfully.", comment: "")
+        static let walletPairedSuccessfullyMessage = NSLocalizedString("Before accessing your wallet, please choose a pin number to use to unlock your wallet. It's important you remember this pin as it cannot be reset or changed without first unlocking the app.", comment: "")
+        static let newPinMustBeDifferent = NSLocalizedString("New PIN must be different", comment: "")
+        static let chooseAnotherPin = NSLocalizedString("Please choose another PIN", comment: "")
+        static let pinCodeCommonMessage = NSLocalizedString("The PIN you have selected is extremely common and may be easily guessed by someone with access to your phone within 3 tries. Would you like to use this PIN anyway?", comment: "")
     }
 
     struct Onboarding {
@@ -59,8 +72,10 @@ struct LocalizationConstants {
 /// Should deprecate this once Obj-C is no longer using this
 @objc class LocalizationConstantsObjcBridge: NSObject {
 
-    @objc class func noInternetConnection() -> String { return LocalizationConstants.noInternetConnection }
+    @objc class func noInternetConnection() -> String { return LocalizationConstants.Errors.noInternetConnection }
 
     @objc class func onboardingRecoverFunds() -> String { return LocalizationConstants.Onboarding.recoverFunds }
+
+    @objc class func tryAgain() -> String { return LocalizationConstants.tryAgain }
 }
 

--- a/Blockchain/Pin/Pin.swift
+++ b/Blockchain/Pin/Pin.swift
@@ -1,0 +1,83 @@
+//
+//  Pin.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+struct SavePinError: Error {}
+
+/// Model for a user's 4-digit pin
+class Pin {
+    static let Invalid = Pin(code: 0000)
+
+    private var pinCode: UInt
+
+    /// Checks if this pin is a valid
+    var isValid: Bool {
+        return self != Pin.Invalid
+    }
+
+    /// Checks if this pin is a commonly used pin (read: not very secure)
+    var isCommon: Bool {
+        let commonPinCodes: [UInt] = [1234, 1111, 1212, 7777, 1004]
+        return commonPinCodes.contains(pinCode)
+    }
+
+    /// String representation of the underlying pin
+    var toString: String {
+        return pinCode.pinToString
+    }
+
+    init(code: UInt) {
+        self.pinCode = code
+    }
+
+    // TODO: not the best place for this - move elsewhere
+    func save() throws {
+        //32 Random bytes for key
+        let data = [__uint8_t](repeating: 0, count: 32)
+        let dataPointer = UnsafeMutableRawPointer(mutating: data)
+        var error = SecRandomCopyBytes(kSecRandomDefault, data.count, dataPointer)
+        guard error == noErr else {
+            throw SavePinError()
+        }
+
+        let key = NSData(bytes: dataPointer, length: data.count).hexadecimalString()
+
+        //32 random bytes for value
+        error = SecRandomCopyBytes(kSecRandomDefault, data.count, dataPointer)
+        guard error == noErr else {
+            throw SavePinError()
+        }
+
+        let value = NSData(bytes: dataPointer, length: data.count).hexadecimalString()
+
+        WalletManager.shared.wallet.pinServerPutKey(onPinServerServer: key, value: value, pin: self.toString)
+        // TODO handle touch ID
+        //    #ifdef ENABLE_TOUCH_ID
+        //    if (BlockchainSettings.sharedAppInstance.touchIDEnabled) {
+        //        [KeychainItemWrapper setPINInKeychain:pin];
+        //    }
+        //    #endif
+    }
+}
+
+extension Pin: Equatable, Hashable {
+    static func == (lhs: Pin, rhs: Pin) -> Bool {
+        return lhs.pinCode == rhs.pinCode
+    }
+
+    var hashValue: Int {
+        return Int(pinCode)
+    }
+}
+
+extension UInt {
+    var pinToString: String {
+        return String(format: "%lu", CUnsignedLongLong(self))
+    }
+}

--- a/Blockchain/ReminderModalViewController.h
+++ b/Blockchain/ReminderModalViewController.h
@@ -18,7 +18,6 @@ enum {
 typedef NSInteger ReminderType;
 
 @protocol ReminderModalDelegate
-- (void)openMail;
 - (void)showBackup;
 - (void)showTwoStep;
 @end

--- a/Blockchain/ReminderModalViewController.m
+++ b/Blockchain/ReminderModalViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "ReminderModalViewController.h"
+#import "Blockchain-Swift.h"
 
 @interface ReminderModalViewController ()
 @property (nonatomic, readonly) ReminderType reminderType;
@@ -134,7 +135,7 @@
 
 - (void)openMail
 {
-    [self.delegate openMail];
+    [UIApplication.sharedApplication openMailApplication];
 }
 
 - (void)showBackup

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -230,7 +230,7 @@
 
 - (void)endBackgroundUpdateTask;
 
-- (NSString *)getVersionLabelString;
+//- (NSString *)getVersionLabelString;
 - (void)checkForUnusedAddress:(NSString *)address success:(void (^)(NSString *, BOOL))successBlock error:(void (^)())errorBlock assetType:(AssetType)assetType;
 
 - (BOOL)checkIfWaitingOnEtherTransaction;

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -243,6 +243,7 @@ final class BlockchainSettings: NSObject {
             encryptedPinPassword = nil
             pinKey = nil
             passwordPartHash = nil
+            AuthenticationCoordinator.shared.lastEnteredPIN = Pin.Invalid
         }
     }
 

--- a/Blockchain/SettingsAboutUsViewController.m
+++ b/Blockchain/SettingsAboutUsViewController.m
@@ -8,6 +8,7 @@
 
 #import "SettingsAboutUsViewController.h"
 #import "RootService.h"
+#import "Blockchain-Swift.h"
 
 @interface SettingsAboutUsViewController ()
 @end
@@ -38,7 +39,7 @@
     infoLabel.textAlignment = NSTextAlignmentCenter;
     infoLabel.textColor = COLOR_BLOCKCHAIN_BLUE;
     infoLabel.numberOfLines = 3;
-    infoLabel.text = [NSString stringWithFormat:@"%@ %@\n%@\n%@", ABOUT_STRING_BLOCKCHAIN_WALLET, [app getVersionLabelString], [NSString stringWithFormat:@"%@ %@ %@", ABOUT_STRING_COPYRIGHT_LOGO, COPYRIGHT_YEAR, ABOUT_STRING_BLOCKCHAIN_LUXEMBOURG_SA], BC_STRING_BLOCKCHAIN_ALL_RIGHTS_RESERVED];
+    infoLabel.text = [NSString stringWithFormat:@"%@ %@\n%@\n%@", ABOUT_STRING_BLOCKCHAIN_WALLET, [NSBundle applicationVersion], [NSString stringWithFormat:@"%@ %@ %@", ABOUT_STRING_COPYRIGHT_LOGO, COPYRIGHT_YEAR, ABOUT_STRING_BLOCKCHAIN_LUXEMBOURG_SA], BC_STRING_BLOCKCHAIN_ALL_RIGHTS_RESERVED];
     infoLabel.center = self.view.center;
     [self.view addSubview:infoLabel];
 

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -79,7 +79,7 @@ extension WalletManager: WalletDelegate {
         guard let guid = wallet.guid, guid.count == 36 else {
             AlertViewPresenter.shared.standardNotify(
                 message: LocalizationConstants.Authentication.errorDecryptingWallet,
-                title: LocalizationConstants.error) { _ in
+                title: LocalizationConstants.Errors.error) { _ in
                     UIApplication.shared.suspend()
             }
             return
@@ -88,7 +88,7 @@ extension WalletManager: WalletDelegate {
         guard let sharedKey = wallet.sharedKey, sharedKey.count == 36 else {
             AlertViewPresenter.shared.standardNotify(
                 message: LocalizationConstants.Authentication.invalidSharedKey,
-                title: LocalizationConstants.error
+                title: LocalizationConstants.Errors.error
             )
             return
         }
@@ -109,5 +109,22 @@ extension WalletManager: WalletDelegate {
             BlockchainSettings.App.shared.clearPin()
         }
     }
-    
+
+    func walletDidFinishLoad() {
+        print("walletDidFinishLoad()")
+
+        wallet.btcSwipeAddressToSubscribe = nil
+        wallet.bchSwipeAddressToSubscribe = nil
+
+        wallet.twoFactorInput = nil
+
+        // TODO move this
+        // [manualPairView clearTextFields];
+
+        ModalPresenter.shared.closeAllModals()
+
+        AuthenticationCoordinator.shared.start()
+
+        // TODO move other methods from RootService to here
+    }
 }

--- a/Blockchain/WalletSetupViewController.h
+++ b/Blockchain/WalletSetupViewController.h
@@ -9,11 +9,7 @@
 #import <UIKit/UIKit.h>
 
 @protocol SetupDelegate
-- (CGRect)getFrame;
 - (BOOL)enableTouchIDClicked;
-- (void)openMailClicked;
-- (NSString *)getEmail;
-- (void)getAccountInfo;
 @end
 
 @interface WalletSetupViewController : UIViewController

--- a/Blockchain/WalletSetupViewController.m
+++ b/Blockchain/WalletSetupViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "WalletSetupViewController.h"
+#import "Blockchain-Swift.h"
 
 @interface WalletSetupViewController ()
 @property (nonatomic) UIScrollView *scrollView;
@@ -25,7 +26,7 @@
 
 - (void)loadView
 {
-    self.view = [[UIView alloc] initWithFrame:[self.delegate getFrame]];
+    self.view = [[UIView alloc] initWithFrame:UIApplication.sharedApplication.keyWindow.frame];
     self.view.backgroundColor = [UIColor whiteColor];
     
     if (self.view == nil) {
@@ -107,7 +108,7 @@
     
     self.emailLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, titleLabel.frame.origin.y + titleLabel.frame.size.height + 8, emailView.frame.size.width - 50, 30)];
     self.emailLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_SEMIBOLD size:FONT_SIZE_SMALL_MEDIUM];
-    self.emailLabel.text = [self.delegate getEmail];
+    self.emailLabel.text = [WalletManager.sharedInstance.wallet getEmail];
     self.emailLabel.textColor = COLOR_TEXT_DARK_GRAY;
     self.emailLabel.center = CGPointMake(emailView.center.x - self.view.frame.size.width, self.emailLabel.center.y);
     self.emailLabel.textAlignment = NSTextAlignmentCenter;
@@ -185,7 +186,7 @@
 
 - (void)openMail
 {
-    [self.delegate openMailClicked];
+    [UIApplication.sharedApplication openMailApplication];
 }
 
 - (void)enableTouchID:(UIButton *)sender

--- a/BlockchainTests/PinTests.swift
+++ b/BlockchainTests/PinTests.swift
@@ -1,0 +1,34 @@
+//
+//  PinTests.swift
+//  BlockchainTests
+//
+//  Created by Chris Arriola on 4/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import XCTest
+@testable import Blockchain
+
+class PinTests: XCTestCase {
+
+    func testInValidPin() {
+        let pin = Pin(code: 0000)
+        XCTAssertFalse(pin.isValid)
+    }
+
+    func testValidPin() {
+        let pin = Pin(code: 6309)
+        XCTAssertTrue(pin.isValid)
+    }
+
+    func testCommonPins() {
+        let pin1 = Pin(code: 1111)
+        XCTAssertTrue(pin1.isCommon)
+
+        let pin2 = Pin(code: 1234)
+        XCTAssertTrue(pin2.isCommon)
+
+        let pin3 = Pin(code: 5923)
+        XCTAssertFalse(pin3.isCommon)
+    }
+}

--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -41,7 +41,7 @@ static PEViewController *EnterController()
 	c.prompt = BC_STRING_PLEASE_ENTER_PIN;
 	c.title = @"";
 
-    c.versionLabel.text = [app getVersionLabelString];
+    c.versionLabel.text = [NSBundle applicationVersion];
     c.versionLabel.hidden = NO;
     
 	return c;
@@ -53,7 +53,7 @@ static PEViewController *NewController()
 	c.prompt = BC_STRING_PLEASE_ENTER_NEW_PIN;
 	c.title = @"";
 
-    c.versionLabel.text = [app getVersionLabelString];
+    c.versionLabel.text = [NSBundle applicationVersion];
 
     return c;
 }
@@ -64,7 +64,7 @@ static PEViewController *VerifyController()
 	c.prompt = BC_STRING_CONFIRM_PIN;
 	c.title = @"";
 
-    c.versionLabel.text = [app getVersionLabelString];
+    c.versionLabel.text = [NSBundle applicationVersion];
 
 	return c;
 }


### PR DESCRIPTION
Summary:
* Created `AuthenticationCoordinator` and move `PEPinEntryViewController` flow in here
* Migrated `PEPinEntryViewController` pin delegate methods in `AuthenticationCoordinator`
* Created `Pin` class

Note: pin entry flow has not yet been fully migrated (i.e. pin-related wallet delegate calls, touch ID, etc.). Will work on that in a separate PR.