### PR TITLE
refactor(pin): migrate change pin out of RootService

### DIFF
--- a/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
@@ -10,6 +10,25 @@ import Foundation
 
 extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
 
+    /// Coordinates the change pin flow.
+    @objc func changePin() {
+        let pinChangeController = PEPinEntryController.pinChange()!
+        pinChangeController.pinDelegate = self
+        pinChangeController.isNavigationBarHidden = true
+
+        let peViewController = pinChangeController.viewControllers[0] as! PEViewController
+        peViewController.cancelButton.isHidden = false
+        peViewController.cancelButton.addTarget(self, action: #selector(onPinCloseButtonTapped), for: .touchUpInside)
+        peViewController.modalTransitionStyle = .coverVertical
+
+        self.pinEntryViewController = pinChangeController
+
+        AppCoordinator.shared.tabControllerManager.tabViewController.dismiss(animated: true)
+
+        UIApplication.shared.keyWindow?.rootViewController?.view.addSubview(pinChangeController.view)
+        UIApplication.shared.statusBarStyle = .default
+    }
+
     /// Coordinates the pin validation flow. Primarily used to validate the user's PIN code
     /// when enabling touch ID.
     @objc func validatePin() {
@@ -19,7 +38,7 @@ extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
 
         let peViewController = pinController.viewControllers[0] as! PEViewController
         peViewController.cancelButton.isHidden = false
-        peViewController.cancelButton.addTarget(self, action: #selector(onValidatePinCloseButtonTapped), for: .touchUpInside)
+        peViewController.cancelButton.addTarget(self, action: #selector(onPinCloseButtonTapped), for: .touchUpInside)
         peViewController.modalTransitionStyle = .coverVertical
 
         self.pinEntryViewController = pinController
@@ -34,7 +53,7 @@ extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
         UIApplication.shared.statusBarStyle = .default
     }
 
-    @objc func onValidatePinCloseButtonTapped() {
+    @objc func onPinCloseButtonTapped() {
         AppCoordinator.shared.showSettingsView()
     }
 

--- a/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
@@ -106,7 +106,7 @@ extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
         self.lastEnteredPIN = pin
 
         guard WalletManager.shared.wallet.isInitialized() || WalletManager.shared.wallet.password != nil else {
-            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.Pin.cannotSaveInvalidWalletState)
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Pin.cannotSaveInvalidWalletState)
             return
         }
 
@@ -212,7 +212,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
     }
 
     func errorGetPinEmptyResponse() {
-        showPinError(withMessage: LocalizationConstants.Authentication.Pin.incorrect)
+        showPinError(withMessage: LocalizationConstants.Pin.incorrect)
     }
 
     func errorGetPinInvalidResponse() {
@@ -231,7 +231,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
         LoadingViewPresenter.shared.hideBusyView()
 
         guard let password = walletManager.wallet.password else {
-            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.Pin.cannotSaveInvalidWalletState)
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Pin.cannotSaveInvalidWalletState)
             return
         }
 
@@ -252,7 +252,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
         }
 
         guard response.key.count != 0 && response.value.count != 0 else {
-            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.Pin.responseKeyOrValueLengthZero)
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Pin.responseKeyOrValueLengthZero)
             return
         }
 
@@ -267,7 +267,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
             password: response.value,
             pbkdf2_iterations: Int32(Constants.Security.pinPBKDF2Iterations)
         ) else {
-            errorDidFailPutPin(errorMessage: LocalizationConstants.Authentication.Pin.encryptedStringIsNil)
+            errorDidFailPutPin(errorMessage: LocalizationConstants.Pin.encryptedStringIsNil)
             return
         }
 
@@ -293,10 +293,10 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
 
         // Incorrect pin
         if response.code == nil {
-            AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.Pin.incorrect)
+            AlertViewPresenter.shared.standardError(message: LocalizationConstants.Pin.incorrect)
         } else if response.code == GetPinResponse.StatusCode.deleted.rawValue {
             // Pin retry limit exceeded
-            AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.Pin.validationCannotBeCompleted)
+            AlertViewPresenter.shared.standardError(message: LocalizationConstants.Pin.validationCannotBeCompleted)
             BlockchainSettings.App.shared.clearPin()
             logout(showPasswordView: false)
             DispatchQueue.main.async { [weak self] in
@@ -305,7 +305,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
                 strongSelf.closePinEntryView(animated: true)
             }
         } else if response.code == GetPinResponse.StatusCode.incorrect.rawValue {
-            let error = response.error ?? LocalizationConstants.Authentication.Pin.incorrectUnknownError
+            let error = response.error ?? LocalizationConstants.Pin.incorrectUnknownError
             AlertViewPresenter.shared.standardError(message: error)
         } else if response.code == GetPinResponse.StatusCode.success.rawValue {
 
@@ -327,7 +327,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
 
             // Initial PIN setup ?
             if response.pinDecryptionValue?.count == 0 {
-                AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.Pin.responseSuccessLengthZero)
+                AlertViewPresenter.shared.standardError(message: LocalizationConstants.Pin.responseSuccessLengthZero)
                 return
             }
 
@@ -341,7 +341,7 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
             if let decryptedPassword = decryptedPassword, decryptedPassword.count > 0 {
                 tryToLoadWallet(password: decryptedPassword)
             } else {
-                AlertViewPresenter.shared.standardError(message: LocalizationConstants.Authentication.Pin.decryptedPasswordLengthZero)
+                AlertViewPresenter.shared.standardError(message: LocalizationConstants.Pin.decryptedPasswordLengthZero)
                 askIfUserWantsToResetPIN()
                 return
             }
@@ -382,8 +382,8 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
 
     private func askIfUserWantsToResetPIN() {
         let alert = UIAlertController(
-            title: LocalizationConstants.Authentication.Pin.validationError,
-            message: LocalizationConstants.Authentication.Pin.validationErrorMessage,
+            title: LocalizationConstants.Pin.validationError,
+            message: LocalizationConstants.Pin.validationErrorMessage,
             preferredStyle: .alert
         )
         alert.addAction(

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -79,19 +79,19 @@ struct LocalizationConstants {
         static let secondPasswordRequired = NSLocalizedString("Second Password Required", comment: "")
         static let secondPasswordIncorrect = NSLocalizedString("Second Password Incorrect", comment: "")
         static let password = NSLocalizedString("Password", comment: "")
+    }
 
-        struct Pin {
-            static let incorrect = NSLocalizedString("Incorrect PIN. Please retry.", comment: "")
-            static let cannotSaveInvalidWalletState = NSLocalizedString("Cannot save PIN Code while wallet is not initialized or password is null", comment: "")
-            static let responseKeyOrValueLengthZero = NSLocalizedString("PIN Response Object key or value length 0", comment: "")
-            static let encryptedStringIsNil = NSLocalizedString("PIN Encrypted String is nil", comment: "")
-            static let validationCannotBeCompleted = NSLocalizedString("PIN Validation cannot be completed. Please enter your wallet password manually.", comment: "")
-            static let incorrectUnknownError = NSLocalizedString("PIN Code Incorrect. Unknown Error Message.", comment: "")
-            static let responseSuccessLengthZero = NSLocalizedString("PIN Response Object success length 0", comment: "")
-            static let decryptedPasswordLengthZero = NSLocalizedString("Decrypted PIN Password length 0", comment: "")
-            static let validationError = NSLocalizedString("PIN Validation Error", comment: "")
-            static let validationErrorMessage = NSLocalizedString("An error occurred validating your PIN code with the remote server. You may be offline or Blockchain may be experiencing difficulties. Would you like retry validation or instead enter your password manually?", comment: "")
-        }
+    struct Pin {
+        static let incorrect = NSLocalizedString("Incorrect PIN. Please retry.", comment: "")
+        static let cannotSaveInvalidWalletState = NSLocalizedString("Cannot save PIN Code while wallet is not initialized or password is null", comment: "")
+        static let responseKeyOrValueLengthZero = NSLocalizedString("PIN Response Object key or value length 0", comment: "")
+        static let encryptedStringIsNil = NSLocalizedString("PIN Encrypted String is nil", comment: "")
+        static let validationCannotBeCompleted = NSLocalizedString("PIN Validation cannot be completed. Please enter your wallet password manually.", comment: "")
+        static let incorrectUnknownError = NSLocalizedString("PIN Code Incorrect. Unknown Error Message.", comment: "")
+        static let responseSuccessLengthZero = NSLocalizedString("PIN Response Object success length 0", comment: "")
+        static let decryptedPasswordLengthZero = NSLocalizedString("Decrypted PIN Password length 0", comment: "")
+        static let validationError = NSLocalizedString("PIN Validation Error", comment: "")
+        static let validationErrorMessage = NSLocalizedString("An error occurred validating your PIN code with the remote server. You may be offline or Blockchain may be experiencing difficulties. Would you like retry validation or instead enter your password manually?", comment: "")
     }
 
     struct Biometrics {
@@ -154,7 +154,7 @@ struct LocalizationConstants {
 
     @objc class func timedOut() -> String { return LocalizationConstants.Errors.timedOut }
 
-    @objc class func incorrectPin() -> String { return LocalizationConstants.Authentication.Pin.incorrect }
+    @objc class func incorrectPin() -> String { return LocalizationConstants.Pin.incorrect }
 
     @objc class func logout() -> String { return LocalizationConstants.SideMenu.logout }
 

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -206,10 +206,10 @@
 - (void)paymentReceived:(uint64_t)amount showBackupReminder:(BOOL)showBackupReminder;
 - (void)checkIfPaymentRequestFulfilled:(Transaction *)transaction;
 
-- (void)clearPin;
-- (void)showPinModalAsView:(BOOL)asView;
-- (void)validatePINOptionally;
-- (void)changePIN;
+//- (void)clearPin;
+//- (void)showPinModalAsView:(BOOL)asView;
+//- (void)validatePINOptionally;
+//- (void)changePIN;
 
 //- (BOOL)checkInternetConnection;
 

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -2926,26 +2926,26 @@ SideMenuViewController *sideMenuViewController;
 //
 //    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
 //}
-
-- (void)changePIN
-{
-    PEPinEntryController *pinChangeController = [PEPinEntryController pinChangeController];
-    pinChangeController.pinDelegate = self;
-    pinChangeController.navigationBarHidden = YES;
-
-    PEViewController *peViewController = (PEViewController *)[[pinChangeController viewControllers] objectAtIndex:0];
-    peViewController.cancelButton.hidden = NO;
-    [peViewController.cancelButton addTarget:self action:@selector(showSettings) forControlEvents:UIControlEventTouchUpInside];
-
-    self.pinEntryViewController = pinChangeController;
-
-    peViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
-    [self.tabControllerManager.tabViewController dismissViewControllerAnimated:YES completion:nil];
-
-    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:self.pinEntryViewController.view];
-
-    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
-}
+//
+//- (void)changePIN
+//{
+//    PEPinEntryController *pinChangeController = [PEPinEntryController pinChangeController];
+//    pinChangeController.pinDelegate = self;
+//    pinChangeController.navigationBarHidden = YES;
+//
+//    PEViewController *peViewController = (PEViewController *)[[pinChangeController viewControllers] objectAtIndex:0];
+//    peViewController.cancelButton.hidden = NO;
+//    [peViewController.cancelButton addTarget:self action:@selector(showSettings) forControlEvents:UIControlEventTouchUpInside];
+//
+//    self.pinEntryViewController = pinChangeController;
+//
+//    peViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+//    [self.tabControllerManager.tabViewController dismissViewControllerAnimated:YES completion:nil];
+//
+//    [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:self.pinEntryViewController.view];
+//
+//    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
+//}
 //
 //- (void)clearPin
 //{

--- a/Blockchain/SettingsTableViewController.m
+++ b/Blockchain/SettingsTableViewController.m
@@ -1076,7 +1076,7 @@ const int aboutPrivacyPolicy = 2;
                 [self showBackup];
                 return;
             } else if (indexPath.row == PINChangePIN) {
-                [app changePIN];
+                [AuthenticationCoordinator.sharedInstance changePin];
                 return;
             }
             return;


### PR DESCRIPTION
Also fixed swiftlint error about having deeply nested classes (i.e. `LocalizationConstants.Authentication.Pin`). The linter recommends only one level of nesting.