### PR TITLE
refactor(ShowType): Migrating show type to PostAuthenticationRoute.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -241,12 +241,14 @@
 		AA31A7BB2098DFCF00FE6268 /* SideMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */; };
 		AA31A7BC2098DFCF00FE6268 /* SideMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */; };
 		AA31A7D12099310B00FE6268 /* WalletBuySellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7D02099310B00FE6268 /* WalletBuySellDelegate.swift */; };
-		AA63F85920A134DA002B719B /* BCTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D95A251B3DD86B0012EBB1 /* BCTextField.swift */; };
 		AA63F84B20A12AE9002B719B /* URLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F84A20A12AE9002B719B /* URLs.swift */; };
 		AA63F84C20A12AE9002B719B /* URLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F84A20A12AE9002B719B /* URLs.swift */; };
 		AA63F85020A12DA6002B719B /* BitcoinURLPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F84F20A12DA6002B719B /* BitcoinURLPayload.swift */; };
 		AA63F85120A12DA6002B719B /* BitcoinURLPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F84F20A12DA6002B719B /* BitcoinURLPayload.swift */; };
 		AA63F85420A12FC8002B719B /* BitcoinURLPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F85320A12FC8002B719B /* BitcoinURLPayloadTests.swift */; };
+		AA63F85920A134DA002B719B /* BCTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D95A251B3DD86B0012EBB1 /* BCTextField.swift */; };
+		AA63F86720A27AC6002B719B /* PostAuthenticationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F86620A27AC6002B719B /* PostAuthenticationRoute.swift */; };
+		AA63F86820A27AC6002B719B /* PostAuthenticationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F86620A27AC6002B719B /* PostAuthenticationRoute.swift */; };
 		AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F6582086A2720054EFCE /* AppCoordinator.swift */; };
 		AA69F65F2086A7500054EFCE /* BlockchainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */; };
 		AAA3314E20893CE100BBD292 /* PairingInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */; };
@@ -1236,6 +1238,7 @@
 		AA63F84A20A12AE9002B719B /* URLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = URLs.swift; path = Extensions/URLs.swift; sourceTree = "<group>"; };
 		AA63F84F20A12DA6002B719B /* BitcoinURLPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinURLPayload.swift; sourceTree = "<group>"; };
 		AA63F85320A12FC8002B719B /* BitcoinURLPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinURLPayloadTests.swift; sourceTree = "<group>"; };
+		AA63F86620A27AC6002B719B /* PostAuthenticationRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAuthenticationRoute.swift; path = Authentication/Models/PostAuthenticationRoute.swift; sourceTree = "<group>"; };
 		AA69F6582086A2720054EFCE /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchainSettings.swift; sourceTree = "<group>"; };
 		AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingInstructionsView.swift; sourceTree = "<group>"; };
@@ -1635,6 +1638,7 @@
 				51A665C62080EBD80040EE7C /* AuthenticationError.swift */,
 				AAD279AF209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift */,
 				510EA16F2080F16100A63AB8 /* PasscodePayload.swift */,
+				AA63F86620A27AC6002B719B /* PostAuthenticationRoute.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -2926,6 +2930,7 @@
 				AACE31D52092A99B00B7B806 /* Coordinator.swift in Sources */,
 				AACE32082097835F00B7B806 /* AuthenticationManagerTests.swift in Sources */,
 				5185E11C208E7F7C00A26B64 /* BlockchainSettings.swift in Sources */,
+				AA63F86820A27AC6002B719B /* PostAuthenticationRoute.swift in Sources */,
 				AACE31DB2092A99B00B7B806 /* UIDevice.swift in Sources */,
 				51135703209CF5D000056D65 /* AuthenticationTwoFactorType.swift in Sources */,
 				AA1E52332097CC260099BD10 /* WalletAuthDelegate.swift in Sources */,
@@ -3032,6 +3037,7 @@
 				67EE1DCF19E3325900DBBFC9 /* UIViewController+ECSlidingViewController.m in Sources */,
 				C9BE917B1945D8F600FD516D /* PENumpadView.m in Sources */,
 				AACE314C209152D800B7B806 /* UIApplication.swift in Sources */,
+				AA63F86720A27AC6002B719B /* PostAuthenticationRoute.swift in Sources */,
 				C7EEB8451EA95505002F28B9 /* UIView+ChangeFrameAttribute.m in Sources */,
 				C74E21C12024BA1C00A9FBB1 /* BCBalanceChartLegendKeyView.m in Sources */,
 				516546F5208FCF710019EE63 /* NetworkManager+UserAgent.swift in Sources */,

--- a/Blockchain/AccountsAndAddressesDetailViewController.m
+++ b/Blockchain/AccountsAndAddressesDetailViewController.m
@@ -154,8 +154,8 @@ typedef enum {
     [self dismissViewControllerAnimated:YES completion:^{
         [[AppCoordinator sharedInstance] closeSideMenu];
     }];
-    
-    [app showSendCoins];
+
+    [AppCoordinator.sharedInstance.tabControllerManager showSendCoinsAnimated:YES];
 
     TabControllerManager *tabControllerManager = [AppCoordinator sharedInstance].tabControllerManager;
     [tabControllerManager transferFundsToDefaultAccountFromAddress:self.address];

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -215,8 +215,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             ModalPresenter.shared.closeModal(withTransition: kCATransitionFade)
 
-            // TODO handle show type
-            //        showType = ShowTypeSendCoins;
+            AuthenticationCoordinator.shared.postAuthenticationRoute = .sendCoins
 
             AppCoordinator.shared.tabControllerManager.setupBitcoinPaymentFromURLHandler(
                 withAmountString: bitcoinUrlPayload.amount,

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -16,6 +16,8 @@ import Foundation
         return shared
     }
 
+    var postAuthenticationRoute: PostAuthenticationRoute?
+
     var lastEnteredPIN: Pin?
 
     /// Authentication handler - this should not be a property of AuthenticationCoordinator
@@ -74,10 +76,9 @@ import Foundation
             ReminderCoordinator.shared.checkIfSettingsLoadedAndShowEmailReminder()
         }
 
-        // TODO
-//        let tabControllerManager = AppCoordinator.shared.tabControllerManager
-//        tabControllerManager.sendBitcoinViewController.reload()
-//        tabControllerManager.sendBitcoinCashViewController.reload()
+        let tabControllerManager = AppCoordinator.shared.tabControllerManager
+        tabControllerManager.sendBitcoinViewController?.reload()
+        tabControllerManager.sendBitcoinCashViewController?.reload()
 
         // Enabling touch ID and immediately backgrounding the app hides the status bar
         UIApplication.shared.setStatusBarHidden(false, with: .slide)
@@ -89,13 +90,14 @@ import Foundation
             LegacyPushNotificationManager.shared.requestAuthorization()
         }
 
-        // TODO
-        // if (showType == ShowTypeSendCoins) {
-        //     [self showSendCoins];
-        // } else if (showType == ShowTypeNewPayment) {
-        //     [self.tabControllerManager showTransactionsAnimated:YES];
-        // }
-        // showType = ShowTypeNone;
+        // Handle post authentication route, if any
+        if let route = strongSelf.postAuthenticationRoute {
+            switch route {
+            case .sendCoins:
+                tabControllerManager.showSendCoins(animated: true)
+            }
+            strongSelf.postAuthenticationRoute = nil
+        }
 
         if let topViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController,
             BlockchainSettings.App.shared.isPinSet,

--- a/Blockchain/Authentication/Models/PostAuthenticationRoute.swift
+++ b/Blockchain/Authentication/Models/PostAuthenticationRoute.swift
@@ -1,0 +1,14 @@
+//
+//  PostAuthenticationRoute.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 5/8/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Enumerates routes that can be navigated to after the wallet successfully loads
+enum PostAuthenticationRoute {
+    case sendCoins
+}

--- a/Blockchain/Notifications/PushNotificationManager.swift
+++ b/Blockchain/Notifications/PushNotificationManager.swift
@@ -35,13 +35,9 @@ class PushNotificationManager: NSObject {
         return shared
     }
 
-    /// UNNotification that is to be presented to the user
-    @objc var presentingPushNotification: UNNotification?
-
     /// Requests permission from the user to grant access to receive push notifications
     func requestAuthorization() {
         let userNotificationCenter = UNUserNotificationCenter.current()
-        userNotificationCenter.delegate = self
         userNotificationCenter.requestAuthorization(options: [.sound, .alert, .badge]) { _, error in
             guard error == nil else {
                 print("Push registration FAILED")
@@ -53,17 +49,5 @@ class PushNotificationManager: NSObject {
                 UIApplication.shared.registerForRemoteNotifications()
             }
         }
-    }
-}
-
-@available(iOS 10.0, *)
-extension PushNotificationManager: UNUserNotificationCenterDelegate {
-
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
-        presentingPushNotification = notification
     }
 }

--- a/Blockchain/QRCodeScannerSendViewController.m
+++ b/Blockchain/QRCodeScannerSendViewController.m
@@ -74,7 +74,7 @@
     [[ModalPresenter sharedInstance] closeModalWithTransition:kCATransitionFade];
     
     // Go to the send screen if we are not already on it
-    [app showSendCoins];
+    [AppCoordinator.sharedInstance.tabControllerManager showSendCoinsAnimated:YES];
 }
 
 @end

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -179,7 +179,7 @@
 
 //- (void)pushWebViewController:(NSString*)url title:(NSString *)title;
 
-- (void)showSendCoins;
+//- (void)showSendCoins;
 - (void)showAccountsAndAddresses;
 //- (void)showHdUpgrade;
 //- (void)showDebugMenu:(int)presenter;

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -57,14 +57,14 @@ RootService * app;
 //@synthesize modalView;
 //@synthesize latestResponse;
 
-typedef enum {
-    ShowTypeNone = 100,
-    ShowTypeSendCoins = 200,
-//    ShowTypeNewContact = 300,
-    ShowTypeNewPayment = 400
-} ShowType;
-
-ShowType showType;
+//typedef enum {
+//    ShowTypeNone = 100,
+//    ShowTypeSendCoins = 200,
+////    ShowTypeNewContact = 300,
+//    ShowTypeNewPayment = 400
+//} ShowType;
+//
+//ShowType showType;
 
 enum {
     ShowReminderTypeNone,
@@ -424,8 +424,8 @@ SideMenuViewController *sideMenuViewController;
     // [rootService applicationDidBecomeActive:application];
 //}
 
-- (BOOL)application:(UIApplication *)application openURL:(nonnull NSURL *)url options:(nonnull NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
-{
+//- (BOOL)application:(UIApplication *)application openURL:(nonnull NSURL *)url options:(nonnull NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+//{
 //    if (![BlockchainSettings sharedAppInstance].isPinSet) {
 //        if ([[url absoluteString] isEqualToString:[NSString stringWithFormat:@"%@%@", PREFIX_BLOCKCHAIN_WALLET_URI, @"loginAuthorized"]]) {
 //            [self manualPairClicked:nil];
@@ -453,12 +453,12 @@ SideMenuViewController *sideMenuViewController;
 //    NSString * addr = [dict objectForKey:DICTIONARY_KEY_ADDRESS];
 //    NSString * amount = [dict objectForKey:DICTIONARY_KEY_AMOUNT];
 //
-    showType = ShowTypeSendCoins;
+//    showType = ShowTypeSendCoins;
 //
 //    [self.tabControllerManager setupBitcoinPaymentFromURLHandlerWithAmountString:amount address:addr];
 //
 //    return YES;
-}
+//}
 
 //- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 //{
@@ -974,8 +974,8 @@ SideMenuViewController *sideMenuViewController;
 //    }
 //}
 //
-- (void)walletDidFinishLoad
-{
+//- (void)walletDidFinishLoad
+//{
 //    DLog(@"walletDidFinishLoad");
 
 //    WalletManager.sharedInstance.wallet.btcSwipeAddressToSubscribe = nil;
@@ -1047,7 +1047,7 @@ SideMenuViewController *sideMenuViewController;
 //    }
 //
 //    [WalletManager.sharedInstance.wallet loadContactsThenGetMessages];
-}
+//}
 
 - (void)didGetMultiAddressResponse:(MultiAddressResponse*)response
 {
@@ -1463,9 +1463,9 @@ SideMenuViewController *sideMenuViewController;
 //
 //    [self.modalChain removeAllObjects];
 //}
-
-- (void)closeModalWithTransition:(NSString *)transition
-{
+//
+//- (void)closeModalWithTransition:(NSString *)transition
+//{
 //    [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_KEY_MODAL_VIEW_DISMISSED object:nil];
 //
 //    [modalView removeFromSuperview];
@@ -1509,20 +1509,20 @@ SideMenuViewController *sideMenuViewController;
 //    else {
 //        self.modalView = nil;
 //    }
-}
-
-- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType headerText:(NSString *)headerText
-{
-    [self showModalWithContent:(BCModalContentView *)contentView closeType:closeType showHeader:YES headerText:headerText onDismiss:nil onResume:nil];
-}
-
-- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType headerText:(NSString *)headerText onDismiss:(void (^)())onDismiss onResume:(void (^)())onResume
-{
-    [self showModalWithContent:(BCModalContentView *)contentView closeType:closeType showHeader:YES headerText:headerText onDismiss:onDismiss onResume:onResume];
-}
-
-- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType showHeader:(BOOL)showHeader headerText:(NSString *)headerText onDismiss:(void (^)())onDismiss onResume:(void (^)())onResume
-{
+//}
+//
+//- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType headerText:(NSString *)headerText
+//{
+//    [self showModalWithContent:(BCModalContentView *)contentView closeType:closeType showHeader:YES headerText:headerText onDismiss:nil onResume:nil];
+//}
+//
+//- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType headerText:(NSString *)headerText onDismiss:(void (^)())onDismiss onResume:(void (^)())onResume
+//{
+//    [self showModalWithContent:(BCModalContentView *)contentView closeType:closeType showHeader:YES headerText:headerText onDismiss:onDismiss onResume:onResume];
+//}
+//
+//- (void)showModalWithContent:(UIView *)contentView closeType:(ModalCloseType)closeType showHeader:(BOOL)showHeader headerText:(NSString *)headerText onDismiss:(void (^)())onDismiss onResume:(void (^)())onResume
+//{
 //    // Remove the modal if we have one
 //    if (modalView) {
 //        [modalView removeFromSuperview];
@@ -1577,7 +1577,7 @@ SideMenuViewController *sideMenuViewController;
 //    }
 //
 //    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
-}
+//}
 
 - (void)didFailBackupWallet
 {
@@ -2619,10 +2619,10 @@ SideMenuViewController *sideMenuViewController;
     [self.tabControllerManager showTransactionsAnimated:YES];
 }
 
-- (void)showSendCoins
-{
-    [self.tabControllerManager showSendCoinsAnimated:YES];
-}
+//- (void)showSendCoins
+//{
+//    [self.tabControllerManager showSendCoinsAnimated:YES];
+//}
 
 //- (void)showDebugMenu:(int)presenter
 //{
@@ -2850,12 +2850,12 @@ SideMenuViewController *sideMenuViewController;
 //    [self.window.rootViewController presentViewController:recoveryWarningAlert animated:YES completion:nil];
 //}
 //
-- (IBAction)manualPairClicked:(id)sender
-{
+//- (IBAction)manualPairClicked:(id)sender
+//{
 //    [self showModalWithContent:manualPairView closeType:ModalCloseTypeBack headerText:BC_STRING_MANUAL_PAIRING];
 //    WalletManager.sharedInstance.wallet.twoFactorInput = nil;
 //    [manualPairView clearPasswordTextField];
-}
+//}
 //
 //- (void)showNewWalletSetup
 //{


### PR DESCRIPTION
* Moved `showType` away from `RootService` and renamed this enum to `PostAuthenticationRoute`.
* Added back `userNotificationCenter:didReceive:withCompletionHandler` back to `PushNotificationManager` since it was accidentally removed on b79a4b35 (@woudini can you confirm that `ShowTypeNewPayment` was actually used and not part of contacts in which case we should remove it?)
* Commented out some more unused code in `RootService`