### PR TITLE
refactor(filter): remove asset filtering from RootService.

### DIFF
--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -222,20 +222,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    // TODO: move to appropriate module
-    func toggleSymbol() {
-        let symbolLocal = BlockchainSettings.App.shared.symbolLocal
-        BlockchainSettings.App.shared.symbolLocal = !symbolLocal
-        reloadSymbols()
-    }
-
-    // TODO: don't keep a reference to each contoller, instead allow them to subscribe to value changes
-    func reloadSymbols() {
-        //    [self.tabControllerManager reloadSymbols];
-        //    [_accountsAndAddressesNavigationController reload];
-        //    [sideMenuViewController reload];
-    }
-
     // MARK: - State Checks
 
     func checkForNewInstall() {

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -78,6 +78,7 @@ import Foundation
         self.window.backgroundColor = UIColor.white
         super.init()
         self.walletManager.buySellDelegate = self
+        observeSymbolChanges()
     }
 
     // MARK: Public Methods
@@ -221,6 +222,15 @@ import Foundation
         tabControllerManager.transactionsBitcoinViewController?.messageIdentifier = nil
 
         closeSideMenu()
+    }
+
+    /// Observes symbol changes so that view controllers can reflect the new symbol
+    private func observeSymbolChanges() {
+        BlockchainSettings.App.shared.onSymbolLocalChanged = { [unowned self] _ in
+            self.tabControllerManager.reloadSymbols()
+            self.accountsAndAddressesNavigationController.reload()
+            self.sideMenuViewController.reload()
+        }
     }
 }
 

--- a/Blockchain/ExchangeTableViewCell.m
+++ b/Blockchain/ExchangeTableViewCell.m
@@ -68,7 +68,7 @@
 
 - (IBAction)amountButtonClicked:(id)sender
 {
-    [app toggleSymbol];
+    BlockchainSettings.sharedAppInstance.symbolLocal = !BlockchainSettings.sharedAppInstance.symbolLocal;
 }
 
 @end

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -166,14 +166,14 @@
 
 //- (void)reload;
 - (void)reloadAfterMultiAddressResponse;
-- (void)toggleSymbol;
+//- (void)toggleSymbol;
 
 //- (void)logoutAndShowPasswordModal;
 
-- (NSInteger)filterIndex;
-- (void)filterTransactionsByAccount:(int)accountIndex assetType:(AssetType)assetType;
-- (void)filterTransactionsByImportedAddresses;
-- (void)removeTransactionsFilter;
+//- (NSInteger)filterIndex;
+//- (void)filterTransactionsByAccount:(int)accountIndex assetType:(AssetType)assetType;
+//- (void)filterTransactionsByImportedAddresses;
+//- (void)removeTransactionsFilter;
 
 //- (void)initializeWebview;
 

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -703,8 +703,8 @@ SideMenuViewController *sideMenuViewController;
 //    [sideMenuViewController reloadTableView];
 //}
 
-- (void)toggleSymbol
-{
+//- (void)toggleSymbol
+//{
 //    symbolLocal = !symbolLocal;
 //
 //    // Save this setting here and load it on start
@@ -712,41 +712,41 @@ SideMenuViewController *sideMenuViewController;
 //    [[NSUserDefaults standardUserDefaults] synchronize];
 //
 //    [self reloadSymbols];
-}
+//}
 
-- (NSInteger)filterIndex
-{
-    return [self.tabControllerManager getFilterIndex];
-}
+//- (NSInteger)filterIndex
+//{
+//    return [self.tabControllerManager getFilterIndex];
+//}
 
-- (void)filterTransactionsByAccount:(int)accountIndex assetType:(AssetType)assetType
-{
-    [self.tabControllerManager filterTransactionsByAccount:accountIndex filterLabel:[WalletManager.sharedInstance.wallet getLabelForAccount:accountIndex assetType:self.tabControllerManager.assetType] assetType:assetType];
+//- (void)filterTransactionsByAccount:(int)accountIndex assetType:(AssetType)assetType
+//{
+//    [self.tabControllerManager filterTransactionsByAccount:accountIndex filterLabel:[WalletManager.sharedInstance.wallet getLabelForAccount:accountIndex assetType:self.tabControllerManager.assetType] assetType:assetType];
+//
+//    [WalletManager.sharedInstance.wallet reloadFilter];
+//}
 
-    [WalletManager.sharedInstance.wallet reloadFilter];
-}
+//- (void)filterTransactionsByImportedAddresses
+//{
+//    [self.tabControllerManager filterTransactionsByImportedAddresses];
+//
+//    [WalletManager.sharedInstance.wallet reloadFilter];
+//}
 
-- (void)filterTransactionsByImportedAddresses
-{
-    [self.tabControllerManager filterTransactionsByImportedAddresses];
+//- (void)removeTransactionsFilter
+//{
+//    [self.tabControllerManager removeTransactionsFilter];
+//    [WalletManager.sharedInstance.wallet reloadFilter];
+//}
 
-    [WalletManager.sharedInstance.wallet reloadFilter];
-}
-
-- (void)removeTransactionsFilter
-{
-    [self.tabControllerManager removeTransactionsFilter];
-    [WalletManager.sharedInstance.wallet reloadFilter];
-}
-
-- (void)reloadSymbols
-{
+//- (void)reloadSymbols
+//{
 //    [self.tabControllerManager reloadSymbols];
 //
 //    [_contactsViewController reloadSymbols];
 //    [_accountsAndAddressesNavigationController reload];
 //    [sideMenuViewController reload];
-}
+//}
 
 //- (void)showBusyViewWithLoadingText:(NSString *)text
 //{

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -121,12 +121,22 @@ final class BlockchainSettings: NSObject {
             }
         }
 
+        var onSymbolLocalChanged: ((Bool) -> Void)?
+
+        /// Property indicating whether or not the currency symbol that should be used throughout the app
+        /// should be fiat, if set to true, or the asset-specific symbol, if false.
         @objc var symbolLocal: Bool {
             get {
                 return defaults.bool(forKey: UserDefaults.Keys.symbolLocal.rawValue)
             }
             set {
+                let oldValue = symbolLocal
+
                 defaults.set(newValue, forKey: UserDefaults.Keys.symbolLocal.rawValue)
+                
+                if oldValue != newValue {
+                    onSymbolLocalChanged?(newValue)
+                }
             }
         }
 

--- a/Blockchain/SideMenuViewController.m
+++ b/Blockchain/SideMenuViewController.m
@@ -224,8 +224,9 @@ int accountEntries = 0;
     headerView.backgroundView = backgroundView;
     
     [self.tableView deselectRowAtIndexPath:[self.tableView indexPathForSelectedRow] animated:NO];
-    
-    [app removeTransactionsFilter];
+
+    [AppCoordinator.sharedInstance.tabControllerManager removeTransactionsFilter];
+    [WalletManager.sharedInstance.wallet reloadFilter];
 }
 
 #pragma mark - SlidingViewController Delegate

--- a/Blockchain/TransactionDetailViewController.m
+++ b/Blockchain/TransactionDetailViewController.m
@@ -429,7 +429,7 @@ const CGFloat rowHeightValueReceived = 80;
 
 - (void)toggleSymbol
 {
-    [app toggleSymbol];
+    BlockchainSettings.sharedAppInstance.symbolLocal = !BlockchainSettings.sharedAppInstance.symbolLocal;
 }
 
 - (void)textViewDidChange:(UITextView *)textView

--- a/Blockchain/TransactionsBitcoinViewController.m
+++ b/Blockchain/TransactionsBitcoinViewController.m
@@ -485,11 +485,16 @@
 
 - (void)didSelectFilter:(int)filter
 {
+    TabControllerManager *tabControllerManager = AppCoordinator.sharedInstance.tabControllerManager;
+
     if (filter == FILTER_INDEX_IMPORTED_ADDRESSES) {
-        [app filterTransactionsByImportedAddresses];
+        [tabControllerManager filterTransactionsByImportedAddresses];
     } else {
-        [app filterTransactionsByAccount:filter assetType:self.assetType];
+        NSString *filterLabel = [WalletManager.sharedInstance.wallet getLabelForAccount:filter assetType:self.assetType];
+        [tabControllerManager filterTransactionsByAccount:filter filterLabel:filterLabel assetType:self.assetType];
     }
+
+    [WalletManager.sharedInstance.wallet reloadFilter];
 }
 
 #pragma mark - View lifecycle


### PR DESCRIPTION
Can't test this until `app->symbolLocal` is migrated.

@woudini, I won't mess with that since you mentioned you're changing that.