### PR TITLE
fix(ModalPresenter): post notification before checking for existing m…

### DIFF
--- a/Blockchain/ModalPresenter.swift
+++ b/Blockchain/ModalPresenter.swift
@@ -69,12 +69,13 @@ typealias OnModalResumed = () -> Void
     }
 
     @objc func closeModal(withTransition transition: String) {
+
+        NotificationCenter.default.post(name: Constants.NotificationKeys.modalViewDismissed, object: nil)
+
         guard let modalView = modalView else {
             print("Cannot close modal. modalView is nil.")
             return
         }
-
-        NotificationCenter.default.post(name: Constants.NotificationKeys.modalViewDismissed, object: nil)
 
         modalView.removeFromSuperview()
 


### PR DESCRIPTION
…odal view

The `BCModalViewController` is the way the app historically reused modal views by presenting them inside its own view controller. This was how modal views were shown for side menu items, which were presented by the tab view controller.