### PR TITLE
refactor(pin): Complete pin entry flow on new wallet creation.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -205,6 +205,19 @@
 		A2913FA21B31830000DC6C15 /* BackupNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2913FA11B31830000DC6C15 /* BackupNavigationViewController.swift */; };
 		AA31A7B42098DA4900FE6268 /* AlertViewPresenter+Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */; };
 		AA31A7B52098DA5200FE6268 /* AlertViewPresenter+Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */; };
+		AA1E522B2097CA360099BD10 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522A2097CA360099BD10 /* AuthenticationCoordinator.swift */; };
+		AA1E522D2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522C2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift */; };
+		AA1E522F2097CC010099BD10 /* WalletAuthDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522E2097CC010099BD10 /* WalletAuthDelegate.swift */; };
+		AA1E52312097CC1F0099BD10 /* WalletPinEntryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52302097CC1F0099BD10 /* WalletPinEntryDelegate.swift */; };
+		AA1E52322097CC230099BD10 /* WalletPinEntryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52302097CC1F0099BD10 /* WalletPinEntryDelegate.swift */; };
+		AA1E52332097CC260099BD10 /* WalletAuthDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522E2097CC010099BD10 /* WalletAuthDelegate.swift */; };
+		AA1E52342097CC2C0099BD10 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522A2097CA360099BD10 /* AuthenticationCoordinator.swift */; };
+		AA1E52352097CC2E0099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522C2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift */; };
+		AA1E52382097D3C50099BD10 /* PutPinResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52372097D3C50099BD10 /* PutPinResponse.swift */; };
+		AA1E523A2097E2190099BD10 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52392097E2190099BD10 /* Strings.swift */; };
+		AA1E523B2097E2190099BD10 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52392097E2190099BD10 /* Strings.swift */; };
+		AA1E523D2097E6AC0099BD10 /* GetPinResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E523C2097E6AC0099BD10 /* GetPinResponse.swift */; };
+		AA1E523E2097E6AC0099BD10 /* GetPinResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E523C2097E6AC0099BD10 /* GetPinResponse.swift */; };
 		AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F6582086A2720054EFCE /* AppCoordinator.swift */; };
 		AA69F65F2086A7500054EFCE /* BlockchainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */; };
 		AAA3314E20893CE100BBD292 /* PairingInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */; };
@@ -242,7 +255,6 @@
 		AACE31CB2092A99B00B7B806 /* AssetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511646C4208124E200C43522 /* AssetType.swift */; };
 		AACE31CC2092A99B00B7B806 /* BitcoinAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862D820921E7600B338E0 /* BitcoinAddress.swift */; };
 		AACE31CD2092A99B00B7B806 /* BitcoinCashAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A862DB20921EBD00B338E0 /* BitcoinCashAddress.swift */; };
-		AACE31CE2092A99B00B7B806 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE31472091430900B7B806 /* AuthenticationCoordinator.swift */; };
 		AACE31CF2092A99B00B7B806 /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E5C72F20741A130000A7FD /* AuthenticationManager.swift */; };
 		AACE31D02092A99B00B7B806 /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A665C62080EBD80040EE7C /* AuthenticationError.swift */; };
 		AACE31D12092A99B00B7B806 /* PasscodePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510EA16F2080F16100A63AB8 /* PasscodePayload.swift */; };
@@ -1170,6 +1182,13 @@
 		A2AADC041B0B98720085144B /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Backup.strings; sourceTree = "<group>"; };
 		A2AADC071B0B999F0085144B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Backup.strings; sourceTree = "<group>"; };
 		AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AlertViewPresenter+Wallet.swift"; sourceTree = "<group>"; };
+		AA1E522A2097CA360099BD10 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthenticationCoordinator.swift; path = Authentication/AuthenticationCoordinator.swift; sourceTree = "<group>"; };
+		AA1E522C2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "AuthenticationCoordinator+Pin.swift"; path = "Authentication/Models/AuthenticationCoordinator+Pin.swift"; sourceTree = "<group>"; };
+		AA1E522E2097CC010099BD10 /* WalletAuthDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAuthDelegate.swift; sourceTree = "<group>"; };
+		AA1E52302097CC1F0099BD10 /* WalletPinEntryDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletPinEntryDelegate.swift; sourceTree = "<group>"; };
+		AA1E52372097D3C50099BD10 /* PutPinResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PutPinResponse.swift; sourceTree = "<group>"; };
+		AA1E52392097E2190099BD10 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Strings.swift; path = Extensions/Strings.swift; sourceTree = "<group>"; };
+		AA1E523C2097E6AC0099BD10 /* GetPinResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPinResponse.swift; sourceTree = "<group>"; };
 		AA69F6582086A2720054EFCE /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchainSettings.swift; sourceTree = "<group>"; };
 		AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingInstructionsView.swift; sourceTree = "<group>"; };
@@ -1189,7 +1208,6 @@
 		AABDED91208FDFE3002D8BAC /* HTTPCookieStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPCookieStorage.swift; sourceTree = "<group>"; };
 		AACE31202091004900B7B806 /* UIApplication+Suspend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIApplication+Suspend.h"; path = "Extensions/UIApplication+Suspend.h"; sourceTree = "<group>"; };
 		AACE31212091004A00B7B806 /* UIApplication+Suspend.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIApplication+Suspend.m"; path = "Extensions/UIApplication+Suspend.m"; sourceTree = "<group>"; };
-		AACE31472091430900B7B806 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinator.swift; sourceTree = "<group>"; };
 		AACE314B209152D800B7B806 /* UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIApplication.swift; path = Extensions/UIApplication.swift; sourceTree = "<group>"; };
 		AACE31802092794D00B7B806 /* Pin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pin.swift; sourceTree = "<group>"; };
 		AACE31B72092A87900B7B806 /* PinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinTests.swift; sourceTree = "<group>"; };
@@ -1550,7 +1568,8 @@
 		510EA1732080F58700A63AB8 /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
-				AACE31472091430900B7B806 /* AuthenticationCoordinator.swift */,
+				AA1E522A2097CA360099BD10 /* AuthenticationCoordinator.swift */,
+				AA1E522C2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift */,
 				51E5C72F20741A130000A7FD /* AuthenticationManager.swift */,
 				510EA1742080F59C00A63AB8 /* Models */,
 				AACE31ED2092B1BA00B7B806 /* Views */,
@@ -1576,6 +1595,7 @@
 				516546F7208FCF800019EE63 /* Enum+Enumeratable.swift */,
 				5185E123208F6E5E00A26B64 /* Enum+RawValued.swift */,
 				AABDED6F208FACB9002D8BAC /* Reachability.swift */,
+				AA1E52392097E2190099BD10 /* Strings.swift */,
 				AACE314B209152D800B7B806 /* UIApplication.swift */,
 				511646E1208523E300C43522 /* UIDevice.swift */,
 				AABDED3F208A6E8D002D8BAC /* UIViewController.swift */,
@@ -2081,6 +2101,15 @@
 			name = "View Controllers";
 			sourceTree = "<group>";
 		};
+		AA1E52362097D3B20099BD10 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				AA1E523C2097E6AC0099BD10 /* GetPinResponse.swift */,
+				AA1E52372097D3C50099BD10 /* PutPinResponse.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		AA69F65C2086A7330054EFCE /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -2146,7 +2175,10 @@
 			isa = PBXGroup;
 			children = (
 				C74FEA222093B38A007CAB5D /* JSContextWithDOM.swift */,
+				AA1E522E2097CC010099BD10 /* WalletAuthDelegate.swift */,
 				AABDED6B208EC330002D8BAC /* WalletManager.swift */,
+				AA1E52302097CC1F0099BD10 /* WalletPinEntryDelegate.swift */,
+				AA1E52362097D3B20099BD10 /* Models */,
 			);
 			path = Wallet;
 			sourceTree = "<group>";
@@ -2767,6 +2799,7 @@
 				AACE31382091220300B7B806 /* HTTPCookieStorage.swift in Sources */,
 				51A862BE2090DD6400B338E0 /* PairingInstructionsView.swift in Sources */,
 				AAD279CC209A826900C0EAFC /* BCSecureTextField.swift in Sources */,
+				AA1E523B2097E2190099BD10 /* Strings.swift in Sources */,
 				AACE31CD2092A99B00B7B806 /* BitcoinCashAddress.swift in Sources */,
 				AACE320B20978EB100B7B806 /* MockWallet.swift in Sources */,
 				51A862E42092686300B338E0 /* CheckForUnusedAddressTests.swift in Sources */,
@@ -2779,7 +2812,9 @@
 				AACE32082097835F00B7B806 /* AuthenticationManagerTests.swift in Sources */,
 				5185E11C208E7F7C00A26B64 /* BlockchainSettings.swift in Sources */,
 				AACE31DB2092A99B00B7B806 /* UIDevice.swift in Sources */,
+				AA1E52332097CC260099BD10 /* WalletAuthDelegate.swift in Sources */,
 				AACE31CF2092A99B00B7B806 /* AuthenticationManager.swift in Sources */,
+				AA1E52322097CC230099BD10 /* WalletPinEntryDelegate.swift in Sources */,
 				AACE31CA2092A99B00B7B806 /* AssetAddress.swift in Sources */,
 				AACE31B82092A87900B7B806 /* PinTests.swift in Sources */,
 				AACE31C82092A99B00B7B806 /* ModalPresenter.swift in Sources */,
@@ -2788,10 +2823,10 @@
 				AACE31D72092A99B00B7B806 /* Enum+Enumeratable.swift in Sources */,
 				AACE31D82092A99B00B7B806 /* Enum+RawValued.swift in Sources */,
 				AAD279CA209A825500C0EAFC /* BCTextField.swift in Sources */,
+				AA1E523E2097E6AC0099BD10 /* GetPinResponse.swift in Sources */,
 				AACE31C92092A99B00B7B806 /* AlertViewPresenter.swift in Sources */,
 				AACE31E02092A99B00B7B806 /* NetworkManager.swift in Sources */,
 				AACE31DD2092A99B00B7B806 /* UserDefaults.swift in Sources */,
-				AACE31CE2092A99B00B7B806 /* AuthenticationCoordinator.swift in Sources */,
 				AACE31DF2092A99B00B7B806 /* CertificatePinner.swift in Sources */,
 				AA31A7B52098DA5200FE6268 /* AlertViewPresenter+Wallet.swift in Sources */,
 				519435B1208E62F6001EF882 /* BlockchainAPI+URL.swift in Sources */,
@@ -2799,11 +2834,13 @@
 				AACE31C72092A99B00B7B806 /* LocalizationConstants.swift in Sources */,
 				AACE31CC2092A99B00B7B806 /* BitcoinAddress.swift in Sources */,
 				AACE31D12092A99B00B7B806 /* PasscodePayload.swift in Sources */,
+				AA1E52352097CC2E0099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */,
 				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
 				AACE31C52092A99B00B7B806 /* Environment.swift in Sources */,
 				51A862D620921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */,
 				5185E12B208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */,
 				AACE31CB2092A99B00B7B806 /* AssetType.swift in Sources */,
+				AA1E52342097CC2C0099BD10 /* AuthenticationCoordinator.swift in Sources */,
 				AACE31C62092A99B00B7B806 /* LoadingViewPresenter.swift in Sources */,
 				AACE31D22092A99B00B7B806 /* UINavigationController+PopToRootWithCompletion.swift in Sources */,
 				AACE31D32092A99B00B7B806 /* OnboardingCoordinator.swift in Sources */,
@@ -2850,9 +2887,9 @@
 				C7E4D293203E12AA00F6DCEB /* TransactionsBitcoinCashViewController.m in Sources */,
 				23F720F21C32DC0A00577738 /* DebugTableViewController.m in Sources */,
 				23E2FC081C7F60E7004CFF79 /* BCInsetLabel.m in Sources */,
+				AA1E522D2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */,
 				23444F871DCD217E00573C8C /* BTCNetwork.m in Sources */,
 				C9BE917D1945D8F600FD516D /* PEViewController.m in Sources */,
-				AACE31482091430900B7B806 /* AuthenticationCoordinator.swift in Sources */,
 				674709EC19D1D14300757D46 /* BCWelcomeView.m in Sources */,
 				67D95A281B3DDC900012EBB1 /* Constants.swift in Sources */,
 				9F765F3214BC622E00048EFB /* TransactionsBitcoinViewController.m in Sources */,
@@ -2874,6 +2911,7 @@
 				C73406221F54791C00143100 /* EtherAmountInputViewController.m in Sources */,
 				51A7349320891EB3009727D5 /* NetworkManager.swift in Sources */,
 				C7559CB21F56FE09005B2375 /* TransactionsEtherViewController.m in Sources */,
+				AA1E522B2097CA360099BD10 /* AuthenticationCoordinator.swift in Sources */,
 				23FDEFAC1D6F669100FC80D6 /* NSURLSession+SendSynchronousRequest.m in Sources */,
 				AABDED70208FACB9002D8BAC /* Reachability.swift in Sources */,
 				C74FEA232093B38A007CAB5D /* JSContextWithDOM.swift in Sources */,
@@ -2885,6 +2923,7 @@
 				AA69F65F2086A7500054EFCE /* BlockchainSettings.swift in Sources */,
 				23B731D31E01AC1100129770 /* ReminderModalViewController.m in Sources */,
 				23444F9F1DCD221A00573C8C /* BTCProtocolSerialization.m in Sources */,
+				AA1E522F2097CC010099BD10 /* WalletAuthDelegate.swift in Sources */,
 				84FC02FA1981452D00B97D5B /* NSString+JSONParser_NSString.m in Sources */,
 				9F765F3D14BC7C4F00048EFB /* Transaction.m in Sources */,
 				5185E124208F6E5E00A26B64 /* Enum+RawValued.swift in Sources */,
@@ -2929,9 +2968,11 @@
 				AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */,
 				67D95A261B3DD86B0012EBB1 /* BCTextField.swift in Sources */,
 				2322DCC01D771831000E5AC1 /* SRRandom.m in Sources */,
+				AA1E523A2097E2190099BD10 /* Strings.swift in Sources */,
 				23FB5C0D1D9ABB650008C6AB /* TransactionDetailFromCell.m in Sources */,
 				2322DCBA1D771831000E5AC1 /* SRConstants.m in Sources */,
 				A2599BA71B0B726900C2EA81 /* BackupVerifyViewController.swift in Sources */,
+				AA1E523D2097E6AC0099BD10 /* GetPinResponse.swift in Sources */,
 				AACE31812092794D00B7B806 /* Pin.swift in Sources */,
 				23107F831BBEF0AC00A6A9D4 /* BCConfirmPaymentView.m in Sources */,
 				23FB5C131D9ABB8B0008C6AB /* TransactionDetailStatusCell.m in Sources */,
@@ -2984,6 +3025,7 @@
 				ECD244F719A8B444004B1F40 /* UIImage+Utils.m in Sources */,
 				23444F961DCD21C600573C8C /* BTCKeychain.m in Sources */,
 				2322DCB61D771831000E5AC1 /* SRIOConsumerPool.m in Sources */,
+				AA1E52312097CC1F0099BD10 /* WalletPinEntryDelegate.swift in Sources */,
 				AABDED92208FDFE3002D8BAC /* HTTPCookieStorage.swift in Sources */,
 				2322DCBB1D771831000E5AC1 /* SRError.m in Sources */,
 				9F1831E21516A39500FB3D52 /* NSData+Hex.m in Sources */,
@@ -3009,6 +3051,7 @@
 				67EE1DCB19E3325900DBBFC9 /* ECSlidingAnimationController.m in Sources */,
 				67470A0819D43AFE00757D46 /* BCManualPairView.m in Sources */,
 				C7E2750E1F59C2D50054EFA5 /* UILabel+Animations.m in Sources */,
+				AA1E52382097D3C50099BD10 /* PutPinResponse.swift in Sources */,
 				6E2D90A21BBEC34800B719EC /* BCRecoveryView.m in Sources */,
 				A2599B9F1B0B5FC800C2EA81 /* BackupViewController.swift in Sources */,
 				C9BE917C1945D8F600FD516D /* PEPinEntryController.m in Sources */,

--- a/Blockchain/Alerts/AlertViewPresenter.swift
+++ b/Blockchain/Alerts/AlertViewPresenter.swift
@@ -22,18 +22,13 @@ import Foundation
     /// Shows the user an alert that the app failed to read values from the keychain.
     /// Upon confirming on the presented alert, the app will terminate.
     @objc func showKeychainReadError() {
-        // TODO
-//        UIAlertController *alert = [UIAlertController alertControllerWithTitle:BC_STRING_FAILED_TO_LOAD_WALLET_TITLE
-        // message:BC_STRING_ERROR_LOADING_WALLET_IDENTIFIER_FROM_KEYCHAIN preferredStyle:UIAlertControllerStyleAlert];
-//        [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_CLOSE_APP
-        // style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-//            // Close App
-//            UIApplication *app = [UIApplication sharedApplication];
-//            [app performSelector:@selector(suspend)];
-//            }]];
-//
-//        [[UIApplication sharedApplication].keyWindow.rootViewController
-        //presentViewController:alert animated:YES completion:nil];
+        standardNotify(
+            message: LocalizationConstants.Errors.errorLoadingWalletIdentifierFromKeychain,
+            title: LocalizationConstants.Authentication.failedToLoadWallet
+        ) { _ in
+            // Close App
+            UIApplication.shared.suspend()
+        }
     }
 
     @objc func checkAndWarnOnJailbrokenPhones() {

--- a/Blockchain/Authentication/AuthenticationManager.swift
+++ b/Blockchain/Authentication/AuthenticationManager.swift
@@ -251,13 +251,12 @@ extension AuthenticationManager: WalletAuthDelegate {
         // With the hash prefix we can then figure out if the password changed. If so, clear the pin
         // so that the user can reset it
         guard let password = password,
-            let passwordSha256 = NSString(string: password).sha256(),
-            let passwordPartHash = BlockchainSettings.App.shared.passwordPartHash else {
+            let passwordPartHash = password.passwordPartHash,
+            let savedPasswordPartHash = BlockchainSettings.App.shared.passwordPartHash else {
                 return
         }
 
-        let endIndex = passwordSha256.index(passwordSha256.startIndex, offsetBy: min(password.count, 5))
-        guard passwordSha256[..<endIndex] != passwordPartHash else {
+        guard passwordPartHash != savedPasswordPartHash else {
             return
         }
 
@@ -276,8 +275,8 @@ extension AuthenticationManager: WalletAuthDelegate {
         // TODO
     }
 
-    func authenticationError() {
-        failAuth()
+    func authenticationError(error: AuthenticationError?) {
+        failAuth(withError: error)
     }
 
     func authenticationCompleted() {

--- a/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
@@ -51,7 +51,7 @@ extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
         self.lastEnteredPIN = pin
 
         guard WalletManager.shared.wallet.isInitialized() || WalletManager.shared.wallet.password != nil else {
-            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.cannotSavePinInvalidWalletState)
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.Pin.cannotSaveInvalidWalletState)
             return
         }
 
@@ -155,7 +155,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
     }
 
     func errorGetPinEmptyResponse() {
-        showPinError(withMessage: LocalizationConstants.Authentication.incorrectPin)
+        showPinError(withMessage: LocalizationConstants.Authentication.Pin.incorrect)
     }
 
     func errorGetPinInvalidResponse() {
@@ -174,7 +174,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
         LoadingViewPresenter.shared.hideBusyView()
 
         guard let password = walletManager.wallet.password else {
-            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.cannotSavePinInvalidWalletState)
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.Pin.cannotSaveInvalidWalletState)
             return
         }
 
@@ -195,7 +195,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
         }
 
         guard response.key.count != 0 && response.value.count != 0 else {
-            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.pinResponseKeyOrValueLength0)
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.Pin.responseKeyOrValueLengthZero)
             return
         }
 
@@ -211,7 +211,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
             password: response.value,
             pbkdf2_iterations: Int32(Constants.Security.pinPBKDF2Iterations)
         ) else {
-            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.pinEncryptedStringIsNil)
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.Pin.encryptedStringIsNil)
             return
         }
 
@@ -237,10 +237,10 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
 
         // Incorrect pin
         if response.code == nil {
-            AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.incorrectPin)
+            AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.Pin.incorrect)
         } else if response.code == GetPinResponse.StatusCode.deleted.rawValue {
             // Pin retry limit exceeded
-            AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.pinValidationCannotBeCompleted)
+            AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.Pin.validationCannotBeCompleted)
             BlockchainSettings.App.shared.clearPin()
             logout()
             DispatchQueue.main.async { [weak self] in
@@ -249,7 +249,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
                 strongSelf.closePinEntryView(animated: true)
             }
         } else if response.code == GetPinResponse.StatusCode.incorrect.rawValue {
-            let error = response.error ?? "PIN Code Incorrect. Unknown Error Message."
+            let error = response.error ?? LocalizationConstants.Authentication.Pin.incorrectUnknownError
             AlertViewPresenter.shared.standardNotify(message: error)
         } else if response.code == GetPinResponse.StatusCode.success.rawValue {
 
@@ -273,7 +273,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
 
             // Initial PIN setup ?
             if response.pinDecryptionValue?.count == 0 {
-                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.pinResponseSuccessLength0)
+                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.Pin.responseSuccessLengthZero)
                 return
             }
 
@@ -284,7 +284,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
                 pbkdf2_iterations: Int32(Constants.Security.pinPBKDF2Iterations)
             )
             if decryptedPassword?.count == 0 {
-                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.decryptedPinPasswordLength0)
+                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.Pin.decryptedPasswordLengthZero)
                 askIfUserWantsToResetPIN()
                 return
             }
@@ -325,8 +325,8 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
 
     private func askIfUserWantsToResetPIN() {
         let alert = UIAlertController(
-            title: LocalizationConstants.Authentication.pinValidationError,
-            message: LocalizationConstants.Authentication.pinValidationErrorMessage,
+            title: LocalizationConstants.Authentication.Pin.validationError,
+            message: LocalizationConstants.Authentication.Pin.validationErrorMessage,
             preferredStyle: .alert
         )
         alert.addAction(

--- a/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
@@ -1,0 +1,356 @@
+//
+//  AuthenticationCoordinator+Pin.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/30/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
+    func pinEntryController(
+        _ pinEntryController: PEPinEntryController!,
+        shouldAcceptPin pinInt: UInt,
+        callback: ((Bool) -> Void)!
+        ) {
+        let pin = Pin(code: pinInt)
+        self.lastEnteredPIN = pin
+
+        // Check if we have an internet connection
+        // This only checks if a network interface is up. All other errors (including timeouts)
+        // are handled by JavaScript callbacks in Wallet.m
+        guard Reachability.hasInternetConnection() else {
+            AlertViewPresenter.shared.showNoInternetConnectionAlert()
+            return
+        }
+
+        showVerifyingBusyView(withTimeout: 30)
+
+        let pinKey = BlockchainSettings.App.shared.pinKey
+        let pinString = pin.toString
+
+        // TODO: Handle touch ID
+        //        #ifdef ENABLE_TOUCH_ID
+        //        if (self.pinEntryViewController.verifyOptional) {
+        //            [KeychainItemWrapper setPINInKeychain:pin];
+        //        }
+        //        #endif
+
+        // TODO: migrate check for maintenance
+
+        //        dispatch_async(dispatch_get_main_queue(), ^{
+        //            [self checkForMaintenanceWithPinKey:pinKey pin:pin];
+        //        });
+
+        self.pinViewControllerCallback = callback
+    }
+
+    func pinEntryController(_ pinEntryController: PEPinEntryController!, changedPin pinInt: UInt) {
+        let pin = Pin(code: pinInt)
+        self.lastEnteredPIN = pin
+
+        guard WalletManager.shared.wallet.isInitialized() || WalletManager.shared.wallet.password != nil else {
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.cannotSavePinInvalidWalletState)
+            return
+        }
+
+        LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.verifying)
+
+        try? pin.save()
+    }
+
+    func pinEntryController(_ pinEntryController: PEPinEntryController!, willChangeToNewPin pinInt: UInt) {
+        let pin = Pin(code: pinInt)
+
+        // Check that the selected pin passes checks
+
+        guard pin.isValid else {
+            AlertViewPresenter.shared.standardNotify(
+                message: LocalizationConstants.Authentication.chooseAnotherPin,
+                title: LocalizationConstants.Errors.error
+            ) { [unowned self] _ in
+                self.reopenChangePin()
+            }
+            return
+        }
+
+        guard pin != self.lastEnteredPIN else {
+            AlertViewPresenter.shared.standardNotify(
+                message: LocalizationConstants.Authentication.newPinMustBeDifferent,
+                title: LocalizationConstants.Errors.error
+            ) { [unowned self] _ in
+                self.reopenChangePin()
+            }
+            return
+        }
+
+        guard !pin.isCommon else {
+            let alert = UIAlertController(
+                title: LocalizationConstants.Errors.warning,
+                message: LocalizationConstants.Authentication.pinCodeCommonMessage,
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: LocalizationConstants.continueString, style: .default))
+            alert.addAction(
+                UIAlertAction(title: LocalizationConstants.tryAgain, style: .cancel) {  [unowned self] _ in
+                    self.reopenChangePin()
+                }
+            )
+            pinEntryController.present(alert, animated: true)
+            return
+        }
+    }
+
+    func pinEntryControllerDidCancel(_ pinEntryController: PEPinEntryController!) {
+        print("Pin change cancelled!")
+        closePinEntryView(animated: true)
+    }
+
+    // MARK: - Private
+
+    private func reopenChangePin() {
+        closePinEntryView(animated: false)
+
+        guard let pinViewController = PEPinEntryController.pinCreate() else {
+            return
+        }
+
+        pinViewController.isNavigationBarHidden = true
+        pinViewController.pinDelegate = self
+
+        if BlockchainSettings.App.shared.isPinSet {
+            pinViewController.inSettings = true
+        }
+
+        UIApplication.shared.keyWindow?.rootViewController?.view.addSubview(pinViewController.view)
+
+        pinEntryViewController = pinViewController
+    }
+
+    private func showVerifyingBusyView(withTimeout seconds: Int) {
+        LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.verifying)
+
+        // TODO: this timeout approach should be deprecated in favor of checking actual success/error responses
+        if #available(iOS 10.0, *) {
+            loginTimeout = Timer.scheduledTimer(withTimeInterval: TimeInterval(seconds), repeats: false) { [weak self] _ in
+                self?.showLoginError()
+            }
+        } else {
+            loginTimeout = Timer.scheduledTimer(
+                timeInterval: TimeInterval(seconds),
+                target: self,
+                selector: #selector(showLoginError),
+                userInfo: nil,
+                repeats: false
+            )
+        }
+    }
+}
+
+extension AuthenticationCoordinator: WalletPinEntryDelegate {
+
+    func errorGetPinValueTimeout() {
+        showPinError(withMessage: LocalizationConstants.Errors.timedOut)
+    }
+
+    func errorGetPinEmptyResponse() {
+        showPinError(withMessage: LocalizationConstants.Authentication.incorrectPin)
+    }
+
+    func errorGetPinInvalidResponse() {
+        showPinError(withMessage: LocalizationConstants.Errors.invalidServerResponse)
+    }
+
+    func errorDidFailPutPin(errorMessage: String) {
+        LoadingViewPresenter.shared.hideBusyView()
+
+        AlertViewPresenter.shared.standardNotify(message: errorMessage)
+
+        reopenChangePin()
+    }
+
+    func putPinSuccess(response: PutPinResponse) {
+        LoadingViewPresenter.shared.hideBusyView()
+
+        guard let password = walletManager.wallet.password else {
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.cannotSavePinInvalidWalletState)
+            return
+        }
+
+        walletManager.wallet.isNew = false
+
+        guard response.error == nil else {
+            errorDidFailPutPin(errorMessage: response.error!)
+            return
+        }
+
+        guard response.isStatusCodeOk else {
+            let message = String(
+                format: LocalizationConstants.Errors.invalidStatusCodeReturned,
+                response.code ?? -1
+            )
+            errorDidFailPutPin(errorMessage: message)
+            return
+        }
+
+        guard response.key.count != 0 && response.value.count != 0 else {
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.pinResponseKeyOrValueLength0)
+            return
+        }
+
+        let inSettings = pinEntryViewController?.inSettings ?? false
+        if inSettings {
+            // TODO migrate this
+            // [self showSettings];
+        }
+
+        // Encrypt the wallet password with the random value
+        guard let encryptedPinPassword = walletManager.wallet.encrypt(
+            password,
+            password: response.value,
+            pbkdf2_iterations: Int32(Constants.Security.pinPBKDF2Iterations)
+        ) else {
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.pinEncryptedStringIsNil)
+            return
+        }
+
+        let appSettings = BlockchainSettings.App.shared
+        appSettings.encryptedPinPassword = encryptedPinPassword
+        appSettings.pinKey = response.key
+        appSettings.passwordPartHash = password.passwordPartHash
+
+        // Update your info to new pin code
+        closePinEntryView(animated: true)
+
+        if walletManager.wallet.isInitialized() && !inSettings {
+            AlertViewPresenter.shared.showMobileNoticeIfNeeded()
+        }
+
+        AppCoordinator.shared.showHdUpgradeViewIfNeeded()
+    }
+
+    func getPinSuccess(response: GetPinResponse) {
+        LoadingViewPresenter.shared.hideBusyView()
+
+        var pinSuccess = false
+
+        // Incorrect pin
+        if response.code == nil {
+            AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.incorrectPin)
+        } else if response.code == GetPinResponse.StatusCode.deleted.rawValue {
+            // Pin retry limit exceeded
+            AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.pinValidationCannotBeCompleted)
+            BlockchainSettings.App.shared.clearPin()
+            logout()
+            DispatchQueue.main.async { [weak self] in
+                guard let strongSelf = self else { return }
+                strongSelf.showPasswordModal()
+                strongSelf.closePinEntryView(animated: true)
+            }
+        } else if response.code == GetPinResponse.StatusCode.incorrect.rawValue {
+            let error = response.error ?? "PIN Code Incorrect. Unknown Error Message."
+            AlertViewPresenter.shared.standardNotify(message: error)
+        } else if response.code == GetPinResponse.StatusCode.success.rawValue {
+
+            // TODO handle touch ID
+            // #ifdef ENABLE_TOUCH_ID
+            // if (self.pinEntryViewController.verifyOptional) {
+            //     BlockchainSettings.sharedAppInstance.touchIDEnabled = YES;
+            //     [[NSUserDefaults standardUserDefaults] synchronize];
+            //     [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
+            //     [self showSettings];
+            //     return;
+            // }
+            // #endif
+
+            // This is for change PIN - verify the password first, then show the enter screens
+            if !(pinEntryViewController?.verifyOnly ?? false) {
+                pinViewControllerCallback?(true)
+                pinViewControllerCallback = nil
+                return
+            }
+
+            // Initial PIN setup ?
+            if response.pinDecryptionValue?.count == 0 {
+                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.pinResponseSuccessLength0)
+                return
+            }
+
+            let encryptedPinPassword = BlockchainSettings.App.shared.encryptedPinPassword!
+            let decryptedPassword = walletManager.wallet.decrypt(
+                encryptedPinPassword,
+                password: response.pinDecryptionValue,
+                pbkdf2_iterations: Int32(Constants.Security.pinPBKDF2Iterations)
+            )
+            if decryptedPassword?.count == 0 {
+                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.decryptedPinPasswordLength0)
+                askIfUserWantsToResetPIN()
+                return
+            }
+
+            let appSettings = BlockchainSettings.App.shared
+            if let guid = appSettings.guid,
+                let sharedKey = appSettings.sharedKey {
+                walletManager.wallet.load(withGuid: guid, sharedKey: sharedKey, password: decryptedPassword)
+            } else {
+                if appSettings.guid == nil {
+                    print("failed to retrieve GUID from Keychain")
+                }
+                if appSettings.sharedKey == nil {
+                    print("failed to retrieve sharedKey from Keychain")
+                }
+                if appSettings.guid != nil && appSettings.sharedKey == nil {
+                    print("!!! Failed to retrieve sharedKey from Keychain but was able to retreive GUID ???")
+                }
+                AlertViewPresenter.shared.showKeychainReadError()
+            }
+
+            closePinEntryView(animated: true)
+            pinSuccess = true
+        } else {
+            askIfUserWantsToResetPIN()
+        }
+
+        pinViewControllerCallback?(pinSuccess)
+        pinViewControllerCallback = nil
+
+        // TODO handle touch ID
+//        #ifdef ENABLE_TOUCH_ID
+//        if (!pinSuccess && self.pinEntryViewController.verifyOptional) {
+//            [KeychainItemWrapper removePinFromKeychain];
+//        }
+//        #endif
+    }
+
+    private func askIfUserWantsToResetPIN() {
+        let alert = UIAlertController(
+            title: LocalizationConstants.Authentication.pinValidationError,
+            message: LocalizationConstants.Authentication.pinValidationErrorMessage,
+            preferredStyle: .alert
+        )
+        alert.addAction(
+            UIAlertAction(title: LocalizationConstants.Authentication.enterPassword, style: .cancel) { [unowned self] _ in
+                self.closePinEntryView(animated: true)
+                self.showPasswordModal()
+            }
+        )
+        alert.addAction(
+            UIAlertAction(title: LocalizationConstants.Authentication.retryValidation, style: .default) { [unowned self] _ in
+                self.pinEntryController(
+                    self.pinEntryViewController!,
+                    shouldAcceptPin: self.lastEnteredPIN!.pinCode,
+                    callback: self.pinViewControllerCallback
+                )
+            }
+        )
+        UIApplication.shared.keyWindow?.rootViewController?.topMostViewController?.present(alert, animated: true)
+    }
+
+    private func showPinError(withMessage message: String) {
+        AlertViewPresenter.shared.standardNotify(message: message, title: LocalizationConstants.Errors.error) { [unowned self] _ in
+            LoadingViewPresenter.shared.hideBusyView()
+            self.pinEntryViewController?.reset()
+        }
+    }
+}

--- a/Blockchain/Authentication/Models/AuthenticationError.swift
+++ b/Blockchain/Authentication/Models/AuthenticationError.swift
@@ -19,6 +19,7 @@ internal struct AuthenticationError {
         case noPassword
         case errorDecryptingWallet
         case invalidSharedKey
+        case failedToLoadWallet
         case unknown
     }
 

--- a/Blockchain/BCCreateWalletView.m
+++ b/Blockchain/BCCreateWalletView.m
@@ -230,7 +230,7 @@
     if ([message isEqualToString:@""]) {
         [AlertViewPresenter.sharedInstance showNoInternetConnectionAlert];
     } else if ([message isEqualToString:ERROR_TIMEOUT_REQUEST]){
-        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_TIMED_OUT title:BC_STRING_ERROR handler: nil];
+        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:LocalizationConstantsObjcBridge.timedOut title:BC_STRING_ERROR handler: nil];
     } else if ([message isEqualToString:ERROR_FAILED_NETWORK_REQUEST] || [message containsString:ERROR_TIMEOUT_ERROR] || [[message stringByReplacingOccurrencesOfString:@" " withString:@""] containsString:ERROR_STATUS_ZERO]){
         dispatch_after(DELAY_KEYBOARD_DISMISSAL, dispatch_get_main_queue(), ^{
             [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_REQUEST_FAILED_PLEASE_CHECK_INTERNET_CONNECTION title:BC_STRING_ERROR handler: nil];

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -679,8 +679,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 #define PIN_API_STATUS_CODE_DELETED 1
 #define PIN_API_STATUS_PIN_INCORRECT 2
 #define PIN_API_STATUS_OK 0
-#define PIN_API_STATUS_UNKNOWN 3
-#define PIN_API_STATUS_DUPLICATE_KEY 4
 
 // Most common pin codes: http://datagenetics.com/blog/september32012/index.html
 
@@ -693,8 +691,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 
 #define DELAY_KEYBOARD_DISMISSAL 0.6f
 #define DELAY_GET_HISTORY_BACKUP 3.0f
-
-#define PIN_PBKDF2_ITERATIONS 1 // This does not need to be large because the key is already 256 bits
 
 #define BTC_LIMIT_IN_SATOSHI 21e14 // 21,000,000 (Total possible Bitcoins) * 100,000,000 (Satoshi)
 #define ETH_DECIMAL_LIMIT 18

--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -74,6 +74,9 @@ struct Constants {
     struct Schemas {
         static let mail = "message://"
     }
+    struct Security {
+        static let pinPBKDF2Iterations = 1 // This does not need to be large because the key is already 256 bits
+    }
     struct Time {
         static let securityReminderModalTimeInterval: TimeInterval = 60 * 60 * 24 * 30 // Seconds in thirty days
     }

--- a/Blockchain/Extensions/Strings.swift
+++ b/Blockchain/Extensions/Strings.swift
@@ -1,0 +1,19 @@
+//
+//  Strings.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/30/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+
+    /// Returns the first 5 characters of the SHA256 hash of this string
+    var passwordPartHash: String? {
+        guard let hashedString = NSString(string: self).sha256() else { return nil }
+        let endIndex = hashedString.index(hashedString.startIndex, offsetBy: min(self.count, 5))
+        return String(hashedString[..<endIndex])
+    }
+}

--- a/Blockchain/LocalizationConstants.h
+++ b/Blockchain/LocalizationConstants.h
@@ -112,7 +112,6 @@
 
 #define BC_STRING_ERROR NSLocalizedString(@"Error", nil)
 #define BC_STRING_INVALID_AUTHENTICATION_TYPE NSLocalizedString(@"Invalid two-factor authentication type", nil)
-#define BC_STRING_ERROR_LOADING_WALLET_IDENTIFIER_FROM_KEYCHAIN NSLocalizedString(@"An error was encountered retrieving your wallet identifier from the keychain. Please close the application and try again.", nil)
 
 #define BC_STRING_INFORMATION NSLocalizedString(@"Information", nil)
 #define BC_STRING_LEARN_MORE NSLocalizedString(@"Learn More", nil)

--- a/Blockchain/LocalizationConstants.h
+++ b/Blockchain/LocalizationConstants.h
@@ -131,7 +131,6 @@
 #define BC_STRING_OK NSLocalizedString(@"OK", nil)
 #define BC_STRING_OPEN_MAIL_APP NSLocalizedString(@"Open Mail App", nil)
 #define BC_STRING_CANNOT_OPEN_MAIL_APP NSLocalizedString(@"Cannot open Mail App", nil)
-#define BC_STRING_FAILED_TO_LOAD_WALLET_TITLE NSLocalizedString(@"Failed To Load Wallet", nil)
 
 #define BC_STRING_FAILED_VALIDATION_CERTIFICATE_TITLE NSLocalizedString(@"Failed to validate server certificate", nil)
 #define BC_STRING_FAILED_VALIDATION_CERTIFICATE_MESSAGE NSLocalizedString(@"A connection cannot be established because the server certificate could not be validated. Please check your network settings and ensure that you are using a secure connection.", nil)
@@ -139,12 +138,9 @@
 
 #define BC_STRING_REQUEST_FAILED_PLEASE_CHECK_INTERNET_CONNECTION NSLocalizedString(@"Request failed. Please check your internet connection.", nil)
 #define BC_STRING_SOMETHING_WENT_WRONG_CHECK_INTERNET_CONNECTION NSLocalizedString(@"An error occurred while updating your spendable balance. Please check your internet connection and try again.", nil)
-#define BC_STRING_TIMED_OUT NSLocalizedString(@"Connection timed out. Please check your internet connection.", nil)
 #define BC_STRING_EMPTY_RESPONSE NSLocalizedString(@"Empty response from server.", nil)
-#define BC_STRING_INVALID_RESPONSE NSLocalizedString(@"Invalid server response. Please check your internet connection.", nil)
 #define BC_STRING_MAINTENANCE_MODE NSLocalizedString(@"Blockchain is currently down for maintenance. Please try again later.", nil)
 
-#define BC_STRING_FAILED_TO_LOAD_WALLET_DETAIL NSLocalizedString(@"An error was encountered loading your wallet. You may be offline or Blockchain is experiencing difficulties. Please close the application and try again later or re-pair your device.", nil)
 #define BC_STRING_FORGET_WALLET NSLocalizedString(@"Forget Wallet", nil)
 
 #define BC_STRING_CLOSE_APP NSLocalizedString(@"Close App", nil)
@@ -188,24 +184,11 @@
 #define BC_STRING_HOW_WOULD_YOU_LIKE_TO_PAIR NSLocalizedString(@"How would you like to pair?", nil)
 #define BC_STRING_MANUALLY NSLocalizedString(@"Manually", nil)
 #define BC_STRING_AUTOMATICALLY NSLocalizedString(@"Automatically", nil)
-#define BC_STRING_PIN_VALIDATION_ERROR NSLocalizedString(@"PIN Validation Error", nil)
 #define BC_PIN_NO_MATCH NSLocalizedString(@"PINs do not match", nil)
-
-#define BC_STRING_PIN_VALIDATION_ERROR_DETAIL NSLocalizedString(@"An error occurred validating your PIN code with the remote server. You may be offline or Blockchain may be experiencing difficulties. Would you like retry validation or instead enter your password manually?", nil)
-#define BC_STRING_ENTER_PASSWORD NSLocalizedString(@"Enter Password", nil)
 #define BC_STRING_ENTER_PIN NSLocalizedString(@"Enter PIN", nil)
 #define BC_STRING_PLEASE_ENTER_PIN NSLocalizedString(@"Please enter your PIN", nil)
 #define BC_STRING_PLEASE_ENTER_NEW_PIN NSLocalizedString(@"Please enter a new PIN", nil)
 #define BC_STRING_CONFIRM_PIN NSLocalizedString(@"Confirm your PIN", nil)
-#define BC_STRING_INCORRECT_PIN_RETRY NSLocalizedString(@"Incorrect PIN. Please retry.", nil)
-#define RETRY_VALIDATION NSLocalizedString(@"Retry Validation", nil)
-#define BC_STRING_PIN_VALIDATION_CANNOT_BE_COMPLETED NSLocalizedString(@"PIN Validation cannot be completed. Please enter your wallet password manually.", nil)
-#define BC_STRING_PIN_RESPONSE_OBJECT_SUCCESS_LENGTH_0 NSLocalizedString(@"PIN Response Object success length 0", nil)
-#define BC_STRING_DECRYPTED_PIN_PASSWORD_LENGTH_0 NSLocalizedString(@"Decrypted PIN Password length 0", nil)
-#define BC_STRING_CANNOT_SAVE_PIN_CODE_WHILE NSLocalizedString(@"Cannot save PIN Code while wallet is not initialized or password is null", nil)
-#define BC_STRING_INVALID_STATUS_CODE_RETURNED NSLocalizedString(@"Invalid Status Code Returned %@", nil)
-#define BC_STRING_PIN_RESPONSE_OBJECT_KEY_OR_VALUE_LENGTH_0 NSLocalizedString(@"PIN Response Object key or value length 0", nil)
-#define BC_STRING_PIN_ENCRYPTED_STRING_IS_NIL NSLocalizedString(@"PIN Encrypted String is nil", nil)
 #define BC_STRING_WARNING_TITLE NSLocalizedString(@"Warning", nil)
 
 #define BC_STRING_PAYMENT_REQUEST_BITCOIN_ARGUMENT_ARGUMENT NSLocalizedString(@"Please send %@ to bitcoin address.\n%@", nil)

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -47,6 +47,9 @@ struct LocalizationConstants {
         static let unsafeDeviceWarningMessage = NSLocalizedString("Your device appears to be jailbroken. The security of your wallet may be compromised.", comment: "")
         static let noInternetConnection = NSLocalizedString("No internet connection.", comment: "")
         static let warning = NSLocalizedString("Warning", comment: "")
+        static let timedOut = NSLocalizedString("Connection timed out. Please check your internet connection.", comment: "")
+        static let invalidServerResponse = NSLocalizedString("Invalid server response. Please check your internet connection.", comment: "")
+        static let invalidStatusCodeReturned = NSLocalizedString("Invalid Status Code Returned %@", comment: "")
     }
 
     struct Authentication {
@@ -63,6 +66,22 @@ struct LocalizationConstants {
         static let passwordRequired = NSLocalizedString("Password Required", comment: "")
         static let downloadingWallet = NSLocalizedString("Downloading Wallet", comment: "")
         static let noPasswordEntered = NSLocalizedString("No Password Entered", comment: "")
+        static let failedToLoadWallet = NSLocalizedString("Failed To Load Wallet", comment: "")
+        static let failedToLoadWalletDetail = NSLocalizedString("An error was encountered loading your wallet. You may be offline or Blockchain is experiencing difficulties. Please close the application and try again later or re-pair your device.", comment: "")
+        static let forgetWallet = NSLocalizedString("Forget Wallet", comment: "")
+        static let forgetWalletDetail = NSLocalizedString("This will erase all wallet data on this device. Please confirm you have your wallet information saved elsewhere otherwise any bitcoin in this wallet will be inaccessible!!", comment: "")
+        static let incorrectPin = NSLocalizedString("Incorrect PIN. Please retry.", comment: "")
+        static let cannotSavePinInvalidWalletState = NSLocalizedString("Cannot save PIN Code while wallet is not initialized or password is null", comment: "")
+        static let pinResponseKeyOrValueLength0 = NSLocalizedString("PIN Response Object key or value length 0", comment: "")
+        static let pinEncryptedStringIsNil = NSLocalizedString("PIN Encrypted String is nil", comment: "")
+        static let pinValidationCannotBeCompleted = NSLocalizedString("PIN Validation cannot be completed. Please enter your wallet password manually.", comment: "")
+        static let pinCodeIncorrectUnknownError = NSLocalizedString("PIN Code Incorrect. Unknown Error Message.", comment: "")
+        static let pinResponseSuccessLength0 = NSLocalizedString("PIN Response Object success length 0", comment: "")
+        static let decryptedPinPasswordLength0 = NSLocalizedString("Decrypted PIN Password length 0", comment: "")
+        static let pinValidationError = NSLocalizedString("PIN Validation Error", comment: "")
+        static let pinValidationErrorMessage = NSLocalizedString("An error occurred validating your PIN code with the remote server. You may be offline or Blockchain may be experiencing difficulties. Would you like retry validation or instead enter your password manually?", comment: "")
+        static let enterPassword = NSLocalizedString("Enter Password", comment: "")
+        static let retryValidation = NSLocalizedString("Retry Validation", comment: "")
     }
 
     struct Onboarding {
@@ -86,4 +105,8 @@ struct LocalizationConstants {
     @objc class func passwordRequired() -> String { return LocalizationConstants.Authentication.passwordRequired }
 
     @objc class func downloadingWallet() -> String { return LocalizationConstants.Authentication.downloadingWallet }
+
+    @objc class func timedOut() -> String { return LocalizationConstants.Errors.timedOut }
+
+    @objc class func incorrectPin() -> String { return LocalizationConstants.Authentication.incorrectPin }
 }

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -50,6 +50,7 @@ struct LocalizationConstants {
         static let timedOut = NSLocalizedString("Connection timed out. Please check your internet connection.", comment: "")
         static let invalidServerResponse = NSLocalizedString("Invalid server response. Please check your internet connection.", comment: "")
         static let invalidStatusCodeReturned = NSLocalizedString("Invalid Status Code Returned %@", comment: "")
+        static let errorLoadingWalletIdentifierFromKeychain = NSLocalizedString("An error was encountered retrieving your wallet identifier from the keychain. Please close the application and try again.", comment: "")
     }
 
     struct Authentication {

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -71,18 +71,21 @@ struct LocalizationConstants {
         static let failedToLoadWalletDetail = NSLocalizedString("An error was encountered loading your wallet. You may be offline or Blockchain is experiencing difficulties. Please close the application and try again later or re-pair your device.", comment: "")
         static let forgetWallet = NSLocalizedString("Forget Wallet", comment: "")
         static let forgetWalletDetail = NSLocalizedString("This will erase all wallet data on this device. Please confirm you have your wallet information saved elsewhere otherwise any bitcoin in this wallet will be inaccessible!!", comment: "")
-        static let incorrectPin = NSLocalizedString("Incorrect PIN. Please retry.", comment: "")
-        static let cannotSavePinInvalidWalletState = NSLocalizedString("Cannot save PIN Code while wallet is not initialized or password is null", comment: "")
-        static let pinResponseKeyOrValueLength0 = NSLocalizedString("PIN Response Object key or value length 0", comment: "")
-        static let pinEncryptedStringIsNil = NSLocalizedString("PIN Encrypted String is nil", comment: "")
-        static let pinValidationCannotBeCompleted = NSLocalizedString("PIN Validation cannot be completed. Please enter your wallet password manually.", comment: "")
-        static let pinCodeIncorrectUnknownError = NSLocalizedString("PIN Code Incorrect. Unknown Error Message.", comment: "")
-        static let pinResponseSuccessLength0 = NSLocalizedString("PIN Response Object success length 0", comment: "")
-        static let decryptedPinPasswordLength0 = NSLocalizedString("Decrypted PIN Password length 0", comment: "")
-        static let pinValidationError = NSLocalizedString("PIN Validation Error", comment: "")
-        static let pinValidationErrorMessage = NSLocalizedString("An error occurred validating your PIN code with the remote server. You may be offline or Blockchain may be experiencing difficulties. Would you like retry validation or instead enter your password manually?", comment: "")
         static let enterPassword = NSLocalizedString("Enter Password", comment: "")
         static let retryValidation = NSLocalizedString("Retry Validation", comment: "")
+
+        struct Pin {
+            static let incorrect = NSLocalizedString("Incorrect PIN. Please retry.", comment: "")
+            static let cannotSaveInvalidWalletState = NSLocalizedString("Cannot save PIN Code while wallet is not initialized or password is null", comment: "")
+            static let responseKeyOrValueLengthZero = NSLocalizedString("PIN Response Object key or value length 0", comment: "")
+            static let encryptedStringIsNil = NSLocalizedString("PIN Encrypted String is nil", comment: "")
+            static let validationCannotBeCompleted = NSLocalizedString("PIN Validation cannot be completed. Please enter your wallet password manually.", comment: "")
+            static let incorrectUnknownError = NSLocalizedString("PIN Code Incorrect. Unknown Error Message.", comment: "")
+            static let responseSuccessLengthZero = NSLocalizedString("PIN Response Object success length 0", comment: "")
+            static let decryptedPasswordLengthZero = NSLocalizedString("Decrypted PIN Password length 0", comment: "")
+            static let validationError = NSLocalizedString("PIN Validation Error", comment: "")
+            static let validationErrorMessage = NSLocalizedString("An error occurred validating your PIN code with the remote server. You may be offline or Blockchain may be experiencing difficulties. Would you like retry validation or instead enter your password manually?", comment: "")
+        }
     }
 
     struct Onboarding {
@@ -109,5 +112,5 @@ struct LocalizationConstants {
 
     @objc class func timedOut() -> String { return LocalizationConstants.Errors.timedOut }
 
-    @objc class func incorrectPin() -> String { return LocalizationConstants.Authentication.incorrectPin }
+    @objc class func incorrectPin() -> String { return LocalizationConstants.Authentication.Pin.incorrect }
 }

--- a/Blockchain/Pin/Pin.swift
+++ b/Blockchain/Pin/Pin.swift
@@ -14,7 +14,7 @@ struct SavePinError: Error {}
 class Pin {
     static let Invalid = Pin(code: 0000)
 
-    private var pinCode: UInt
+    private(set) var pinCode: UInt
 
     /// Checks if this pin is a valid
     var isValid: Bool {

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -126,7 +126,7 @@
 
 
 //- (void)showWelcome;
-- (void)logout;
+//- (void)logout;
 //- (void)forgetWallet;
 //- (void)showPasswordModal;
 

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -247,24 +247,24 @@ void (^secondPasswordSuccess)(NSString *);
 //    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
 }
 
-- (void)showPinScreen
-{
-    BlockchainSettings.sharedAppInstance.hasSeenAllCards = YES;
-    BlockchainSettings.sharedAppInstance.shouldHideAllCards = YES;
-
-    if ([BlockchainSettings sharedAppInstance].isPinSet) {
-        [self showPinModalAsView:YES];
-        // [rootService authenticateWithBiometrics];
-    } else {
-        [self checkForMaintenance];
-        [self showPasswordModal];
-        [[AlertViewPresenter sharedInstance] checkAndWarnOnJailbrokenPhones];
-    }
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reloadSideMenu) name:NOTIFICATION_KEY_GET_ACCOUNT_INFO_SUCCESS object:nil];
-
-    [self migratePasswordAndPinFromNSUserDefaults];
-}
+//- (void)showPinScreen
+//{
+//    BlockchainSettings.sharedAppInstance.hasSeenAllCards = YES;
+//    BlockchainSettings.sharedAppInstance.shouldHideAllCards = YES;
+//
+//    if ([BlockchainSettings sharedAppInstance].isPinSet) {
+//        [self showPinModalAsView:YES];
+//        // [rootService authenticateWithBiometrics];
+//    } else {
+//        [self checkForMaintenance];
+//        [self showPasswordModal];
+//        [[AlertViewPresenter sharedInstance] checkAndWarnOnJailbrokenPhones];
+//    }
+//
+//    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reloadSideMenu) name:NOTIFICATION_KEY_GET_ACCOUNT_INFO_SUCCESS object:nil];
+//
+//    [self migratePasswordAndPinFromNSUserDefaults];
+//}
 
 - (void)applicationWillResignActive:(UIApplication *)application
 {
@@ -948,26 +948,26 @@ void (^secondPasswordSuccess)(NSString *);
         return;
     }
 
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:BC_STRING_FAILED_TO_LOAD_WALLET_TITLE message:[NSString stringWithFormat:BC_STRING_FAILED_TO_LOAD_WALLET_DETAIL] preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_FORGET_WALLET style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        UIAlertController *forgetWalletAlert = [UIAlertController alertControllerWithTitle:BC_STRING_WARNING message:BC_STRING_FORGET_WALLET_DETAILS preferredStyle:UIAlertControllerStyleAlert];
-        [forgetWalletAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-            [self walletFailedToLoad];
-        }]];
-        [forgetWalletAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_FORGET_WALLET style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-            [WalletManager.sharedInstance forgetWallet];
-            [self showWelcomeScreen];
-        }]];
-        [_window.rootViewController presentViewController:forgetWalletAlert animated:YES completion:nil];
-    }]];
-
-    [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_CLOSE_APP style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-        UIApplication *app = [UIApplication sharedApplication];
-
-        [app performSelector:@selector(suspend)];
-    }]];
-
-    [_window.rootViewController presentViewController:alert animated:YES completion:nil];
+//    UIAlertController *alert = [UIAlertController alertControllerWithTitle:BC_STRING_FAILED_TO_LOAD_WALLET_TITLE message:[NSString stringWithFormat:BC_STRING_FAILED_TO_LOAD_WALLET_DETAIL] preferredStyle:UIAlertControllerStyleAlert];
+//    [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_FORGET_WALLET style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+//        UIAlertController *forgetWalletAlert = [UIAlertController alertControllerWithTitle:BC_STRING_WARNING message:BC_STRING_FORGET_WALLET_DETAILS preferredStyle:UIAlertControllerStyleAlert];
+//        [forgetWalletAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+//            [self walletFailedToLoad];
+//        }]];
+//        [forgetWalletAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_FORGET_WALLET style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+//            [WalletManager.sharedInstance forgetWallet];
+//            [self showWelcomeScreen];
+//        }]];
+//        [_window.rootViewController presentViewController:forgetWalletAlert animated:YES completion:nil];
+//    }]];
+//
+//    [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_CLOSE_APP style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+//        UIApplication *app = [UIApplication sharedApplication];
+//
+//        [app performSelector:@selector(suspend)];
+//    }]];
+//
+//    [_window.rootViewController presentViewController:alert animated:YES completion:nil];
 }
 //
 //- (void)walletDidDecrypt
@@ -3355,181 +3355,181 @@ void (^secondPasswordSuccess)(NSString *);
 //    self.pinViewControllerCallback = callback;
 }
 
-- (void)showPinErrorWithMessage:(NSString *)message
-{
-    DLog(@"Pin error: %@", message);
+//- (void)showPinErrorWithMessage:(NSString *)message
+//{
+//    DLog(@"Pin error: %@", message);
+//
+//    UIAlertController *alert = [UIAlertController alertControllerWithTitle:BC_STRING_ERROR message:message preferredStyle:UIAlertControllerStyleAlert];
+//    [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+//        // Reset the pin entry field
+//        [self hideBusyView];
+//        [self.pinEntryViewController reset];
+//    }]];
+//
+//    UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
+//    [topViewController presentViewController:alert animated:YES completion:nil];
+//}
+//
+//- (void)askIfUserWantsToResetPIN
+//{
+//    UIAlertController *alert = [UIAlertController alertControllerWithTitle:BC_STRING_PIN_VALIDATION_ERROR message:BC_STRING_PIN_VALIDATION_ERROR_DETAIL preferredStyle:UIAlertControllerStyleAlert];
+//    [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_ENTER_PASSWORD style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+//        [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
+//        [self showPasswordModal];
+//    }]];
+//    [alert addAction:[UIAlertAction actionWithTitle:RETRY_VALIDATION style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+//        [self pinEntryController:self.pinEntryViewController shouldAcceptPin:self.lastEnteredPIN callback:self.pinViewControllerCallback];
+//    }]];
+//
+//    [self.window.rootViewController presentViewController:alert animated:YES completion:nil];
+//}
+//
+//- (void)didFailGetPinTimeout
+//{
+//    [self showPinErrorWithMessage:BC_STRING_TIMED_OUT];
+//}
+//
+//- (void)didFailGetPinNoResponse
+//{
+//    [self showPinErrorWithMessage:BC_STRING_INCORRECT_PIN_RETRY];
+//}
+//
+//- (void)didFailGetPinInvalidResponse
+//{
+//    [self showPinErrorWithMessage:BC_STRING_INVALID_RESPONSE];
+//}
+//
+//- (void)didGetPinResponse:(NSDictionary*)dictionary
+//{
+//    [self hideBusyView];
+//
+//    NSNumber * code = [dictionary objectForKey:DICTIONARY_KEY_CODE]; //This is a status code from the server
+//    NSString * error = [dictionary objectForKey:DICTIONARY_KEY_ERROR]; //This is an error string from the server or nil
+//    NSString * success = [dictionary objectForKey:DICTIONARY_KEY_SUCCESS]; //The PIN decryption value from the server
+//    NSString * encryptedPINPassword = [BlockchainSettings sharedAppInstance].encryptedPinPassword;
+//
+//    BOOL pinSuccess = FALSE;
+//
+//    // Incorrect pin
+//    if (code == nil) {
+//        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:LocalizationConstantsObjcBridge.incorrectPin title:BC_STRING_ERROR handler: nil];
+//    }
+//    // Pin retry limit exceeded
+//    else if ([code intValue] == PIN_API_STATUS_CODE_DELETED) {
+//
+//        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_PIN_VALIDATION_CANNOT_BE_COMPLETED title:BC_STRING_ERROR handler: nil];
+//
+//        [self clearPin];
+//
+//        [self logout];
+//
+//        dispatch_async(dispatch_get_main_queue(), ^{
+//            [self showPasswordModal];
+//            [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
+//        });
+//
+//    }
+//    // Incorrect pin
+//    else if ([code integerValue] == PIN_API_STATUS_PIN_INCORRECT) {
+//
+//        if (error == nil) {
+//            error = @"PIN Code Incorrect. Unknown Error Message.";
+//        }
+//
+//        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:error title:BC_STRING_ERROR handler: nil];
+//    }
+//    // Pin was accepted
+//    else if ([code intValue] == PIN_API_STATUS_OK) {
+//
+//#ifdef ENABLE_TOUCH_ID
+//        if (self.pinEntryViewController.verifyOptional) {
+//            BlockchainSettings.sharedAppInstance.touchIDEnabled = YES;
+//            [[NSUserDefaults standardUserDefaults] synchronize];
+//            [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
+//            [self showSettings];
+//            return;
+//        }
+//#endif
+//        // This is for change PIN - verify the password first, then show the enter screens
+//        if (self.pinEntryViewController.verifyOnly == NO) {
+//            if (self.pinViewControllerCallback) {
+//                self.pinViewControllerCallback(YES);
+//                self.pinViewControllerCallback = nil;
+//            }
+//
+//            return;
+//        }
+//
+//        // Initial PIN setup ?
+//        if ([success length] == 0) {
+//            [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_PIN_RESPONSE_OBJECT_SUCCESS_LENGTH_0 title:BC_STRING_ERROR handler: nil];
+//            [self askIfUserWantsToResetPIN];
+//            return;
+//        }
+//
+//        NSString *decrypted = [WalletManager.sharedInstance.wallet decrypt:encryptedPINPassword password:success pbkdf2_iterations:PIN_PBKDF2_ITERATIONS];
+//
+//        if ([decrypted length] == 0) {
+//            [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_DECRYPTED_PIN_PASSWORD_LENGTH_0 title:BC_STRING_ERROR handler: nil];
+//            [self askIfUserWantsToResetPIN];
+//            return;
+//        }
+//
+//        NSString *guid = [KeychainItemWrapper guid];
+//        NSString *sharedKey = [KeychainItemWrapper sharedKey];
+//
+//        if (guid && sharedKey) {
+//            [WalletManager.sharedInstance.wallet loadWalletWithGuid:guid sharedKey:sharedKey password:decrypted];
+//        } else {
+//
+//            if (!guid) {
+//                DLog(@"failed to retrieve GUID from Keychain");
+//            }
+//
+//            if (!sharedKey) {
+//                DLog(@"failed to retrieve sharedKey from Keychain");
+//            }
+//
+//            if (guid && !sharedKey) {
+//                DLog(@"!!! Failed to retrieve sharedKey from Keychain but was able to retreive GUID ???");
+//            }
+//
+//            [AlertViewPresenter.sharedInstance showKeychainReadError];
+//        }
+//
+//        [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
+//
+//        pinSuccess = TRUE;
+//
+//    }
+//    // Unknown error
+//    else {
+//        [self askIfUserWantsToResetPIN];
+//    }
+//
+//    if (self.pinViewControllerCallback) {
+//        self.pinViewControllerCallback(pinSuccess);
+//        self.pinViewControllerCallback = nil;
+//    }
+//
+//#ifdef ENABLE_TOUCH_ID
+//    if (!pinSuccess && self.pinEntryViewController.verifyOptional) {
+//        [KeychainItemWrapper removePinFromKeychain];
+//    }
+//#endif
+//}
+//
+//- (void)didFailPutPin:(NSString*)value
+//{
+//    [self hideBusyView];
+//
+//    [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:value title:BC_STRING_ERROR handler: nil];
+//
+//    [self reopenChangePIN];
+//}
 
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:BC_STRING_ERROR message:message preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-        // Reset the pin entry field
-        [self hideBusyView];
-        [self.pinEntryViewController reset];
-    }]];
-
-    UIViewController *topViewController = UIApplication.sharedApplication.keyWindow.rootViewController.topMostViewController;
-    [topViewController presentViewController:alert animated:YES completion:nil];
-}
-
-- (void)askIfUserWantsToResetPIN
-{
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:BC_STRING_PIN_VALIDATION_ERROR message:BC_STRING_PIN_VALIDATION_ERROR_DETAIL preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:BC_STRING_ENTER_PASSWORD style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-        [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
-        [self showPasswordModal];
-    }]];
-    [alert addAction:[UIAlertAction actionWithTitle:RETRY_VALIDATION style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        [self pinEntryController:self.pinEntryViewController shouldAcceptPin:self.lastEnteredPIN callback:self.pinViewControllerCallback];
-    }]];
-
-    [self.window.rootViewController presentViewController:alert animated:YES completion:nil];
-}
-
-- (void)didFailGetPinTimeout
-{
-    [self showPinErrorWithMessage:BC_STRING_TIMED_OUT];
-}
-
-- (void)didFailGetPinNoResponse
-{
-    [self showPinErrorWithMessage:BC_STRING_INCORRECT_PIN_RETRY];
-}
-
-- (void)didFailGetPinInvalidResponse
-{
-    [self showPinErrorWithMessage:BC_STRING_INVALID_RESPONSE];
-}
-
-- (void)didGetPinResponse:(NSDictionary*)dictionary
-{
-    [self hideBusyView];
-
-    NSNumber * code = [dictionary objectForKey:DICTIONARY_KEY_CODE]; //This is a status code from the server
-    NSString * error = [dictionary objectForKey:DICTIONARY_KEY_ERROR]; //This is an error string from the server or nil
-    NSString * success = [dictionary objectForKey:DICTIONARY_KEY_SUCCESS]; //The PIN decryption value from the server
-    NSString * encryptedPINPassword = [BlockchainSettings sharedAppInstance].encryptedPinPassword;
-
-    BOOL pinSuccess = FALSE;
-
-    // Incorrect pin
-    if (code == nil) {
-        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_INCORRECT_PIN_RETRY title:BC_STRING_ERROR handler: nil];
-    }
-    // Pin retry limit exceeded
-    else if ([code intValue] == PIN_API_STATUS_CODE_DELETED) {
-
-        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_PIN_VALIDATION_CANNOT_BE_COMPLETED title:BC_STRING_ERROR handler: nil];
-
-        [self clearPin];
-
-        [self logout];
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self showPasswordModal];
-            [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
-        });
-
-    }
-    // Incorrect pin
-    else if ([code integerValue] == PIN_API_STATUS_PIN_INCORRECT) {
-
-        if (error == nil) {
-            error = @"PIN Code Incorrect. Unknown Error Message.";
-        }
-
-        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:error title:BC_STRING_ERROR handler: nil];
-    }
-    // Pin was accepted
-    else if ([code intValue] == PIN_API_STATUS_OK) {
-
-#ifdef ENABLE_TOUCH_ID
-        if (self.pinEntryViewController.verifyOptional) {
-            BlockchainSettings.sharedAppInstance.touchIDEnabled = YES;
-            [[NSUserDefaults standardUserDefaults] synchronize];
-            [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
-            [self showSettings];
-            return;
-        }
-#endif
-        // This is for change PIN - verify the password first, then show the enter screens
-        if (self.pinEntryViewController.verifyOnly == NO) {
-            if (self.pinViewControllerCallback) {
-                self.pinViewControllerCallback(YES);
-                self.pinViewControllerCallback = nil;
-            }
-
-            return;
-        }
-
-        // Initial PIN setup ?
-        if ([success length] == 0) {
-            [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_PIN_RESPONSE_OBJECT_SUCCESS_LENGTH_0 title:BC_STRING_ERROR handler: nil];
-            [self askIfUserWantsToResetPIN];
-            return;
-        }
-
-        NSString *decrypted = [WalletManager.sharedInstance.wallet decrypt:encryptedPINPassword password:success pbkdf2_iterations:PIN_PBKDF2_ITERATIONS];
-
-        if ([decrypted length] == 0) {
-            [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_DECRYPTED_PIN_PASSWORD_LENGTH_0 title:BC_STRING_ERROR handler: nil];
-            [self askIfUserWantsToResetPIN];
-            return;
-        }
-
-        NSString *guid = [KeychainItemWrapper guid];
-        NSString *sharedKey = [KeychainItemWrapper sharedKey];
-
-        if (guid && sharedKey) {
-            [WalletManager.sharedInstance.wallet loadWalletWithGuid:guid sharedKey:sharedKey password:decrypted];
-        } else {
-
-            if (!guid) {
-                DLog(@"failed to retrieve GUID from Keychain");
-            }
-
-            if (!sharedKey) {
-                DLog(@"failed to retrieve sharedKey from Keychain");
-            }
-
-            if (guid && !sharedKey) {
-                DLog(@"!!! Failed to retrieve sharedKey from Keychain but was able to retreive GUID ???");
-            }
-
-            [AlertViewPresenter.sharedInstance showKeychainReadError];
-        }
-
-        [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
-
-        pinSuccess = TRUE;
-
-    }
-    // Unknown error
-    else {
-        [self askIfUserWantsToResetPIN];
-    }
-
-    if (self.pinViewControllerCallback) {
-        self.pinViewControllerCallback(pinSuccess);
-        self.pinViewControllerCallback = nil;
-    }
-
-#ifdef ENABLE_TOUCH_ID
-    if (!pinSuccess && self.pinEntryViewController.verifyOptional) {
-        [KeychainItemWrapper removePinFromKeychain];
-    }
-#endif
-}
-
-- (void)didFailPutPin:(NSString*)value
-{
-    [self hideBusyView];
-
-    [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:value title:BC_STRING_ERROR handler: nil];
-
-    [self reopenChangePIN];
-}
-
-- (void)reopenChangePIN
-{
+//- (void)reopenChangePIN
+//{
 //    [AuthenticationCoordinator.shared closePinEntryModalWithAnimated:NO];
 //
 //    // Show the pin modal to enter a pin again
@@ -3542,64 +3542,64 @@ void (^secondPasswordSuccess)(NSString *);
 //    }
 //
 //    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:self.pinEntryViewController.view];
-}
-
-- (void)didPutPinSuccess:(NSDictionary*)dictionary
-{
-    [self hideBusyView];
-
-    if (!WalletManager.sharedInstance.wallet.password) {
-        [self didFailPutPin:BC_STRING_CANNOT_SAVE_PIN_CODE_WHILE];
-        return;
-    }
-
-    NSNumber * code = [dictionary objectForKey:DICTIONARY_KEY_CODE]; //This is a status code from the server
-    NSString * error = [dictionary objectForKey:DICTIONARY_KEY_ERROR]; //This is an error string from the server or nil
-    NSString * key = [dictionary objectForKey:DICTIONARY_KEY_KEY]; //This is our pin code lookup key
-    NSString * value = [dictionary objectForKey:DICTIONARY_KEY_VALUE]; //This is our encryption string
-
-    if (error != nil) {
-        [self didFailPutPin:error];
-    } else if (code == nil || [code intValue] != PIN_API_STATUS_OK) {
-        [self didFailPutPin:[NSString stringWithFormat:BC_STRING_INVALID_STATUS_CODE_RETURNED, code]];
-    } else if ([key length] == 0 || [value length] == 0) {
-        [self didFailPutPin:BC_STRING_PIN_RESPONSE_OBJECT_KEY_OR_VALUE_LENGTH_0];
-    } else {
-
-        BOOL inSettings = self.pinEntryViewController.inSettings;
-
-        if (inSettings) {
-            [self showSettings];
-        }
-        //Encrypt the wallet password with the random value
-        NSString * encrypted = [WalletManager.sharedInstance.wallet encrypt:WalletManager.sharedInstance.wallet.password password:value pbkdf2_iterations:PIN_PBKDF2_ITERATIONS];
-
-        //Store the encrypted result and discard the value
-        value = nil;
-
-        if (!encrypted) {
-            [self didFailPutPin:BC_STRING_PIN_ENCRYPTED_STRING_IS_NIL];
-            return;
-        }
-
-        App *appSettings = [BlockchainSettings sharedAppInstance];
-        appSettings.encryptedPinPassword = encrypted;
-        appSettings.pinKey = key;
-        appSettings.passwordPartHash = [[WalletManager.sharedInstance.wallet.password SHA256] substringToIndex:MIN([WalletManager.sharedInstance.wallet.password length], 5)];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-
-        // Update your info to new pin code
-        [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
-
-        if ([WalletManager.sharedInstance.wallet isInitialized] && !inSettings) [AlertViewPresenter.sharedInstance showMobileNoticeIfNeeded];
-
-        if (!WalletManager.sharedInstance.wallet.didUpgradeToHd) {
-            [self forceHDUpgradeForLegacyWallets];
-        }
-    }
-
-    WalletManager.sharedInstance.wallet.isNew = NO;
-}
+//}
+//
+//- (void)didPutPinSuccess:(NSDictionary*)dictionary
+//{
+//    [self hideBusyView];
+//
+//    if (!WalletManager.sharedInstance.wallet.password) {
+//        [self didFailPutPin:BC_STRING_CANNOT_SAVE_PIN_CODE_WHILE];
+//        return;
+//    }
+//
+//    NSNumber * code = [dictionary objectForKey:DICTIONARY_KEY_CODE]; //This is a status code from the server
+//    NSString * error = [dictionary objectForKey:DICTIONARY_KEY_ERROR]; //This is an error string from the server or nil
+//    NSString * key = [dictionary objectForKey:DICTIONARY_KEY_KEY]; //This is our pin code lookup key
+//    NSString * value = [dictionary objectForKey:DICTIONARY_KEY_VALUE]; //This is our encryption string
+//
+//    if (error != nil) {
+//        [self didFailPutPin:error];
+//    } else if (code == nil || [code intValue] != PIN_API_STATUS_OK) {
+//        [self didFailPutPin:[NSString stringWithFormat:BC_STRING_INVALID_STATUS_CODE_RETURNED, code]];
+//    } else if ([key length] == 0 || [value length] == 0) {
+//        [self didFailPutPin:BC_STRING_PIN_RESPONSE_OBJECT_KEY_OR_VALUE_LENGTH_0];
+//    } else {
+//
+//        BOOL inSettings = self.pinEntryViewController.inSettings;
+//
+//        if (inSettings) {
+//            [self showSettings];
+//        }
+//        //Encrypt the wallet password with the random value
+//        NSString * encrypted = [WalletManager.sharedInstance.wallet encrypt:WalletManager.sharedInstance.wallet.password password:value pbkdf2_iterations:PIN_PBKDF2_ITERATIONS];
+//
+//        //Store the encrypted result and discard the value
+//        value = nil;
+//
+//        if (!encrypted) {
+//            [self didFailPutPin:BC_STRING_PIN_ENCRYPTED_STRING_IS_NIL];
+//            return;
+//        }
+//
+//        App *appSettings = [BlockchainSettings sharedAppInstance];
+//        appSettings.encryptedPinPassword = encrypted;
+//        appSettings.pinKey = key;
+//        appSettings.passwordPartHash = [[WalletManager.sharedInstance.wallet.password SHA256] substringToIndex:MIN([WalletManager.sharedInstance.wallet.password length], 5)];
+//        [[NSUserDefaults standardUserDefaults] synchronize];
+//
+//        // Update your info to new pin code
+//        [AuthenticationCoordinator.shared closePinEntryViewWithAnimated:YES];
+//
+//        if ([WalletManager.sharedInstance.wallet isInitialized] && !inSettings) [self showMobileNotice];
+//
+//        if (!WalletManager.sharedInstance.wallet.didUpgradeToHd) {
+//            [self forceHDUpgradeForLegacyWallets];
+//        }
+//    }
+//
+//    WalletManager.sharedInstance.wallet.isNew = NO;
+//}
 
 - (void)pinEntryController:(PEPinEntryController *)c willChangeToNewPin:(NSUInteger)_pin
 {

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -3815,7 +3815,7 @@
     } else if ([error isEqualToString:@""]) {
         [AlertViewPresenter.sharedInstance showNoInternetConnectionAlert];
     } else if ([error isEqualToString:ERROR_TIMEOUT_REQUEST]){
-        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_TIMED_OUT title:BC_STRING_ERROR handler: nil];
+        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:LocalizationConstantsObjcBridge.timedOut title:BC_STRING_ERROR handler: nil];
     } else {
         [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:error title:BC_STRING_ERROR handler: nil];
     }

--- a/Blockchain/Wallet/Models/GetPinResponse.swift
+++ b/Blockchain/Wallet/Models/GetPinResponse.swift
@@ -1,0 +1,34 @@
+//
+//  GetPinResponse.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/30/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+struct GetPinResponse {
+    enum StatusCode: Int {
+        case success = 0
+        case deleted = 1 // Pin retry succeeded
+        case incorrect = 2 // Incorrect pin
+    }
+
+    // This is a status code from the server
+    let code: Int?
+
+    // This is an error string from the server or nil
+    let error: String?
+
+    // The PIN decryption value from the server
+    let pinDecryptionValue: String?
+}
+
+extension GetPinResponse {
+    init(response: [AnyHashable: Any]) {
+        self.code = response["code"] as? Int
+        self.error = response["error"] as? String
+        self.pinDecryptionValue = response["success"] as? String
+    }
+}

--- a/Blockchain/Wallet/Models/PutPinResponse.swift
+++ b/Blockchain/Wallet/Models/PutPinResponse.swift
@@ -1,0 +1,39 @@
+//
+//  PutPinResponse.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/30/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+struct PutPinResponse {
+    /// The status code from the server
+    let code: Int?
+
+    /// Error string from the server, if any
+    let error: String?
+
+    /// Pin code lookup key
+    let key: String
+
+    /// Encryption string
+    let value: String
+
+    var isStatusCodeOk: Bool {
+        guard let code = code else {
+            return false
+        }
+        return code == 0
+    }
+}
+
+extension PutPinResponse {
+    init(response: [AnyHashable: Any]) {
+        self.code = response["code"] as? Int
+        self.error = response["error"] as? String
+        self.key = response["key"] as! String
+        self.value = response["value"] as! String
+    }
+}

--- a/Blockchain/Wallet/WalletAuthDelegate.swift
+++ b/Blockchain/Wallet/WalletAuthDelegate.swift
@@ -1,0 +1,30 @@
+//
+//  WalletAuthDelegate.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/30/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol definition for a delegate for authentication-related wallet callbacks
+protocol WalletAuthDelegate: class {
+    /// Callback invoked when the wallet successfully decrypts
+    func didDecryptWallet(guid: String?, sharedKey: String?, password: String?)
+
+    /// Callback invoked when 2 factor authorization is required
+    func requiresTwoFactorCode()
+
+    /// Callback invoked when the provided two factor code is incorrect
+    func incorrectTwoFactorCode()
+
+    /// Callback invoked when an email authorization is required (only for manual pairing)
+    func emailAuthorizationRequired()
+
+    /// Callback invoked when an error occurred with authenticating
+    func authenticationError(error: AuthenticationError?)
+
+    /// Callback invoked when the user has successfully authenticated
+    func authenticationCompleted()
+}

--- a/Blockchain/Wallet/WalletPinEntryDelegate.swift
+++ b/Blockchain/Wallet/WalletPinEntryDelegate.swift
@@ -1,0 +1,31 @@
+//
+//  WalletPinEntryDelegate.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 4/30/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol definition for a delegate for pin entry-related wallet callbacks
+protocol WalletPinEntryDelegate: class {
+
+    /// Method invoked when the Wallet.getAPIPinValue method times out
+    func errorGetPinValueTimeout()
+
+    /// Method invoked when the Wallet.getAPIPinValue returns an empty response
+    func errorGetPinEmptyResponse()
+
+    /// Method invoked when the Wallet.getAPIPinValue returns an invalid response
+    func errorGetPinInvalidResponse()
+
+    /// Method invoked when Wallet.putPin fails
+    func errorDidFailPutPin(errorMessage: String)
+
+    /// Method invoked when putPin succeeds
+    func putPinSuccess(response: PutPinResponse)
+
+    /// Method invoked when getPin succeeds
+    func getPinSuccess(response: GetPinResponse)
+}

--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -250,7 +250,7 @@ static PEViewController *VerifyController()
                         self.viewControllers = [NSArray arrayWithObject:c];
                     }
                 } else {
-                    controller.prompt = BC_STRING_INCORRECT_PIN_RETRY;
+                    controller.prompt = LocalizationConstantsObjcBridge.incorrectPin;
                     [controller resetPin];
                 }
             }];


### PR DESCRIPTION
* Moved pin creation from RootService to AuthenticationCoordinator
* Created `GetPinResponse` & `PutPinResponse` model objects to wrap pin-related API responses
* Created `WalletPinEntryDelegate` to wrap `WalletDelegate` pin-related methods

Please review/merge PRs all PRs < #132 before reviewing this