### PR TITLE
feat(Alert View Presenter): support custom alert actions

### DIFF
--- a/Blockchain/Alerts/AlertViewPresenter.swift
+++ b/Blockchain/Alerts/AlertViewPresenter.swift
@@ -94,9 +94,8 @@ import Foundation
     }
 
     @objc func standardNotify(message: String, title: String = LocalizationConstants.Errors.error, handler: AlertConfirmHandler? = nil) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: LocalizationConstants.okString, style: .cancel, handler: handler))
-        standardNotify(alert: alert)
+        let standardAction = UIAlertAction(title: LocalizationConstants.okString, style: .cancel, handler: handler)
+        standardNotify(message: message, title: title, actions: [standardAction])
     }
 
     /// Allows custom actions to be included in the standard alert presentation

--- a/Blockchain/Alerts/AlertViewPresenter.swift
+++ b/Blockchain/Alerts/AlertViewPresenter.swift
@@ -93,17 +93,24 @@ import Foundation
         }
     }
 
-    @objc func standardNotify(
-        message: String,
-        title: String = LocalizationConstants.Errors.error,
-        handler: AlertConfirmHandler? = nil
-    ) {
+    @objc func standardNotify(message: String, title: String = LocalizationConstants.Errors.error, handler: AlertConfirmHandler? = nil) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: LocalizationConstants.okString, style: .cancel, handler: handler))
+        standardNotify(alert: alert)
+    }
+
+    /// Allows custom actions to be included in the standard alert presentation
+    @objc func standardNotify(message: String, title: String, actions: [UIAlertAction]) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        actions.forEach { alert.addAction($0) }
+        if actions.isEmpty {
+            alert.addAction(UIAlertAction(title: LocalizationConstants.okString, style: .cancel, handler: nil))
+        }
+        standardNotify(alert: alert)
+    }
+
+    private func standardNotify(alert: UIAlertController) {
         DispatchQueue.main.async {
-            guard UIApplication.shared.applicationState == .active else { return }
-
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: LocalizationConstants.okString, style: .cancel, handler: handler))
-
             let window = UIApplication.shared.keyWindow
             guard let topMostViewController = window?.rootViewController?.topMostViewController else {
                 window?.rootViewController?.present(alert, animated: true)

--- a/Blockchain/Alerts/AlertViewPresenter.swift
+++ b/Blockchain/Alerts/AlertViewPresenter.swift
@@ -93,7 +93,12 @@ import Foundation
         }
     }
 
-    @objc func standardNotify(message: String, title: String = LocalizationConstants.Errors.error, handler: AlertConfirmHandler? = nil) {
+    /// Displays the standard error alert
+    @objc func standardError(message: String, title: String = LocalizationConstants.Errors.error, handler: AlertConfirmHandler? = nil) {
+        standardNotify(message: message, title: title, handler: handler)
+    }
+
+    @objc func standardNotify(message: String, title: String, handler: AlertConfirmHandler? = nil) {
         let standardAction = UIAlertAction(title: LocalizationConstants.okString, style: .cancel, handler: handler)
         standardNotify(message: message, title: title, actions: [standardAction])
     }

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -37,7 +37,7 @@ import Foundation
                 strongSelf.handleFailedToLoadWallet()
             default:
                 if let description = error!.description {
-                    AlertViewPresenter.shared.standardNotify(message: description)
+                    AlertViewPresenter.shared.standardError(message: description)
                 }
             }
             return
@@ -246,11 +246,11 @@ import Foundation
             case .notAuthorized:
                 AlertViewPresenter.shared.showNeedsCameraPermissionAlert()
             default:
-                AlertViewPresenter.shared.standardNotify(message: error.localizedDescription)
+                AlertViewPresenter.shared.standardError(message: error.localizedDescription)
             }
             return
         } catch {
-            AlertViewPresenter.shared.standardNotify(message: error.localizedDescription)
+            AlertViewPresenter.shared.standardError(message: error.localizedDescription)
         }
 
         let pairingCodeParserViewController = PairingCodeParser(success: { [weak self] response in
@@ -261,7 +261,7 @@ import Foundation
             AuthenticationManager.shared.authenticate(using: payload, andReply: strongSelf.authHandler)
         }, error: { error in
             guard let errorMessage = error else { return }
-            AlertViewPresenter.shared.standardNotify(message: errorMessage)
+            AlertViewPresenter.shared.standardError(message: errorMessage)
         })!
         UIApplication.shared.keyWindow?.rootViewController?.topMostViewController?.present(
             pairingCodeParserViewController,
@@ -416,12 +416,12 @@ import Foundation
         passwordConfirmView.validateSecondPassword = validateSecondPassword
         passwordConfirmView.confirmHandler = { [unowned self] password in
             guard password.count > 0 else {
-                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.noPasswordEntered)
+                AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.noPasswordEntered)
                 return
             }
 
             guard !passwordConfirmView.validateSecondPassword || self.walletManager.wallet.validateSecondPassword(password) else {
-                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.secondPasswordIncorrect)
+                AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.secondPasswordIncorrect)
                 return
             }
 
@@ -448,7 +448,7 @@ import Foundation
         }
         pinEntryViewController?.reset()
         LoadingViewPresenter.shared.hideBusyView()
-        AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Errors.errorLoadingWallet)
+        AlertViewPresenter.shared.standardError(message: LocalizationConstants.Errors.errorLoadingWallet)
     }
 
     // MARK: - Private

--- a/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
@@ -173,7 +173,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
     func errorDidFailPutPin(errorMessage: String) {
         LoadingViewPresenter.shared.hideBusyView()
 
-        AlertViewPresenter.shared.standardNotify(message: errorMessage)
+        AlertViewPresenter.shared.standardError(message: errorMessage)
 
         reopenChangePin()
     }
@@ -245,10 +245,10 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
 
         // Incorrect pin
         if response.code == nil {
-            AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.Pin.incorrect)
+            AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.Pin.incorrect)
         } else if response.code == GetPinResponse.StatusCode.deleted.rawValue {
             // Pin retry limit exceeded
-            AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.Pin.validationCannotBeCompleted)
+            AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.Pin.validationCannotBeCompleted)
             BlockchainSettings.App.shared.clearPin()
             logout(showPasswordView: false)
             DispatchQueue.main.async { [weak self] in
@@ -258,7 +258,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
             }
         } else if response.code == GetPinResponse.StatusCode.incorrect.rawValue {
             let error = response.error ?? LocalizationConstants.Authentication.Pin.incorrectUnknownError
-            AlertViewPresenter.shared.standardNotify(message: error)
+            AlertViewPresenter.shared.standardError(message: error)
         } else if response.code == GetPinResponse.StatusCode.success.rawValue {
 
             // TODO handle touch ID
@@ -281,7 +281,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
 
             // Initial PIN setup ?
             if response.pinDecryptionValue?.count == 0 {
-                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.Pin.responseSuccessLengthZero)
+                AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.Pin.responseSuccessLengthZero)
                 return
             }
 
@@ -292,7 +292,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
                 pbkdf2_iterations: Int32(Constants.Security.pinPBKDF2Iterations)
             )
             if decryptedPassword?.count == 0 {
-                AlertViewPresenter.shared.standardNotify(message: LocalizationConstants.Authentication.Pin.decryptedPasswordLengthZero)
+                AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.Pin.decryptedPasswordLengthZero)
                 askIfUserWantsToResetPIN()
                 return
             }

--- a/Blockchain/Extensions/UIApplication.swift
+++ b/Blockchain/Extensions/UIApplication.swift
@@ -13,7 +13,7 @@ extension UIApplication {
     // Opens the mail application, if possible, otherwise, displays an error
     @objc func openMailApplication() {
         guard let mailURL = URL(string: Constants.Schemas.mail), canOpenURL(mailURL) else {
-            AlertViewPresenter.shared.standardNotify(
+            AlertViewPresenter.shared.standardError(
                 message: NSString(
                     format: LocalizationConstants.Errors.cannotOpenURLArg as NSString,
                     Constants.Schemas.mail


### PR DESCRIPTION
This PR adds support for custom alert actions for the `standardNotify` functions. It also fixes an issue that prevented alerts from showing while the application was transitioning to the active state.