### PR TITLE
refactor(AppFeature): Removing #defines for app feature enabling.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -234,8 +234,8 @@
 		AA1E523B2097E2190099BD10 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52392097E2190099BD10 /* Strings.swift */; };
 		AA1E523D2097E6AC0099BD10 /* GetPinResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E523C2097E6AC0099BD10 /* GetPinResponse.swift */; };
 		AA1E523E2097E6AC0099BD10 /* GetPinResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E523C2097E6AC0099BD10 /* GetPinResponse.swift */; };
-		AA1E52592098374A0099BD10 /* AuthenticationCoordinator+TouchID.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52582098374A0099BD10 /* AuthenticationCoordinator+TouchID.swift */; };
-		AA1E525A2098374A0099BD10 /* AuthenticationCoordinator+TouchID.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52582098374A0099BD10 /* AuthenticationCoordinator+TouchID.swift */; };
+		AA1E52592098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52582098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift */; };
+		AA1E525A2098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52582098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift */; };
 		AA31A7B42098DA4900FE6268 /* AlertViewPresenter+Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */; };
 		AA31A7B52098DA5200FE6268 /* AlertViewPresenter+Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */; };
 		AA31A7BB2098DFCF00FE6268 /* SideMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */; };
@@ -249,6 +249,12 @@
 		AA63F85920A134DA002B719B /* BCTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D95A251B3DD86B0012EBB1 /* BCTextField.swift */; };
 		AA63F86720A27AC6002B719B /* PostAuthenticationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F86620A27AC6002B719B /* PostAuthenticationRoute.swift */; };
 		AA63F86820A27AC6002B719B /* PostAuthenticationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F86620A27AC6002B719B /* PostAuthenticationRoute.swift */; };
+		AA63F87420A39D8D002B719B /* AppFeatureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87320A39D8D002B719B /* AppFeatureConfiguration.swift */; };
+		AA63F87520A39D8D002B719B /* AppFeatureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87320A39D8D002B719B /* AppFeatureConfiguration.swift */; };
+		AA63F87720A39DCF002B719B /* AppFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87620A39DCF002B719B /* AppFeature.swift */; };
+		AA63F87820A39DCF002B719B /* AppFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87620A39DCF002B719B /* AppFeature.swift */; };
+		AA63F87A20A3A198002B719B /* AppFeatureConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87920A3A198002B719B /* AppFeatureConfigurator.swift */; };
+		AA63F87B20A3A198002B719B /* AppFeatureConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87920A3A198002B719B /* AppFeatureConfigurator.swift */; };
 		AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F6582086A2720054EFCE /* AppCoordinator.swift */; };
 		AA69F65F2086A7500054EFCE /* BlockchainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */; };
 		AAA3314E20893CE100BBD292 /* PairingInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */; };
@@ -1233,7 +1239,7 @@
 		AA1E52372097D3C50099BD10 /* PutPinResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PutPinResponse.swift; sourceTree = "<group>"; };
 		AA1E52392097E2190099BD10 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Strings.swift; path = Extensions/Strings.swift; sourceTree = "<group>"; };
 		AA1E523C2097E6AC0099BD10 /* GetPinResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPinResponse.swift; sourceTree = "<group>"; };
-		AA1E52582098374A0099BD10 /* AuthenticationCoordinator+TouchID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "AuthenticationCoordinator+TouchID.swift"; path = "Authentication/AuthenticationCoordinator+TouchID.swift"; sourceTree = "<group>"; };
+		AA1E52582098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "AuthenticationCoordinator+Biometrics.swift"; path = "Authentication/AuthenticationCoordinator+Biometrics.swift"; sourceTree = "<group>"; };
 		AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AlertViewPresenter+Wallet.swift"; sourceTree = "<group>"; };
 		AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuItem.swift; sourceTree = "<group>"; };
 		AA31A7D02099310B00FE6268 /* WalletBuySellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletBuySellDelegate.swift; sourceTree = "<group>"; };
@@ -1241,6 +1247,9 @@
 		AA63F84F20A12DA6002B719B /* BitcoinURLPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinURLPayload.swift; sourceTree = "<group>"; };
 		AA63F85320A12FC8002B719B /* BitcoinURLPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinURLPayloadTests.swift; sourceTree = "<group>"; };
 		AA63F86620A27AC6002B719B /* PostAuthenticationRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAuthenticationRoute.swift; path = Authentication/Models/PostAuthenticationRoute.swift; sourceTree = "<group>"; };
+		AA63F87320A39D8D002B719B /* AppFeatureConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureConfiguration.swift; sourceTree = "<group>"; };
+		AA63F87620A39DCF002B719B /* AppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeature.swift; sourceTree = "<group>"; };
+		AA63F87920A3A198002B719B /* AppFeatureConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureConfigurator.swift; sourceTree = "<group>"; };
 		AA69F6582086A2720054EFCE /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchainSettings.swift; sourceTree = "<group>"; };
 		AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingInstructionsView.swift; sourceTree = "<group>"; };
@@ -1627,7 +1636,7 @@
 			children = (
 				AA1E522A2097CA360099BD10 /* AuthenticationCoordinator.swift */,
 				AA1E522C2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift */,
-				AA1E52582098374A0099BD10 /* AuthenticationCoordinator+TouchID.swift */,
+				AA1E52582098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift */,
 				51E5C72F20741A130000A7FD /* AuthenticationManager.swift */,
 				510EA1742080F59C00A63AB8 /* Models */,
 				AACE31ED2092B1BA00B7B806 /* Views */,
@@ -2049,6 +2058,7 @@
 				9F1831F315176F2200FB3D52 /* Categories */,
 				AAA33338208811460019AD55 /* Coordinators */,
 				510EA19620811FF100A63AB8 /* Extensions */,
+				AA63F87220A39D4E002B719B /* Feature Configuration */,
 				9F0CBAAB15135DF200CD945D /* JavaScript */,
 				9F765F3A14BC7C3100048EFB /* Models */,
 				51A7348B20891EB3009727D5 /* Network */,
@@ -2220,6 +2230,16 @@
 				AA63F85320A12FC8002B719B /* BitcoinURLPayloadTests.swift */,
 			);
 			path = URL;
+			sourceTree = "<group>";
+		};
+		AA63F87220A39D4E002B719B /* Feature Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				AA63F87620A39DCF002B719B /* AppFeature.swift */,
+				AA63F87320A39D8D002B719B /* AppFeatureConfiguration.swift */,
+				AA63F87920A3A198002B719B /* AppFeatureConfigurator.swift */,
+			);
+			path = "Feature Configuration";
 			sourceTree = "<group>";
 		};
 		AA69F65C2086A7330054EFCE /* Settings */ = {
@@ -2902,12 +2922,14 @@
 			files = (
 				51135709209CF6C000056D65 /* SecondPasswordViewController.swift in Sources */,
 				AACE32012093FA1A00B7B806 /* ReminderCoordinator.swift in Sources */,
+				AA63F87B20A3A198002B719B /* AppFeatureConfigurator.swift in Sources */,
 				AACE31DA2092A99B00B7B806 /* UIApplication.swift in Sources */,
 				C787180220A22362000CC46E /* WalletAddressesDelegate.swift in Sources */,
 				AA31A7BC2098DFCF00FE6268 /* SideMenuItem.swift in Sources */,
 				AA63F85920A134DA002B719B /* BCTextField.swift in Sources */,
 				AACE31D42092A99B00B7B806 /* AppCoordinator.swift in Sources */,
 				AACE31D02092A99B00B7B806 /* AuthenticationError.swift in Sources */,
+				AA63F87520A39D8D002B719B /* AppFeatureConfiguration.swift in Sources */,
 				AACE31D92092A99B00B7B806 /* Reachability.swift in Sources */,
 				AACE31DE2092A99B00B7B806 /* BlockchainAPI.swift in Sources */,
 				516546F6208FCF710019EE63 /* NetworkManager+UserAgent.swift in Sources */,
@@ -2943,6 +2965,7 @@
 				51135707209CF68500056D65 /* BackupViewController.swift in Sources */,
 				AACE31CA2092A99B00B7B806 /* AssetAddress.swift in Sources */,
 				51135702209CEEB900056D65 /* PushNotificationAuthPayload.swift in Sources */,
+				AA63F87820A39DCF002B719B /* AppFeature.swift in Sources */,
 				AACE31B82092A87900B7B806 /* PinTests.swift in Sources */,
 				AACE31C82092A99B00B7B806 /* ModalPresenter.swift in Sources */,
 				AACE31C32092A99B00B7B806 /* AppDelegate.swift in Sources */,
@@ -2974,7 +2997,7 @@
 				5185E12B208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */,
 				AACE31CB2092A99B00B7B806 /* AssetType.swift in Sources */,
 				AAD27A31209D22FD00C0EAFC /* AVCaptureDeviceInput.swift in Sources */,
-				AA1E525A2098374A0099BD10 /* AuthenticationCoordinator+TouchID.swift in Sources */,
+				AA1E525A2098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift in Sources */,
 				51135706209CF64900056D65 /* BackupNavigationViewController.swift in Sources */,
 				AA1E52342097CC2C0099BD10 /* AuthenticationCoordinator.swift in Sources */,
 				AACE31C62092A99B00B7B806 /* LoadingViewPresenter.swift in Sources */,
@@ -3071,6 +3094,7 @@
 				2322DCC31D771831000E5AC1 /* NSRunLoop+SRWebSocket.m in Sources */,
 				84B601C7197ACD6300DA1829 /* UITextField+Blocks.m in Sources */,
 				9F765F4714BC8AEF00048EFB /* MultiAddressResponse.m in Sources */,
+				AA63F87A20A3A198002B719B /* AppFeatureConfigurator.swift in Sources */,
 				C780A446202228A400E49274 /* BCPriceChartView.m in Sources */,
 				FA6323391A433B1C00EB3974 /* Foundation-Utility.m in Sources */,
 				239CD5681C122BDE00997DF5 /* SettingsTwoStepViewController.m in Sources */,
@@ -3129,6 +3153,7 @@
 				C79EEFC21E898E380087DDCD /* WalletSetupViewController.m in Sources */,
 				6762507D1A2CC5800052B63F /* BCEditAccountView.m in Sources */,
 				C723F3491F64413400A858A9 /* TransactionsViewController.m in Sources */,
+				AA63F87720A39DCF002B719B /* AppFeature.swift in Sources */,
 				C7F041961E3BD4A6004E8B4A /* BuyBitcoinViewController.m in Sources */,
 				C7448A9C2034DDF80041947E /* AssetSelectorView.m in Sources */,
 				C7CE34B81F4DCB7E00032806 /* CardsViewController.m in Sources */,
@@ -3165,7 +3190,7 @@
 				67EE1DCA19E3325900DBBFC9 /* ECPercentDrivenInteractiveTransition.m in Sources */,
 				C74E21CD2028A61F00A9FBB1 /* BCPriceChartContainerViewController.m in Sources */,
 				C71859471F3E227D00745A87 /* BCDescriptionView.m in Sources */,
-				AA1E52592098374A0099BD10 /* AuthenticationCoordinator+TouchID.swift in Sources */,
+				AA1E52592098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift in Sources */,
 				678CD7481A2777E600748AA5 /* BCCreateAccountView.m in Sources */,
 				23F8DE531DAEB11C001899AE /* BCNavigationController.m in Sources */,
 				C7A0E92E1FA8FFBF004F4267 /* ExchangeConfirmViewController.m in Sources */,
@@ -3249,6 +3274,7 @@
 				84CCFAAF197D859C00DA4482 /* NSString+NSString_EscapeQuotes.m in Sources */,
 				2390C10B1D87376E00342C38 /* TransactionRecipientsViewController.m in Sources */,
 				C7618B611F66C817003E7589 /* QRCodeScannerSendViewController.m in Sources */,
+				AA63F87420A39D8D002B719B /* AppFeatureConfiguration.swift in Sources */,
 				23FB5C071D9ABB450008C6AB /* TransactionDetailDescriptionCell.m in Sources */,
 				23BA220E1D6B4AB500D0472B /* KeychainItemWrapper+Credentials.m in Sources */,
 				23DEF96E1DB11C98004AAAB6 /* TransferAllFundsBuilder.m in Sources */,

--- a/Blockchain/AccountsAndAddressesDetailViewController.m
+++ b/Blockchain/AccountsAndAddressesDetailViewController.m
@@ -136,15 +136,16 @@ typedef enum {
 
 - (BOOL)canTransferFromAddress
 {
-#ifdef ENABLE_TRANSFER_FUNDS
+    AppFeatureConfiguration *transferFundsConfiguration = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureTransferFundsFromImportedAddress];
+    if (!transferFundsConfiguration.isEnabled) {
+        return NO;
+    }
+
     if (self.address) {
         return [[WalletManager.sharedInstance.wallet getLegacyAddressBalance:self.address assetType:self.assetType] longLongValue] >= [WalletManager.sharedInstance.wallet dust] && ![WalletManager.sharedInstance.wallet isWatchOnlyLegacyAddress:self.address] && ![self isArchived] && [WalletManager.sharedInstance.wallet didUpgradeToHd];
     } else {
         return NO;
     }
-#else
-    return NO;
-#endif
 }
 
 #pragma mark - Actions

--- a/Blockchain/AccountsAndAddressesNavigationController.m
+++ b/Blockchain/AccountsAndAddressesNavigationController.m
@@ -56,17 +56,19 @@
     [backButton addTarget:self action:@selector(backButtonClicked:) forControlEvents:UIControlEventTouchUpInside];
     [topBar addSubview:backButton];
     self.backButton = backButton;
-#ifdef ENABLE_TRANSFER_FUNDS
-    UIButton *warningButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    warningButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
-    warningButton.imageEdgeInsets = UIEdgeInsetsMake(0, 4, 0, 0);
-    [warningButton.titleLabel setFont:[UIFont systemFontOfSize:FONT_SIZE_MEDIUM]];
-    [warningButton setImage:[UIImage imageNamed:@"warning"] forState:UIControlStateNormal];
-    [warningButton addTarget:self action:@selector(transferAllFundsWarningClicked) forControlEvents:UIControlEventTouchUpInside];
-    [topBar addSubview:warningButton];
-    warningButton.hidden = YES;
-    self.warningButton = warningButton;
-#endif
+
+    AppFeatureConfiguration *transferFundsConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureTransferFundsFromImportedAddress];
+    if (transferFundsConfig.isEnabled) {
+        UIButton *warningButton = [UIButton buttonWithType:UIButtonTypeCustom];
+        warningButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+        warningButton.imageEdgeInsets = UIEdgeInsetsMake(0, 4, 0, 0);
+        [warningButton.titleLabel setFont:[UIFont systemFontOfSize:FONT_SIZE_MEDIUM]];
+        [warningButton setImage:[UIImage imageNamed:@"warning"] forState:UIControlStateNormal];
+        [warningButton addTarget:self action:@selector(transferAllFundsWarningClicked) forControlEvents:UIControlEventTouchUpInside];
+        [topBar addSubview:warningButton];
+        warningButton.hidden = YES;
+        self.warningButton = warningButton;
+    }
 
     CGFloat assetSelectorViewHorizontalPadding = 8;
     self.assetSelectorView = [[AssetSelectorView alloc] initWithFrame:CGRectMake(assetSelectorViewHorizontalPadding, headerLabel.frame.origin.y + headerLabel.frame.size.height + 8, self.view.frame.size.width - assetSelectorViewHorizontalPadding*2, ASSET_SELECTOR_ROW_HEIGHT) assets:@[[NSNumber numberWithInteger:AssetTypeBitcoin], [NSNumber numberWithInteger:AssetTypeBitcoinCash]] delegate:self];
@@ -186,7 +188,11 @@
 
 - (void)alertUserToTransferAllFunds:(BOOL)userClicked
 {
-#ifdef ENABLE_TRANSFER_FUNDS
+    AppFeatureConfiguration *transferFundsConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureTransferFundsFromImportedAddress];
+    if (!transferFundsConfig.isEnabled) {
+        return;
+    }
+
     UIAlertController *alertToTransfer = [UIAlertController alertControllerWithTitle:BC_STRING_TRANSFER_FUNDS message:[NSString stringWithFormat:@"%@\n\n%@", BC_STRING_TRANSFER_FUNDS_DESCRIPTION_ONE, BC_STRING_TRANSFER_FUNDS_DESCRIPTION_TWO] preferredStyle:UIAlertControllerStyleAlert];
     [alertToTransfer addAction:[UIAlertAction actionWithTitle:BC_STRING_NOT_NOW style:UIAlertActionStyleCancel handler:nil]];
     [alertToTransfer addAction:[UIAlertAction actionWithTitle:BC_STRING_TRANSFER_FUNDS style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
@@ -200,7 +206,6 @@
     }
     
     [self presentViewController:alertToTransfer animated:YES completion:nil];
-#endif
 }
 
 #pragma mark - Transfer Funds

--- a/Blockchain/Authentication/AuthenticationCoordinator+Biometrics.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator+Biometrics.swift
@@ -1,5 +1,5 @@
 //
-//  AuthenticationCoordinator+TouchID.swift
+//  AuthenticationCoordinator+Biometrics.swift
 //  Blockchain
 //
 //  Created by Chris Arriola on 4/30/18.

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -150,13 +150,11 @@ import Foundation
 
         if BlockchainSettings.App.shared.isPinSet {
             showPinEntryView(asModal: true)
-            // TODO enable touch ID
-//            #ifdef ENABLE_TOUCH_ID
-//            if ([[NSUserDefaults standardUserDefaults] boolForKey:USER_DEFAULTS_KEY_TOUCH_ID_ENABLED]) {
-//                [self authenticateWithTouchID];
-//            }
-//            #endif
-            authenticateWithBiometrics()
+            if let config = AppFeatureConfigurator.shared.configuration(for: .touchId),
+                config.isEnabled,
+                BlockchainSettings.App.shared.touchIDEnabled {
+                authenticateWithBiometrics()
+            }
         } else {
             NetworkManager.shared.checkForMaintenance(withCompletion: { response in
                 guard let message = response else { return }

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -14,12 +14,6 @@
     #import "LocalizationConstants.h"
 #endif
 
-#define ENABLE_TRANSFER_FUNDS 1
-// #define ENABLE_TRANSACTION_FETCHING 1
-#define ENABLE_SWIPE_TO_RECEIVE 1
-#define ENABLE_TOUCH_ID 1
-// #define ENABLE_CONTACTS 1
-
 #define APP_STORE_LINK_PREFIX @"itms-apps://itunes.apple.com/app/"
 #define APP_STORE_ID @"id493253309"
 

--- a/Blockchain/Feature Configuration/AppFeature.swift
+++ b/Blockchain/Feature Configuration/AppFeature.swift
@@ -1,0 +1,16 @@
+//
+//  AppFeature.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 5/9/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Enumerates app features that can be dynamically configured (e.g. enabled/disabled)
+@objc enum AppFeature: Int, RawValued {
+    case touchId
+    case swipeToReceive
+    case transferFundsFromImportedAddress
+}

--- a/Blockchain/Feature Configuration/AppFeatureConfiguration.swift
+++ b/Blockchain/Feature Configuration/AppFeatureConfiguration.swift
@@ -1,0 +1,19 @@
+//
+//  AppFeatureConfiguration.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 5/9/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Defines a configuration for a given `AppFeature`
+@objc class AppFeatureConfiguration: NSObject {
+
+    @objc let isEnabled: Bool
+
+    init(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+    }
+}

--- a/Blockchain/Feature Configuration/AppFeatureConfigurator.swift
+++ b/Blockchain/Feature Configuration/AppFeatureConfigurator.swift
@@ -1,0 +1,35 @@
+//
+//  AppFeatureConfigurator.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 5/9/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+@objc class AppFeatureConfigurator: NSObject {
+    static let shared = AppFeatureConfigurator()
+
+    /// Class function to retrieve the AppFeatureConfigurator shared instance for obj-c compatibility.
+    @objc class func sharedInstance() -> AppFeatureConfigurator { return shared }
+
+    private var featureToConfigurations = [AppFeature: AppFeatureConfiguration]()
+
+    private override init() {
+        super.init()
+        // Enable all features by default
+        AppFeature.rawValues.forEach {
+            let feature = AppFeature(rawValue: $0)!
+            featureToConfigurations[feature] = AppFeatureConfiguration(isEnabled: true)
+        }
+    }
+
+    /// Returns an `AppFeatureConfiguration` object for the provided feature.
+    ///
+    /// - Parameter feature: the feature
+    /// - Returns: the configuration for the feature requested
+    @objc func configuration(for feature: AppFeature) -> AppFeatureConfiguration? {
+        return featureToConfigurations[feature]
+    }
+}

--- a/Blockchain/Pin/Pin.swift
+++ b/Blockchain/Pin/Pin.swift
@@ -57,12 +57,13 @@ class Pin {
         let value = NSData(bytes: dataPointer, length: data.count).hexadecimalString()
 
         WalletManager.shared.wallet.pinServerPutKey(onPinServerServer: key, value: value, pin: self.toString)
-        // TODO handle touch ID
-        //    #ifdef ENABLE_TOUCH_ID
-        //    if (BlockchainSettings.sharedAppInstance.touchIDEnabled) {
-        //        [KeychainItemWrapper setPINInKeychain:pin];
-        //    }
-        //    #endif
+
+        // Optionally save PIN in keychain if touch ID is enabled
+        if let config = AppFeatureConfigurator.shared.configuration(for: .touchId),
+            config.isEnabled,
+            BlockchainSettings.App.shared.touchIDEnabled {
+            KeychainItemWrapper.setPINInKeychain(self.toString)
+        }
     }
 }
 

--- a/Blockchain/SettingsTableViewController.m
+++ b/Blockchain/SettingsTableViewController.m
@@ -37,16 +37,6 @@ const int securityTwoStep = 0;
 const int securityPasswordChange = 1;
 const int securityWalletRecoveryPhrase = 2;
 const int PINChangePIN = 3;
-#if defined(ENABLE_TOUCH_ID) && defined(ENABLE_SWIPE_TO_RECEIVE)
-const int PINTouchID = 4;
-const int PINSwipeToReceive = 5;
-#elif ENABLE_TOUCH_ID
-const int PINTouchID = 4;
-const int PINSwipeToReceive = -1;
-#elif ENABLE_SWIPE_TO_RECEIVE
-const int PINSwipeToReceive = 4;
-const int PINTouchID = -1;
-#endif
 
 const int aboutSection = 3;
 const int aboutUs = 0;
@@ -70,9 +60,36 @@ const int aboutPrivacyPolicy = 2;
 @property (nonatomic) BOOL isEnablingTwoStepSMS;
 @property (nonatomic) BackupNavigationViewController *backupController;
 
+@property (readonly, nonatomic) int PINTouchID;
+@property (readonly, nonatomic) int PINSwipeToReceive;
+
 @end
 
 @implementation SettingsTableViewController
+
+- (int)PINTouchID
+{
+    AppFeatureConfiguration *touchIDConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureTouchId];
+    AppFeatureConfiguration *swipeToReceiveConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureSwipeToReceive];
+    if (touchIDConfig.isEnabled && swipeToReceiveConfig.isEnabled) {
+        return 4;
+    } else if (touchIDConfig.isEnabled) {
+        return 4;
+    }
+    return -1;
+}
+
+- (int)PINSwipeToReceive
+{
+    AppFeatureConfiguration *touchIDConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureTouchId];
+    AppFeatureConfiguration *swipeToReceiveConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureSwipeToReceive];
+    if (touchIDConfig.isEnabled && swipeToReceiveConfig.isEnabled) {
+        return 5;
+    } else if (touchIDConfig.isEnabled) {
+        return -1;
+    }
+    return 4;
+}
 
 - (void)viewDidLoad
 {
@@ -544,7 +561,7 @@ const int aboutPrivacyPolicy = 2;
             }
         }]];
         [swipeToReceiveAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:PINSwipeToReceive inSection:sectionSecurity];
+            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:self.PINSwipeToReceive inSection:sectionSecurity];
             [self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
         }]];
         [self presentViewController:swipeToReceiveAlert animated:YES completion:nil];
@@ -569,7 +586,7 @@ const int aboutPrivacyPolicy = 2;
 
         UIAlertController *alertTouchIDError = [UIAlertController alertControllerWithTitle:BC_STRING_ERROR message:errorString preferredStyle:UIAlertControllerStyleAlert];
         [alertTouchIDError addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:PINTouchID inSection:sectionSecurity];
+            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:self.PINTouchID inSection:sectionSecurity];
             [self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
         }]];
         [self presentViewController:alertTouchIDError animated:YES completion:nil];
@@ -583,7 +600,7 @@ const int aboutPrivacyPolicy = 2;
     if (!(touchIDEnabled == YES)) {
         UIAlertController *alertForTogglingTouchID = [UIAlertController alertControllerWithTitle:BC_STRING_SETTINGS_PIN_USE_TOUCH_ID_AS_PIN message:BC_STRING_TOUCH_ID_WARNING preferredStyle:UIAlertControllerStyleAlert];
         [alertForTogglingTouchID addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:PINTouchID inSection:sectionSecurity];
+            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:self.PINTouchID inSection:sectionSecurity];
             [self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
         }]];
         [alertForTogglingTouchID addAction:[UIAlertAction actionWithTitle:BC_STRING_CONTINUE style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
@@ -1097,9 +1114,9 @@ const int aboutPrivacyPolicy = 2;
         case sectionSecurity: {
             NSInteger numberOfRows = 0;
 
-            if (PINTouchID > 0 && PINSwipeToReceive > 0) {
+            if (self.PINTouchID > 0 && self.PINSwipeToReceive > 0) {
                 numberOfRows = 5;
-            } else if (PINTouchID > 0 || PINSwipeToReceive > 0) {
+            } else if (self.PINTouchID > 0 || self.PINSwipeToReceive > 0) {
                 numberOfRows = 4;
             } else {
                 numberOfRows = 3;
@@ -1264,7 +1281,7 @@ const int aboutPrivacyPolicy = 2;
                 cell.textLabel.text = BC_STRING_CHANGE_PIN;
                 cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
                 return cell;
-            } else if (indexPath.row == PINTouchID) {
+            } else if (indexPath.row == self.PINTouchID) {
                 cell.textLabel.adjustsFontSizeToFitWidth = YES;
                 cell.detailTextLabel.adjustsFontSizeToFitWidth = YES;
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -1276,7 +1293,7 @@ const int aboutPrivacyPolicy = 2;
                 [switchForTouchID addTarget:self action:@selector(switchTouchIDTapped) forControlEvents:UIControlEventTouchUpInside];
                 cell.accessoryView = switchForTouchID;
                 return cell;
-            } else if (indexPath.row == PINSwipeToReceive) {
+            } else if (indexPath.row == self.PINSwipeToReceive) {
                 cell.textLabel.adjustsFontSizeToFitWidth = YES;
                 cell.detailTextLabel.adjustsFontSizeToFitWidth = YES;
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -135,7 +135,13 @@ static PEViewController *VerifyController()
 
 - (void)setupQRCode
 {
-#ifdef ENABLE_SWIPE_TO_RECEIVE
+    AppFeatureConfiguration *swipeToReceiveConfiguration = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureSwipeToReceive];
+    if (!swipeToReceiveConfiguration.isEnabled) {
+        pinController.swipeLabel.hidden = YES;
+        pinController.swipeLabelImageView.hidden = YES;
+        return;
+    }
+
     if (self.verifyOnly &&
         BlockchainSettings.sharedAppInstance.swipeToReceiveEnabled) {
         
@@ -180,10 +186,6 @@ static PEViewController *VerifyController()
         pinController.swipeLabel.hidden = YES;
         pinController.swipeLabelImageView.hidden = YES;
     }
-#else
-    pinController.swipeLabel.hidden = YES;
-    pinController.swipeLabelImageView.hidden = YES;
-#endif
 }
 
 - (void)addAddressToSwipeView:(BCSwipeAddressView *)swipeView assetType:(AssetType)assetType


### PR DESCRIPTION
Removing `#defines`  for enabling/disabling app features such as touch ID, swipe to receive, etc. If a component requires a configuration for a specific feature, it will request it by invoking `AppFeatureConfigurator.shared.configuration(for: feature)`. The benefit of using a design like this is that we can eventually add more specific feature configurations into an instance of `AppFeatureConfiguration`. At the moment, all it does is tell you if a feature is enabled or not (by default, all features are enabled).

Other changes:
* Renamed extension class to `AuthenticationCoordinator+Biometrics`
* Implemented TODOs that depended on the `#define ENABLE_TOUCH_ID`
* Removed #defines