### PR TITLE
Asset address

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -147,6 +147,25 @@
 		51A7349120891EB3009727D5 /* CertificatePinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7348C20891EB3009727D5 /* CertificatePinner.swift */; };
 		51A7349320891EB3009727D5 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7348D20891EB3009727D5 /* NetworkManager.swift */; };
 		51A7349720891EB3009727D5 /* BlockchainAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A7349020891EB3009727D5 /* BlockchainAPI.swift */; };
+		51A862B72090DB5000B338E0 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333C208813040019AD55 /* OnboardingCoordinator.swift */; };
+		51A862B82090DB5200B338E0 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F6582086A2720054EFCE /* AppCoordinator.swift */; };
+		51A862B92090DB5400B338E0 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333A2088115C0019AD55 /* Coordinator.swift */; };
+		51A862BA2090DB8400B338E0 /* LoadingViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */; };
+		51A862BB2090DB8800B338E0 /* ModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333E2088131D0019AD55 /* ModalPresenter.swift */; };
+		51A862BC2090DBD900B338E0 /* AlertViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */; };
+		51A862BD2090DD4500B338E0 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED3F208A6E8D002D8BAC /* UIViewController.swift */; };
+		51A862BE2090DD6400B338E0 /* PairingInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */; };
+		51A862D520921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D420921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift */; };
+		51A862D620921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D420921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift */; };
+		51A862D920921E7600B338E0 /* BitcoinAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D820921E7600B338E0 /* BitcoinAddress.swift */; };
+		51A862DA20921E7600B338E0 /* BitcoinAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D820921E7600B338E0 /* BitcoinAddress.swift */; };
+		51A862DC20921EBD00B338E0 /* BitcoinCashAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862DB20921EBD00B338E0 /* BitcoinCashAddress.swift */; };
+		51A862DD20921EBD00B338E0 /* BitcoinCashAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862DB20921EBD00B338E0 /* BitcoinCashAddress.swift */; };
+		51A862DF20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862DE20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift */; };
+		51A862E12092506600B338E0 /* AssetAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862E02092506600B338E0 /* AssetAddress.swift */; };
+		51A862E22092506600B338E0 /* AssetAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862E02092506600B338E0 /* AssetAddress.swift */; };
+		51A862E42092686300B338E0 /* CheckForUnusedAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862E32092686300B338E0 /* CheckForUnusedAddressTests.swift */; };
+		51A862E7209268D300B338E0 /* sample-unused-address.json in Resources */ = {isa = PBXBuildFile; fileRef = 51A862E6209268D300B338E0 /* sample-unused-address.json */; };
 		51E5C73220741A130000A7FD /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E5C72F20741A130000A7FD /* AuthenticationManager.swift */; };
 		51E5C73320741A130000A7FD /* LocalizationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E5C73020741A130000A7FD /* LocalizationConstants.swift */; };
 		670595A41AB0F59D00D2D6D9 /* KeychainItemWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 670595A31AB0F59D00D2D6D9 /* KeychainItemWrapper.m */; };
@@ -987,6 +1006,13 @@
 		51A7348C20891EB3009727D5 /* CertificatePinner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificatePinner.swift; sourceTree = "<group>"; };
 		51A7348D20891EB3009727D5 /* NetworkManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		51A7349020891EB3009727D5 /* BlockchainAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockchainAPI.swift; sourceTree = "<group>"; };
+		51A862D420921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockchainAPI+URLSuffix.swift"; sourceTree = "<group>"; };
+		51A862D820921E7600B338E0 /* BitcoinAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BitcoinAddress.swift; path = Assets/Bitcoin/BitcoinAddress.swift; sourceTree = "<group>"; };
+		51A862DB20921EBD00B338E0 /* BitcoinCashAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BitcoinCashAddress.swift; path = Assets/BitcoinCash/BitcoinCashAddress.swift; sourceTree = "<group>"; };
+		51A862DE20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockchainAPI+URLSuffixTests.swift"; sourceTree = "<group>"; };
+		51A862E02092506600B338E0 /* AssetAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AssetAddress.swift; path = Assets/AssetAddress.swift; sourceTree = "<group>"; };
+		51A862E32092686300B338E0 /* CheckForUnusedAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUnusedAddressTests.swift; sourceTree = "<group>"; };
+		51A862E6209268D300B338E0 /* sample-unused-address.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "sample-unused-address.json"; sourceTree = "<group>"; };
 		51E5C72F20741A130000A7FD /* AuthenticationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthenticationManager.swift; path = Authentication/AuthenticationManager.swift; sourceTree = "<group>"; };
 		51E5C73020741A130000A7FD /* LocalizationConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalizationConstants.swift; sourceTree = "<group>"; };
 		51F6A9BB206964D6002968EC /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
@@ -1545,6 +1571,7 @@
 		511646C02081247700C43522 /* Assets */ = {
 			isa = PBXGroup;
 			children = (
+				51A862E02092506600B338E0 /* AssetAddress.swift */,
 				511646C4208124E200C43522 /* AssetType.swift */,
 				511646C12081248600C43522 /* Bitcoin */,
 				511646C22081248C00C43522 /* Bitcoin Cash */,
@@ -1556,6 +1583,7 @@
 		511646C12081248600C43522 /* Bitcoin */ = {
 			isa = PBXGroup;
 			children = (
+				51A862D820921E7600B338E0 /* BitcoinAddress.swift */,
 			);
 			name = Bitcoin;
 			sourceTree = "<group>";
@@ -1563,6 +1591,7 @@
 		511646C22081248C00C43522 /* Bitcoin Cash */ = {
 			isa = PBXGroup;
 			children = (
+				51A862DB20921EBD00B338E0 /* BitcoinCashAddress.swift */,
 			);
 			name = "Bitcoin Cash";
 			sourceTree = "<group>";
@@ -1598,9 +1627,12 @@
 		5194359F208E61F3001EF882 /* BlockchainTests */ = {
 			isa = PBXGroup;
 			children = (
+				51A862E52092689500B338E0 /* Mock Data */,
 				519435A2208E61F3001EF882 /* Info.plist */,
 				519435A0208E61F3001EF882 /* BlockchainTests.swift */,
 				519435AB208E6279001EF882 /* CertificatePinnerTests.swift */,
+				51A862DE20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift */,
+				51A862E32092686300B338E0 /* CheckForUnusedAddressTests.swift */,
 			);
 			path = BlockchainTests;
 			sourceTree = "<group>";
@@ -1623,8 +1655,17 @@
 				51943595208E3005001EF882 /* BlockchainAPI+URL.swift */,
 				5185E129208F7ACA00A26B64 /* BlockchainAPI+URI.swift */,
 				AABDED91208FDFE3002D8BAC /* HTTPCookieStorage.swift */,
+				51A862D420921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		51A862E52092689500B338E0 /* Mock Data */ = {
+			isa = PBXGroup;
+			children = (
+				51A862E6209268D300B338E0 /* sample-unused-address.json */,
+			);
+			path = "Mock Data";
 			sourceTree = "<group>";
 		};
 		670595A11AB0F59D00D2D6D9 /* KeychainItemWrapper */ = {
@@ -2516,6 +2557,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				51A862E7209268D300B338E0 /* sample-unused-address.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2664,13 +2706,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				51A862DD20921EBD00B338E0 /* BitcoinCashAddress.swift in Sources */,
+				51A862BD2090DD4500B338E0 /* UIViewController.swift in Sources */,
 				519435AD208E62E0001EF882 /* CertificatePinner.swift in Sources */,
 				516546F6208FCF710019EE63 /* NetworkManager+UserAgent.swift in Sources */,
 				5185E125208F6E5E00A26B64 /* Enum+RawValued.swift in Sources */,
+				51A862DA20921E7600B338E0 /* BitcoinAddress.swift in Sources */,
 				519435B3208E630C001EF882 /* UIDevice.swift in Sources */,
 				AACE31382091220300B7B806 /* HTTPCookieStorage.swift in Sources */,
+				51A862BE2090DD6400B338E0 /* PairingInstructionsView.swift in Sources */,
+				51A862E42092686300B338E0 /* CheckForUnusedAddressTests.swift in Sources */,
 				519435B5208E6356001EF882 /* AuthenticationManager.swift in Sources */,
+				51A862DF20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift in Sources */,
 				519435B2208E630A001EF882 /* Bundle.swift in Sources */,
+				51A862E22092506600B338E0 /* AssetAddress.swift in Sources */,
 				519435A1208E61F3001EF882 /* BlockchainTests.swift in Sources */,
 				519435AF208E62E8001EF882 /* NetworkManager.swift in Sources */,
 				5185E11C208E7F7C00A26B64 /* BlockchainSettings.swift in Sources */,
@@ -2681,6 +2730,7 @@
 				519435B7208E6364001EF882 /* Environment.swift in Sources */,
 				519435B6208E635A001EF882 /* AssetType.swift in Sources */,
 				519435BA208E63CE001EF882 /* Passcode.swift in Sources */,
+				51A862D620921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */,
 				519435AE208E62E3001EF882 /* BlockchainAPI.swift in Sources */,
 				5185E12B208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */,
 				519435B9208E63CA001EF882 /* AuthenticationError.swift in Sources */,
@@ -2709,6 +2759,7 @@
 				23EA61CB1B5591260032B907 /* SettingsSelectorTableViewController.m in Sources */,
 				23BA22111D6B736900D0472B /* NSNumberFormatter+Currencies.m in Sources */,
 				23444F811DCD214800573C8C /* BTCBigNumber.m in Sources */,
+				51A862D920921E7600B338E0 /* BitcoinAddress.swift in Sources */,
 				2322DCB51D771831000E5AC1 /* SRIOConsumer.m in Sources */,
 				23BD046D1D79F1EC00DB69E6 /* TransactionDetailNavigationController.m in Sources */,
 				678AD5E919D4610000E9A778 /* BCModalContentView.m in Sources */,
@@ -2774,6 +2825,7 @@
 				FA6323391A433B1C00EB3974 /* Foundation-Utility.m in Sources */,
 				239CD5681C122BDE00997DF5 /* SettingsTwoStepViewController.m in Sources */,
 				23BF73391C454B8C00204503 /* AccountsAndAddressesNavigationController.m in Sources */,
+				51A862D520921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */,
 				2378271A1B7E472D00E9EE03 /* BCSecureTextField.swift in Sources */,
 				9F2D934A14C05DD00053F0FF /* Address.m in Sources */,
 				235BD5661C58216000969B31 /* BCModalViewController.m in Sources */,
@@ -2799,6 +2851,7 @@
 				FCB33B6F1FC369D700317E6B /* ExchangeDetailView.m in Sources */,
 				C7E2750B1F589C8D0054EFA5 /* ReceiveEtherViewController.m in Sources */,
 				AAA3333F2088131D0019AD55 /* ModalPresenter.swift in Sources */,
+				51A862E12092506600B338E0 /* AssetAddress.swift in Sources */,
 				9FCA4D1B151494BF00ECDFBE /* SendBitcoinViewController.m in Sources */,
 				237451C91D624C1C00CF7049 /* RootService.m in Sources */,
 				511646E2208523E300C43522 /* UIDevice.swift in Sources */,
@@ -2911,6 +2964,7 @@
 				C70FF55E1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m in Sources */,
 				AAA3333320880A2C0019AD55 /* AppDelegate.swift in Sources */,
 				C7640FBF2056B70E00D14D51 /* BCSwipeAddressViewModel.m in Sources */,
+				51A862DC20921EBD00B338E0 /* BitcoinCashAddress.swift in Sources */,
 				23F601A41D09C931009102BF /* Reachability.m in Sources */,
 				510EA1702080F16100A63AB8 /* Passcode.swift in Sources */,
 				23444F931DCD21B700573C8C /* BTCBase58.m in Sources */,

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -271,39 +271,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     typealias UnusedAddressError = ((_ error: Error) -> Void)
 
     // TODO: move to appropriate controller
-    func checkForUnusedAddress(_ address: BitcoinAddress,
-                               successHandler: @escaping UnusedAddressSuccess,
-                               errorHandler: @escaping UnusedAddressError) {
+    func checkForUnusedAddress(_ address: AssetAddress, successHandler: @escaping UnusedAddressSuccess, errorHandler: @escaping UnusedAddressError) {
         guard
-            let urlString = BlockchainAPI.suffixURL(btcAddress: address),
-            let url = URL(string: urlString) else {
-                return
-        }
-        NetworkManager.shared.session.sessionDescription = url.host
-        let task = NetworkManager.shared.session.dataTask(with: url, completionHandler: { data, _, error in
-            if let error = error {
-                DispatchQueue.main.async { errorHandler(error) }; return
-            }
-            guard
-                let json = try? JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: AnyObject],
-                let transactions = json!["txs"] as? [NSDictionary] else {
-                    // TODO: call error handler
-                    return
-            }
-            DispatchQueue.main.async {
-                let isUnused = transactions.count == 0
-                successHandler(isUnused)
-            }
-        })
-        task.resume()
-    }
-
-    // TODO: move to appropriate controller
-    func checkForUnusedAddress(_ address: BitcoinCashAddress,
-                               successHandler: @escaping UnusedAddressSuccess,
-                               errorHandler: @escaping UnusedAddressError) {
-        guard
-            let urlString = BlockchainAPI.suffixURL(bchAddress: address),
+            let urlString = BlockchainAPI.shared.suffixURL(address: address),
             let url = URL(string: urlString) else {
                 return
         }

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -267,11 +267,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     //: These two functions are used to justify the regeneration of addresses in the swipe-to-receive screen.
     // NOTE: Ethereum does not apply here, because the address is currently not regenerated.
 
-    typealias UnusedAddressSuccess = ((_ isUnused: Bool) -> Void)
-    typealias UnusedAddressError = ((_ error: Error) -> Void)
-
     // TODO: move to appropriate controller
-    func checkForUnusedAddress(_ address: AssetAddress, successHandler: @escaping UnusedAddressSuccess, errorHandler: @escaping UnusedAddressError) {
+    func checkForUnusedAddress(_ address: AssetAddress,
+                               successHandler: @escaping ((_ isUnused: Bool) -> Void),
+                               errorHandler: @escaping ((_ error: Error) -> Void)) {
         guard
             let urlString = BlockchainAPI.shared.suffixURL(address: address),
             let url = URL(string: urlString) else {

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -15,6 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: - Properties
 
+    // TODO: move to authentication flow
     /// Flag used to indicate whether the device is prompting for biometric authentication.
     @objc public private(set) var isPromptingForBiometricAuthentication = false
 
@@ -85,6 +86,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UserDefaults.standard.set(false, forKey: simulateSurgeKey)
         #endif
 
+        // TODO: prevent any other data tasks from executing until cert is pinned
         CertificatePinner.shared.pinCertificate()
 
         checkForNewInstall()
@@ -260,5 +262,67 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         })
         alert.addAction(action)
         UIApplication.shared.keyWindow?.rootViewController?.present(alert, animated: true, completion: nil)
+    }
+
+    //: These two functions are used to justify the regeneration of addresses in the swipe-to-receive screen.
+    // NOTE: Ethereum does not apply here, because the address is currently not regenerated.
+
+    typealias UnusedAddressSuccess = ((_ isUnused: Bool) -> Void)
+    typealias UnusedAddressError = ((_ error: Error) -> Void)
+
+    // TODO: move to appropriate controller
+    func checkForUnusedAddress(_ address: BitcoinAddress,
+                               successHandler: @escaping UnusedAddressSuccess,
+                               errorHandler: @escaping UnusedAddressError) {
+        guard
+            let urlString = BlockchainAPI.suffixURL(btcAddress: address),
+            let url = URL(string: urlString) else {
+                return
+        }
+        NetworkManager.shared.session.sessionDescription = url.host
+        let task = NetworkManager.shared.session.dataTask(with: url, completionHandler: { data, _, error in
+            if let error = error {
+                DispatchQueue.main.async { errorHandler(error) }; return
+            }
+            guard
+                let json = try? JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: AnyObject],
+                let transactions = json!["txs"] as? [NSDictionary] else {
+                    // TODO: call error handler
+                    return
+            }
+            DispatchQueue.main.async {
+                let isUnused = transactions.count == 0
+                successHandler(isUnused)
+            }
+        })
+        task.resume()
+    }
+
+    // TODO: move to appropriate controller
+    func checkForUnusedAddress(_ address: BitcoinCashAddress,
+                               successHandler: @escaping UnusedAddressSuccess,
+                               errorHandler: @escaping UnusedAddressError) {
+        guard
+            let urlString = BlockchainAPI.suffixURL(bchAddress: address),
+            let url = URL(string: urlString) else {
+                return
+        }
+        NetworkManager.shared.session.sessionDescription = url.host
+        let task = NetworkManager.shared.session.dataTask(with: url, completionHandler: { data, _, error in
+            if let error = error {
+                DispatchQueue.main.async { errorHandler(error) }; return
+            }
+            guard
+                let json = try? JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: AnyObject],
+                let transactions = json!["txs"] as? [NSDictionary] else {
+                    // TODO: call error handler
+                    return
+            }
+            DispatchQueue.main.async {
+                let isUnused = transactions.count == 0
+                successHandler(isUnused)
+            }
+        })
+        task.resume()
     }
 }

--- a/Blockchain/Assets/AssetAddress.swift
+++ b/Blockchain/Assets/AssetAddress.swift
@@ -11,7 +11,8 @@ import Foundation
 /// Blueprint for creating and validating asset addresses.
 public protocol AssetAddress {
     /// String representation of the address.
-    var address: String? { get }
+    var description: String? { get }
+    var assetType: AssetType { get }
     init(string: String)
     func isValid(_ address: String) -> Bool
 }

--- a/Blockchain/Assets/AssetAddress.swift
+++ b/Blockchain/Assets/AssetAddress.swift
@@ -1,0 +1,17 @@
+//
+//  AssetAddress.swift
+//  Blockchain
+//
+//  Created by Maurice A. on 4/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Blueprint for creating and validating asset addresses.
+protocol AssetAddress {
+    /// String representation of the address.
+    var address: String? { get }
+    init(string: String)
+    static func isValid(_ address: String) -> Bool
+}

--- a/Blockchain/Assets/AssetAddress.swift
+++ b/Blockchain/Assets/AssetAddress.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Blueprint for creating and validating asset addresses.
-protocol AssetAddress {
+public protocol AssetAddress {
     /// String representation of the address.
     var address: String? { get }
     init(string: String)

--- a/Blockchain/Assets/AssetAddress.swift
+++ b/Blockchain/Assets/AssetAddress.swift
@@ -11,8 +11,8 @@ import Foundation
 /// Blueprint for creating and validating asset addresses.
 public protocol AssetAddress {
     /// String representation of the address.
-    var description: String? { get }
+    var description: String! { get }
     var assetType: AssetType { get }
-    init(string: String)
+    init?(string: String)
     func isValid(_ address: String) -> Bool
 }

--- a/Blockchain/Assets/AssetAddress.swift
+++ b/Blockchain/Assets/AssetAddress.swift
@@ -13,5 +13,5 @@ public protocol AssetAddress {
     /// String representation of the address.
     var address: String? { get }
     init(string: String)
-    static func isValid(_ address: String) -> Bool
+    func isValid(_ address: String) -> Bool
 }

--- a/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
+++ b/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
@@ -12,17 +12,20 @@ public struct BitcoinAddress: AssetAddress {
 
     // MARK: - Properties
 
-    public let address: String?
+    public var address: String?
 
     // MARK: - Initialization
 
     public init(string: String) {
-        self.address = BitcoinAddress.isValid(string) ? string : nil
+        self.address = nil
+        if isValid(string) {
+            address = string
+        }
     }
 
     // MARK: Public Methods
 
-    public static func isValid(_ address: String) -> Bool {
+    public func isValid(_ address: String) -> Bool {
         // TODO: implement validation logic
         return true
     }

--- a/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
+++ b/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
@@ -12,14 +12,16 @@ public struct BitcoinAddress: AssetAddress {
 
     // MARK: - Properties
 
-    public var address: String?
+    public var description: String?
+    public var assetType: AssetType
 
     // MARK: - Initialization
 
     public init(string: String) {
-        self.address = nil
+        self.description = nil
+        self.assetType = .bitcoin
         if isValid(string) {
-            address = string
+            description = string
         }
     }
 

--- a/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
+++ b/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
@@ -1,0 +1,29 @@
+//
+//  BitcoinAddress.swift
+//  Blockchain
+//
+//  Created by Maurice A. on 4/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+struct BitcoinAddress: AssetAddress {
+
+    // MARK: - Properties
+
+    let address: String?
+
+    // MARK: - Initialization
+
+    init(string: String) {
+        self.address = BitcoinAddress.isValid(string) ? string : nil
+    }
+
+    // MARK: Public Methods
+
+    static func isValid(_ address: String) -> Bool {
+        // TODO: implement validation logic
+        return true
+    }
+}

--- a/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
+++ b/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
@@ -12,17 +12,15 @@ public struct BitcoinAddress: AssetAddress {
 
     // MARK: - Properties
 
-    public var description: String?
+    public var description: String!
     public var assetType: AssetType
 
     // MARK: - Initialization
 
-    public init(string: String) {
-        self.description = nil
+    public init?(string: String) {
         self.assetType = .bitcoin
-        if isValid(string) {
-            description = string
-        }
+        if !isValid(string) { return nil }
+        description = string
     }
 
     // MARK: Public Methods

--- a/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
+++ b/Blockchain/Assets/Bitcoin/BitcoinAddress.swift
@@ -8,21 +8,21 @@
 
 import Foundation
 
-struct BitcoinAddress: AssetAddress {
+public struct BitcoinAddress: AssetAddress {
 
     // MARK: - Properties
 
-    let address: String?
+    public let address: String?
 
     // MARK: - Initialization
 
-    init(string: String) {
+    public init(string: String) {
         self.address = BitcoinAddress.isValid(string) ? string : nil
     }
 
     // MARK: Public Methods
 
-    static func isValid(_ address: String) -> Bool {
+    public static func isValid(_ address: String) -> Bool {
         // TODO: implement validation logic
         return true
     }

--- a/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
+++ b/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
@@ -12,17 +12,15 @@ public struct BitcoinCashAddress: AssetAddress {
 
     // MARK: - Properties
 
-    public var description: String?
+    public var description: String!
     public var assetType: AssetType
 
     // MARK: - Initialization
 
-    public init(string: String) {
-        self.description = nil
-        self.assetType = .bitcoinCash
-        if isValid(string) {
-            description = string
-        }
+    public init?(string: String) {
+        self.assetType = .bitcoin
+        if !isValid(string) { return nil }
+        description = string
     }
 
     // MARK: Public Methods

--- a/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
+++ b/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
@@ -8,21 +8,21 @@
 
 import Foundation
 
-struct BitcoinCashAddress: AssetAddress {
+public struct BitcoinCashAddress: AssetAddress {
 
     // MARK: - Properties
 
-    let address: String?
+    public let address: String?
 
     // MARK: - Initialization
 
-    init(string: String) {
+    public init(string: String) {
         self.address = BitcoinCashAddress.isValid(string) ? string : nil
     }
 
     // MARK: Public Methods
 
-    static func isValid(_ address: String) -> Bool {
+    public static func isValid(_ address: String) -> Bool {
         // TODO: implement validation logic
         return true
     }

--- a/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
+++ b/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
@@ -12,14 +12,16 @@ public struct BitcoinCashAddress: AssetAddress {
 
     // MARK: - Properties
 
-    public var address: String?
+    public var description: String?
+    public var assetType: AssetType
 
     // MARK: - Initialization
 
     public init(string: String) {
-        self.address = nil
+        self.description = nil
+        self.assetType = .bitcoinCash
         if isValid(string) {
-            address = string
+            description = string
         }
     }
 

--- a/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
+++ b/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
@@ -12,17 +12,20 @@ public struct BitcoinCashAddress: AssetAddress {
 
     // MARK: - Properties
 
-    public let address: String?
+    public var address: String?
 
     // MARK: - Initialization
 
     public init(string: String) {
-        self.address = BitcoinCashAddress.isValid(string) ? string : nil
+        self.address = nil
+        if isValid(string) {
+            address = string
+        }
     }
 
     // MARK: Public Methods
 
-    public static func isValid(_ address: String) -> Bool {
+    public func isValid(_ address: String) -> Bool {
         // TODO: implement validation logic
         return true
     }

--- a/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
+++ b/Blockchain/Assets/BitcoinCash/BitcoinCashAddress.swift
@@ -1,0 +1,29 @@
+//
+//  BitcoinCashAddress.swift
+//  Blockchain
+//
+//  Created by Maurice A. on 4/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+struct BitcoinCashAddress: AssetAddress {
+
+    // MARK: - Properties
+
+    let address: String?
+
+    // MARK: - Initialization
+
+    init(string: String) {
+        self.address = BitcoinCashAddress.isValid(string) ? string : nil
+    }
+
+    // MARK: Public Methods
+
+    static func isValid(_ address: String) -> Bool {
+        // TODO: implement validation logic
+        return true
+    }
+}

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -347,8 +347,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 
 #define CHARTS_URL_SUFFIX_ARGUMENTS_BASE_QUOTE_START_SCALE @"/price/index-series?base=%@&quote=%@&start=%@&scale=%@&omitnull=true"
 #define TRANSACTION_RESULT_URL_SUFFIX_HASH_ARGUMENT_ADDRESS_ARGUMENT @"/q/txresult/%@/%@"
-#define ADDRESS_URL_SUFFIX_HASH_ARGUMENT_ADDRESS_ARGUMENT @"/address/%@?format=json"
-#define ADDRESS_URL_SUFFIX_BCH_ADDRESS_ARGUMENT @"/bch/multiaddr?active=%@"
 
 #define URL_SURVEY @"https://blockchain.co1.qualtrics.com/SE/?SID=SV_8c6uSMW5eBV9nal"
 

--- a/Blockchain/Network/Extensions/BlockchainAPI+URLSuffix.swift
+++ b/Blockchain/Network/Extensions/BlockchainAPI+URLSuffix.swift
@@ -9,21 +9,17 @@
 import Foundation
 
 extension BlockchainAPI {
-    static func suffixURL(btcAddress: BitcoinAddress) -> String? {
-        guard
-            let address = btcAddress.address,
-            let walletUrl = shared.walletUrl else {
+    func suffixURL(address: AssetAddress) -> String? {
+        guard let description = address.description else { return nil }
+        switch address.assetType {
+        case .bitcoin:
+            guard let url = walletUrl else { return nil }
+            return String(format: "%@/address/%@?format=json", url, description)
+        case .bitcoinCash:
+            guard let url = apiUrl else { return nil }
+            return String(format: "/bch/multiaddr?active=%@", url, description)
+        default:
             return nil
         }
-        return String(format: "%@/address/%@?format=json", walletUrl, address)
-    }
-
-    static func suffixURL(bchAddress: BitcoinCashAddress) -> String? {
-        guard
-            let address = bchAddress.address,
-            let apiUrl = shared.apiUrl else {
-                return nil
-        }
-        return String(format: "/bch/multiaddr?active=%@", apiUrl, address)
     }
 }

--- a/Blockchain/Network/Extensions/BlockchainAPI+URLSuffix.swift
+++ b/Blockchain/Network/Extensions/BlockchainAPI+URLSuffix.swift
@@ -1,0 +1,29 @@
+//
+//  BlockchainAPI+URLSuffix.swift
+//  Blockchain
+//
+//  Created by Maurice A. on 4/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+extension BlockchainAPI {
+    static func suffixURL(btcAddress: BitcoinAddress) -> String? {
+        guard
+            let address = btcAddress.address,
+            let walletUrl = shared.walletUrl else {
+            return nil
+        }
+        return String(format: "%@/address/%@?format=json", walletUrl, address)
+    }
+
+    static func suffixURL(bchAddress: BitcoinCashAddress) -> String? {
+        guard
+            let address = bchAddress.address,
+            let apiUrl = shared.apiUrl else {
+                return nil
+        }
+        return String(format: "/bch/multiaddr?active=%@", apiUrl, address)
+    }
+}

--- a/Blockchain/Network/NetworkManager.swift
+++ b/Blockchain/Network/NetworkManager.swift
@@ -69,6 +69,8 @@ final class NetworkManager: NSObject, URLSessionDelegate {
 
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {}
 
+    // MARK: - Private Functions
+
     fileprivate func persistServerSessionIDForNewUIWebViews() {
         let cookieStorage = HTTPCookieStorage.shared
         cookieStorage.cookieAcceptPolicy = .always

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -3236,44 +3236,44 @@ void (^secondPasswordSuccess)(NSString *);
     [self.window.rootViewController presentViewController:alert animated:YES completion:nil];
 }
 
-- (void)checkForUnusedAddress:(NSString *)address success:(void (^)(NSString *, BOOL))successBlock error:(void (^)())errorBlock assetType:(AssetType)assetType
-{
-    NSString *URLString;
-
-    if (assetType == AssetTypeBitcoin) {
-        URLString = [[[BlockchainAPI sharedInstance] walletUrl] stringByAppendingString:[NSString stringWithFormat:ADDRESS_URL_SUFFIX_HASH_ARGUMENT_ADDRESS_ARGUMENT, address]];
-    } else if (assetType == AssetTypeBitcoinCash) {
-        NSString *addressToCheck = [WalletManager.sharedInstance.wallet fromBitcoinCash:address];
-        URLString = [[[BlockchainAPI sharedInstance] apiUrl] stringByAppendingString:[NSString stringWithFormat:ADDRESS_URL_SUFFIX_BCH_ADDRESS_ARGUMENT, addressToCheck]];
-    } else {
-        DLog(@"checking for unused address: unsupported asset type!");
-    }
-
-    NSURL *URL = [NSURL URLWithString:URLString];
-    NSURLRequest *request = [NSURLRequest requestWithURL:URL];
-    NSURL *url = [NSURL URLWithString:[[BlockchainAPI sharedInstance] walletUrl]];
-    // session.sessionDescription = url.host;
-    NSURLSessionDataTask *task = [[[NetworkManager sharedInstance] session] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        if (error) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                DLog(@"Error checking for receive address %@: %@", address, error);
-                if (errorBlock) errorBlock();
-            });
-            return;
-        }
-
-        NSDictionary *addressInfo = [NSJSONSerialization JSONObjectWithData:data options: NSJSONReadingAllowFragments error: &error];
-        NSArray *transactions = addressInfo[@"txs"];
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            BOOL isUnused = transactions.count == 0;
-            return successBlock(address, isUnused);
-        });
-
-    }];
-
-    [task resume];
-}
+//- (void)checkForUnusedAddress:(NSString *)address success:(void (^)(NSString *, BOOL))successBlock error:(void (^)())errorBlock assetType:(AssetType)assetType
+//{
+//    NSString *URLString;
+//
+//    if (assetType == AssetTypeBitcoin) {
+//        URLString = [[[BlockchainAPI sharedInstance] walletUrl] stringByAppendingString:[NSString stringWithFormat:ADDRESS_URL_SUFFIX_HASH_ARGUMENT_ADDRESS_ARGUMENT, address]];
+//    } else if (assetType == AssetTypeBitcoinCash) {
+//        NSString *addressToCheck = [app.wallet fromBitcoinCash:address];
+//        URLString = [[[BlockchainAPI sharedInstance] apiUrl] stringByAppendingString:[NSString stringWithFormat:ADDRESS_URL_SUFFIX_BCH_ADDRESS_ARGUMENT, addressToCheck]];
+//    } else {
+//        DLog(@"checking for unused address: unsupported asset type!");
+//    }
+//
+//    NSURL *URL = [NSURL URLWithString:URLString];
+//    NSURLRequest *request = [NSURLRequest requestWithURL:URL];
+//    NSURL *url = [NSURL URLWithString:[[BlockchainAPI sharedInstance] walletUrl]];
+//    // session.sessionDescription = url.host;
+//    NSURLSessionDataTask *task = [[[NetworkManager sharedInstance] session] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+//        if (error) {
+//            dispatch_async(dispatch_get_main_queue(), ^{
+//                DLog(@"Error checking for receive address %@: %@", address, error);
+//                if (errorBlock) errorBlock();
+//            });
+//            return;
+//        }
+//
+//        NSDictionary *addressInfo = [NSJSONSerialization JSONObjectWithData:data options: NSJSONReadingAllowFragments error: &error];
+//        NSArray *transactions = addressInfo[@"txs"];
+//
+//        dispatch_async(dispatch_get_main_queue(), ^{
+//            BOOL isUnused = transactions.count == 0;
+//            return successBlock(address, isUnused);
+//        });
+//
+//    }];
+//
+//    [task resume];
+//}
 
 - (void)openMail
 {

--- a/BlockchainTests/BlockchainAPI+URLSuffixTests.swift
+++ b/BlockchainTests/BlockchainAPI+URLSuffixTests.swift
@@ -1,0 +1,55 @@
+//
+//  BlockchainAPI+URLSuffixTests.swift
+//  BlockchainTests
+//
+//  Created by Maurice A. on 4/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import XCTest
+@testable import Blockchain
+
+class BlockchainAPIURLSuffixTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // MARK: - Bitcoin
+
+    func testSuffixURLWithValidBitcoinAddress() {
+        let btcAddress = BitcoinAddress(string: "1W3hBBAnECvpmpFXcBrWoBXXihJAEkTmA")
+        let url = BlockchainAPI.suffixURL(btcAddress: btcAddress)
+        let expected = "https://blockchain.info/address/\(btcAddress.address!)?format=json"
+        XCTAssertNotNil(url, "Expected the url to be \(expected), but got nil.")
+    }
+
+    // TODO: enable test when address validation is implemented in BitcoinAddress struct.
+
+//    func testSuffixURLWithInvalidBitcoinAddress() {
+//        let invalidBtcAddress = BitcoinAddress(string: "12345")
+//        let url = BlockchainAPI.suffixURL(btcAddress: invalidBtcAddress)
+//        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
+//    }
+
+    // MARK: - Bitcoin Cash
+
+    func testSuffixURLWithValidBitcoinCashAddress() {
+        let bchAddress = BitcoinCashAddress(string: "qqzhunu9f7p39e8kgchr628z9wsdxq0c5ua3yf4kzr")
+        let url = BlockchainAPI.suffixURL(bchAddress: bchAddress)
+        let expected = "https://api.blockchain.info/bch/multiaddr?active=\(bchAddress.address!)"
+        XCTAssertNotNil(url, "Expected the url to be \(expected), but got nil.")
+    }
+
+    // TODO: enable test when address validation is implemented in BitcoinCashAddress struct.
+
+//    func testSuffixURLWithInvalidBitcoinCashAddress() {
+//        let invalidBchAddress = BitcoinCashAddress(string: "abc")
+//        let url = BlockchainAPI.suffixURL(bchAddress: invalidBchAddress)
+//        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
+//    }
+}

--- a/BlockchainTests/BlockchainAPI+URLSuffixTests.swift
+++ b/BlockchainTests/BlockchainAPI+URLSuffixTests.swift
@@ -23,33 +23,33 @@ class BlockchainAPIURLSuffixTests: XCTestCase {
 
     func testSuffixURLWithValidBitcoinAddress() {
         let btcAddress = BitcoinAddress(string: "1W3hBBAnECvpmpFXcBrWoBXXihJAEkTmA")
-        let url = BlockchainAPI.suffixURL(btcAddress: btcAddress)
-        let expected = "https://blockchain.info/address/\(btcAddress.address!)?format=json"
+        let url = BlockchainAPI.shared.suffixURL(address: btcAddress)
+        let expected = "https://blockchain.info/address/\(btcAddress.description!)?format=json"
         XCTAssertNotNil(url, "Expected the url to be \(expected), but got nil.")
     }
 
     // TODO: enable test when address validation is implemented in BitcoinAddress struct.
 
-//    func testSuffixURLWithInvalidBitcoinAddress() {
-//        let invalidBtcAddress = BitcoinAddress(string: "12345")
-//        let url = BlockchainAPI.suffixURL(btcAddress: invalidBtcAddress)
-//        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
-//    }
+    //    func testSuffixURLWithInvalidBitcoinAddress() {
+    //        let invalidBtcAddress = BitcoinAddress(string: "12345")
+    //        let url = BlockchainAPI.shared.suffixURL(address: invalidBtcAddress)
+    //        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
+    //    }
 
     // MARK: - Bitcoin Cash
 
     func testSuffixURLWithValidBitcoinCashAddress() {
         let bchAddress = BitcoinCashAddress(string: "qqzhunu9f7p39e8kgchr628z9wsdxq0c5ua3yf4kzr")
-        let url = BlockchainAPI.suffixURL(bchAddress: bchAddress)
-        let expected = "https://api.blockchain.info/bch/multiaddr?active=\(bchAddress.address!)"
+        let url = BlockchainAPI.shared.suffixURL(address: bchAddress)
+        let expected = "https://api.blockchain.info/bch/multiaddr?active=\(bchAddress.description!)"
         XCTAssertNotNil(url, "Expected the url to be \(expected), but got nil.")
     }
 
     // TODO: enable test when address validation is implemented in BitcoinCashAddress struct.
 
-//    func testSuffixURLWithInvalidBitcoinCashAddress() {
-//        let invalidBchAddress = BitcoinCashAddress(string: "abc")
-//        let url = BlockchainAPI.suffixURL(bchAddress: invalidBchAddress)
-//        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
-//    }
+    //    func testSuffixURLWithInvalidBitcoinCashAddress() {
+    //        let invalidBchAddress = BitcoinCashAddress(string: "abc")
+    //        let url = BlockchainAPI.shared.suffixURL(address: invalidBchAddress)
+    //        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
+    //    }
 }

--- a/BlockchainTests/BlockchainAPI+URLSuffixTests.swift
+++ b/BlockchainTests/BlockchainAPI+URLSuffixTests.swift
@@ -23,33 +23,33 @@ class BlockchainAPIURLSuffixTests: XCTestCase {
 
     func testSuffixURLWithValidBitcoinAddress() {
         let btcAddress = BitcoinAddress(string: "1W3hBBAnECvpmpFXcBrWoBXXihJAEkTmA")
-        let url = BlockchainAPI.shared.suffixURL(address: btcAddress)
-        let expected = "https://blockchain.info/address/\(btcAddress.description!)?format=json"
+        let url = BlockchainAPI.shared.suffixURL(address: btcAddress!)
+        let expected = "https://blockchain.info/address/\(btcAddress!.description!)?format=json"
         XCTAssertNotNil(url, "Expected the url to be \(expected), but got nil.")
     }
 
     // TODO: enable test when address validation is implemented in BitcoinAddress struct.
 
-    //    func testSuffixURLWithInvalidBitcoinAddress() {
-    //        let invalidBtcAddress = BitcoinAddress(string: "12345")
-    //        let url = BlockchainAPI.shared.suffixURL(address: invalidBtcAddress)
-    //        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
-    //    }
+//    func testSuffixURLWithInvalidBitcoinAddress() {
+//        let invalidBtcAddress = BitcoinAddress(string: "12345")
+//        let url = BlockchainAPI.shared.suffixURL(address: invalidBtcAddress!)
+//        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
+//    }
 
     // MARK: - Bitcoin Cash
 
     func testSuffixURLWithValidBitcoinCashAddress() {
         let bchAddress = BitcoinCashAddress(string: "qqzhunu9f7p39e8kgchr628z9wsdxq0c5ua3yf4kzr")
-        let url = BlockchainAPI.shared.suffixURL(address: bchAddress)
-        let expected = "https://api.blockchain.info/bch/multiaddr?active=\(bchAddress.description!)"
+        let url = BlockchainAPI.shared.suffixURL(address: bchAddress!)
+        let expected = "https://api.blockchain.info/bch/multiaddr?active=\(bchAddress!.description!)"
         XCTAssertNotNil(url, "Expected the url to be \(expected), but got nil.")
     }
 
     // TODO: enable test when address validation is implemented in BitcoinCashAddress struct.
 
-    //    func testSuffixURLWithInvalidBitcoinCashAddress() {
-    //        let invalidBchAddress = BitcoinCashAddress(string: "abc")
-    //        let url = BlockchainAPI.shared.suffixURL(address: invalidBchAddress)
-    //        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
-    //    }
+//    func testSuffixURLWithInvalidBitcoinCashAddress() {
+//        let invalidBchAddress = BitcoinCashAddress(string: "abc")
+//        let url = BlockchainAPI.shared.suffixURL(address: invalidBchAddress!)
+//        XCTAssertNil(url, "Expected the url to be nil due to an invalid address.")
+//    }
 }

--- a/BlockchainTests/CheckForUnusedAddressTests.swift
+++ b/BlockchainTests/CheckForUnusedAddressTests.swift
@@ -1,0 +1,39 @@
+//
+//  CheckForUnusedAddressTests.swift
+//  BlockchainTests
+//
+//  Created by Maurice A. on 4/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import XCTest
+@testable import Blockchain
+
+class CheckForUnusedAddressTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testCheckForUnusedAddressWithUnusedAddress() {
+        let testBundle = Bundle(for: type(of: self))
+        if let path = testBundle.url(forResource: "sample-unused-address", withExtension: "json") {
+            do {
+                let data = try Data(contentsOf: path, options: .mappedIfSafe)
+                let json  = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject]
+                if let txs = json!["txs"] as? [NSDictionary] {
+                    let isUnused = txs.count == 0
+                    XCTAssertTrue(isUnused, "Expected to get true, but got \(isUnused)")
+                }
+            } catch let error {
+                XCTFail(error.localizedDescription)
+            }
+        } else {
+            XCTFail("Unable to load mock json file.")
+        }
+    }
+}

--- a/BlockchainTests/Mock Data/sample-unused-address.json
+++ b/BlockchainTests/Mock Data/sample-unused-address.json
@@ -1,0 +1,9 @@
+{
+    "hash160":"057e4f854f8312e4f6462e3d28e22ba0d301f8a7",
+    "address":"1W3hBBAnECvpmpFXcBrWoBXXihJAEkTmA",
+    "n_tx":0,
+    "total_received":0,
+    "total_sent":0,
+    "final_balance":0,
+    "txs":[]
+}


### PR DESCRIPTION
This PR migrates `checkForUnusedAddress` to Swift using the new `AssetAddress` type.

TODO: move `checkForUnusedAddress` to a more appropriate place than the application delegate.