### PR TITLE
refactor(RootService): clean up API calls on startup

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -371,6 +371,8 @@
 		C7618B611F66C817003E7589 /* QRCodeScannerSendViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C7618B601F66C817003E7589 /* QRCodeScannerSendViewController.m */; };
 		C7640FBF2056B70E00D14D51 /* BCSwipeAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = C7640FBE2056B70E00D14D51 /* BCSwipeAddressViewModel.m */; };
 		C769B2DA1FC4ABA9009632B6 /* ContinueButtonInputAccessoryView.m in Sources */ = {isa = PBXBuildFile; fileRef = C769B2D91FC4ABA9009632B6 /* ContinueButtonInputAccessoryView.m */; };
+		C77217CF20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77217CE20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift */; };
+		C77217D020AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77217CE20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift */; };
 		C780A446202228A400E49274 /* BCPriceChartView.m in Sources */ = {isa = PBXBuildFile; fileRef = C780A445202228A400E49274 /* BCPriceChartView.m */; };
 		C780A44C20235E9500E49274 /* BCBalancesChartView.m in Sources */ = {isa = PBXBuildFile; fileRef = C780A44B20235E9500E49274 /* BCBalancesChartView.m */; };
 		C787180120A22362000CC46E /* WalletAddressesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C787180020A22362000CC46E /* WalletAddressesDelegate.swift */; };
@@ -1371,6 +1373,7 @@
 		C7640FBE2056B70E00D14D51 /* BCSwipeAddressViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BCSwipeAddressViewModel.m; sourceTree = "<group>"; };
 		C769B2D81FC4ABA9009632B6 /* ContinueButtonInputAccessoryView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContinueButtonInputAccessoryView.h; sourceTree = "<group>"; };
 		C769B2D91FC4ABA9009632B6 /* ContinueButtonInputAccessoryView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ContinueButtonInputAccessoryView.m; sourceTree = "<group>"; };
+		C77217CE20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAccountInfoAndExchangeRatesDelegate.swift; sourceTree = "<group>"; };
 		C780A444202228A400E49274 /* BCPriceChartView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BCPriceChartView.h; sourceTree = "<group>"; };
 		C780A445202228A400E49274 /* BCPriceChartView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BCPriceChartView.m; sourceTree = "<group>"; };
 		C780A44A20235E9500E49274 /* BCBalancesChartView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BCBalancesChartView.h; sourceTree = "<group>"; };
@@ -2329,6 +2332,7 @@
 		AABDED6A208EC320002D8BAC /* Wallet */ = {
 			isa = PBXGroup;
 			children = (
+				C77217CE20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift */,
 				C74FEA222093B38A007CAB5D /* JSContextWithDOM.swift */,
 				AAE9113420A520D40093A431 /* WalletAccountInfoDelegate.swift */,
 				C787180020A22362000CC46E /* WalletAddressesDelegate.swift */,
@@ -3008,6 +3012,7 @@
 				51135702209CEEB900056D65 /* PushNotificationAuthPayload.swift in Sources */,
 				AA63F87820A39DCF002B719B /* AppFeature.swift in Sources */,
 				AACE31B82092A87900B7B806 /* PinTests.swift in Sources */,
+				C77217D020AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift in Sources */,
 				AACE31C82092A99B00B7B806 /* ModalPresenter.swift in Sources */,
 				AACE31C32092A99B00B7B806 /* AppDelegate.swift in Sources */,
 				AACE31822092858600B7B806 /* Pin.swift in Sources */,
@@ -3199,6 +3204,7 @@
 				5185E12A208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */,
 				23444F7E1DCD213D00573C8C /* BTCKey.m in Sources */,
 				C7A923ED1F8531FD003D9DAF /* GraphTimeFrame.m in Sources */,
+				C77217CF20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift in Sources */,
 				C79EEFC21E898E380087DDCD /* WalletSetupViewController.m in Sources */,
 				6762507D1A2CC5800052B63F /* BCEditAccountView.m in Sources */,
 				C723F3491F64413400A858A9 /* TransactionsViewController.m in Sources */,

--- a/Blockchain/BCAddressSelectionView.m
+++ b/Blockchain/BCAddressSelectionView.m
@@ -547,7 +547,7 @@ typedef enum {
                 NSComparisonResult result = [ethBalance compare:[NSDecimalNumber numberWithInt:0]];
                 zeroBalance = result == NSOrderedDescending || result == NSOrderedSame;
                 TabControllerManager *tabControllerManager = [AppCoordinator sharedInstance].tabControllerManager;
-                cell.balanceLabel.text = app->symbolLocal ? [NSNumberFormatter formatEthToFiatWithSymbol:[ethBalance stringValue] exchangeRate:tabControllerManager.latestEthExchangeRate] : [NSNumberFormatter formatEth:[NSNumberFormatter localFormattedString:[ethBalance stringValue]]];
+                cell.balanceLabel.text = BlockchainSettings.sharedAppInstance.symbolLocal ? [NSNumberFormatter formatEthToFiatWithSymbol:[ethBalance stringValue] exchangeRate:tabControllerManager.latestEthExchangeRate] : [NSNumberFormatter formatEth:[NSNumberFormatter localFormattedString:[ethBalance stringValue]]];
             } else {
                 uint64_t bchBalance = 0;
                 if (section == bchAccountsSectionNumber) {

--- a/Blockchain/BCCreateWalletView.m
+++ b/Blockchain/BCCreateWalletView.m
@@ -224,8 +224,6 @@
     BlockchainSettings.sharedAppInstance.reminderModalDate = NULL;
     
     BlockchainSettings.sharedAppInstance.shouldHideBuySellCard = YES;
-    
-    [WalletManager.sharedInstance.wallet getAllCurrencySymbols];
 }
 
 - (void)errorCreatingNewAccount:(NSString*)message

--- a/Blockchain/Blockchain-Bridging-Header.h
+++ b/Blockchain/Blockchain-Bridging-Header.h
@@ -31,3 +31,4 @@
 #import "UncaughtExceptionHandler.h"
 #import "Wallet.h"
 #import "WebLoginViewController.h"
+#import "MultiAddressResponse.h"

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -506,7 +506,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 
 #define USER_DEFAULTS_KEY_ASSET_TYPE @"assetType"
 
-#define USER_DEFAULTS_KEY_DEFAULT_ACCOUNT_LABELLED_ADDRESSES_COUNT @"defaultAccountLabelledAddressesCount"
 #define USER_DEFAULTS_KEY_NEXT_ADDRESS @"nextReceivingAddress"
 #define USER_DEFAULTS_KEY_NEXT_ADDRESS_USED @"nextReceivingAddressUsed"
 #define USER_DEFAULTS_KEY_APP_REVIEW_PROMPT_DATE @"appReviewPromptDate"

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -78,6 +78,7 @@ import Foundation
         self.window.backgroundColor = UIColor.white
         super.init()
         self.walletManager.buySellDelegate = self
+        self.walletManager.accountInfoAndExchangeRatesDelegate = self
         observeSymbolChanges()
     }
 
@@ -388,5 +389,12 @@ extension AppCoordinator: TabControllerDelegate {
 
         // TODO remove app reference and use wallet singleton.isFe
         walletManager.wallet.isFetchingTransactions = false
+    }
+}
+
+extension AppCoordinator: WalletAccountInfoAndExchangeRatesDelegate {
+    func didGetAccountInfoAndExchangeRates() {
+        LoadingViewPresenter.shared.hideBusyView()
+        reload()
     }
 }

--- a/Blockchain/ExchangeTableViewCell.m
+++ b/Blockchain/ExchangeTableViewCell.m
@@ -46,7 +46,7 @@
     self.actionLabel.frame = CGRectMake(self.actionLabel.frame.origin.x, 29, self.actionLabel.frame.size.width, self.actionLabel.frame.size.height);
     self.dateLabel.frame = CGRectMake(self.dateLabel.frame.origin.x, 11, self.dateLabel.frame.size.width, self.dateLabel.frame.size.height);
     
-    if (app->symbolLocal) {
+    if (BlockchainSettings.sharedAppInstance.symbolLocal) {
         NSString *lowercaseWithdrawalCurrencySymbol = [[trade withdrawalCurrency] lowercaseString];
         if ([lowercaseWithdrawalCurrencySymbol isEqualToString:[CURRENCY_SYMBOL_BTC lowercaseString]]) {
             amountString = [NSNumberFormatter formatMoney:ABS([NSNumberFormatter parseBtcValueFromString:[trade.withdrawalAmount stringValue]])];

--- a/Blockchain/Extensions/UserDefaults.swift
+++ b/Blockchain/Extensions/UserDefaults.swift
@@ -41,5 +41,6 @@ extension UserDefaults {
         case symbolLocal = "symbolLocal"
         case touchIDEnabled = "touchIDEnabled"
         case hideTransferAllFundsAlert = "hideTransferAllFundsAlert"
+        case defaultAccountLabelledAddressesCount = "defaultAccountLabelledAddressesCount"
     }
 }

--- a/Blockchain/NSNumberFormatter+Currencies.m
+++ b/Blockchain/NSNumberFormatter+Currencies.m
@@ -71,7 +71,7 @@
 
 + (NSString*)formatMoney:(uint64_t)value
 {
-    return [self formatMoney:value localCurrency:app->symbolLocal];
+    return [self formatMoney:value localCurrency:BlockchainSettings.sharedAppInstance.symbolLocal];
 }
 
 // Format amount in satoshi as NSString (without symbol)
@@ -126,7 +126,7 @@
 
 + (NSString *)formatMoneyWithLocalSymbol:(uint64_t)value
 {
-    return [self formatMoney:value localCurrency:app->symbolLocal];
+    return [self formatMoney:value localCurrency:BlockchainSettings.sharedAppInstance.symbolLocal];
 }
 
 #pragma mark - Ether
@@ -197,8 +197,8 @@
 {
     NSString *symbol = WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local.symbol;
     BOOL hasSymbol = symbol && ![symbol isKindOfClass:[NSNull class]];
-        
-    if (app->symbolLocal && hasSymbol) {
+
+    if (BlockchainSettings.sharedAppInstance.symbolLocal && hasSymbol) {
         return [NSNumberFormatter formatEthToFiatWithSymbol:ethAmount exchangeRate:exchangeRate];
     } else {
         return [NSNumberFormatter formatEth:ethAmount];
@@ -302,7 +302,7 @@
 
 + (NSString*)formatBchWithSymbol:(uint64_t)value
 {
-    return [self formatBchWithSymbol:value localCurrency:app->symbolLocal];
+    return [self formatBchWithSymbol:value localCurrency:BlockchainSettings.sharedAppInstance.symbolLocal];
 }
 
 // Format amount in satoshi as NSString (with symbol)

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -1048,48 +1048,49 @@ SideMenuViewController *sideMenuViewController;
 //    [WalletManager.sharedInstance.wallet loadContactsThenGetMessages];
 //}
 
-- (void)didGetMultiAddressResponse:(MultiAddressResponse*)response
-{
-    WalletManager.sharedInstance.latestMultiAddressResponse = response;
+//- (void)didGetMultiAddressResponse:(MultiAddressResponse*)response
+//{
+//    WalletManager.sharedInstance.latestMultiAddressResponse = response;
+//
+//    [self.tabControllerManager updateTransactionsViewControllerData:response];
+//
+//#ifdef ENABLE_TRANSACTION_FETCHING
+//    if (WalletManager.sharedInstance.wallet.isFetchingTransactions) {
+//        [_transactionsViewController reload];
+//        WalletManager.sharedInstance.wallet.isFetchingTransactions = NO;
+//    } else {
+//        [self reloadAfterMultiAddressResponse];
+//    }
+//#else
+//    if (WalletManager.sharedInstance.wallet.isFilteringTransactions) {
+//        WalletManager.sharedInstance.wallet.isFilteringTransactions = NO;
+//        [self updateSymbols];
+//        [self reloadAfterMultiAddressResponse];
+//    } else {
+//        [WalletManager.sharedInstance.wallet getAccountInfoAndExchangeRates];
+//    }
+//#endif
+//
+//    int newDefaultAccountLabeledAddressesCount = [WalletManager.sharedInstance.wallet getDefaultAccountLabelledAddressesCount];
+//    NSNumber *lastCount = [[NSUserDefaults standardUserDefaults] objectForKey:USER_DEFAULTS_KEY_DEFAULT_ACCOUNT_LABELLED_ADDRESSES_COUNT];
+//    if (lastCount && [lastCount intValue] != newDefaultAccountLabeledAddressesCount) {
+//        [KeychainItemWrapper removeAllSwipeAddressesForAssetType:AssetTypeBitcoin];
+//    }
+//    [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithInt:newDefaultAccountLabeledAddressesCount] forKey:USER_DEFAULTS_KEY_DEFAULT_ACCOUNT_LABELLED_ADDRESSES_COUNT];
+//}
 
-    [self.tabControllerManager updateTransactionsViewControllerData:response];
+//- (void)didSetLatestBlock:(LatestBlock*)block
+//{
+//    [self.tabControllerManager didSetLatestBlock:block];
+//}
 
-#ifdef ENABLE_TRANSACTION_FETCHING
-    if (WalletManager.sharedInstance.wallet.isFetchingTransactions) {
-        [_transactionsViewController reload];
-        WalletManager.sharedInstance.wallet.isFetchingTransactions = NO;
-    } else {
-        [self reloadAfterMultiAddressResponse];
-    }
-#else
-    if (WalletManager.sharedInstance.wallet.isFilteringTransactions) {
-        WalletManager.sharedInstance.wallet.isFilteringTransactions = NO;
-        [self updateSymbols];
-        [self reloadAfterMultiAddressResponse];
-    } else {
-        [self getAccountInfo];
-    }
-#endif
-
-    int newDefaultAccountLabeledAddressesCount = [WalletManager.sharedInstance.wallet getDefaultAccountLabelledAddressesCount];
-    NSNumber *lastCount = [[NSUserDefaults standardUserDefaults] objectForKey:USER_DEFAULTS_KEY_DEFAULT_ACCOUNT_LABELLED_ADDRESSES_COUNT];
-    if (lastCount && [lastCount intValue] != newDefaultAccountLabeledAddressesCount) {
-        [KeychainItemWrapper removeAllSwipeAddressesForAssetType:LegacyAssetTypeBitcoin];
-    }
-    [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithInt:newDefaultAccountLabeledAddressesCount] forKey:USER_DEFAULTS_KEY_DEFAULT_ACCOUNT_LABELLED_ADDRESSES_COUNT];
-}
-
-- (void)didSetLatestBlock:(LatestBlock*)block
-{
-    [self.tabControllerManager didSetLatestBlock:block];
-}
-
-- (void)getAccountInfo
-{
-    // TODO: move this to WalletManager
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didGetAccountInfo) name:NOTIFICATION_KEY_GET_ACCOUNT_INFO_SUCCESS object:nil];
-    [WalletManager.sharedInstance.wallet getAccountInfo];
-}
+//- (void)getAccountInfo
+//{
+//    // TODO: move this to WalletManager
+//    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didGetAccountInfo) name:NOTIFICATION_KEY_GET_ACCOUNT_INFO_SUCCESS object:nil];
+//    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reloadAfterGettingCurrencySymbols) name:NOTIFICATION_KEY_GET_ALL_CURRENCY_SYMBOLS_SUCCESS object:nil];
+//    [WalletManager.sharedInstance.wallet getAccountInfo];
+//}
 
 //- (void)didGetAccountInfo
 //{
@@ -1119,37 +1120,48 @@ SideMenuViewController *sideMenuViewController;
 //
 //    [WalletManager.sharedInstance.wallet fetchBitcoinCashExchangeRates];
 //}
+//    [WalletManager.sharedInstance.wallet getAllCurrencySymbols];
+//}
 
-- (void)didGetBitcoinCashExchangeRates
-{
-    [WalletManager.sharedInstance.wallet getEthExchangeRate];
-}
+//- (void)reloadAfterGettingCurrencySymbols
+//{
+////    [[NSNotificationCenter defaultCenter] removeObserver:self name:NOTIFICATION_KEY_GET_ALL_CURRENCY_SYMBOLS_SUCCESS object:nil];
+//
+////    [self updateSymbols];
+//
+////    [WalletManager.sharedInstance.wallet fetchBitcoinCashExchangeRates];
+//}
 
-- (void)didFetchBitcoinCashHistory
-{
-    [LoadingViewPresenter.sharedInstance hideBusyView];
+//- (void)didGetBitcoinCashExchangeRates
+//{
+//    [WalletManager.sharedInstance.wallet getEthExchangeRate];
+//}
 
-    [AppCoordinator.sharedInstance reload];
-}
+//- (void)didFetchBitcoinCashHistory
+//{
+//    [LoadingViewPresenter.sharedInstance hideBusyView];
+//
+//    [AppCoordinator.sharedInstance reload];
+//}
 
-- (void)updateSymbols
-{
-    {
-        NSString *fiatCode = WalletManager.sharedInstance.wallet.accountInfo[DICTIONARY_KEY_ACCOUNT_SETTINGS_CURRENCY_FIAT];
-        NSMutableDictionary *symbolLocalDict = [[NSMutableDictionary alloc] initWithDictionary:[WalletManager.sharedInstance.wallet.currencySymbols objectForKey:fiatCode]];
-        [symbolLocalDict setObject:fiatCode forKey:DICTIONARY_KEY_CODE];
-        if (symbolLocalDict) {
-            WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local = [CurrencySymbol symbolFromDict:symbolLocalDict];
-        }
-    }
-
-    {
-        NSString *btcCode = WalletManager.sharedInstance.wallet.accountInfo[DICTIONARY_KEY_ACCOUNT_SETTINGS_CURRENCY_BTC];
-        if (btcCode) {
-            WalletManager.sharedInstance.latestMultiAddressResponse.symbol_btc = [CurrencySymbol btcSymbolFromCode:btcCode];
-        }
-    }
-}
+//- (void)updateSymbols
+//{
+//    {
+//        NSString *fiatCode = WalletManager.sharedInstance.wallet.accountInfo[DICTIONARY_KEY_ACCOUNT_SETTINGS_CURRENCY_FIAT];
+//        NSMutableDictionary *symbolLocalDict = [[NSMutableDictionary alloc] initWithDictionary:[WalletManager.sharedInstance.wallet.currencySymbols objectForKey:fiatCode]];
+//        [symbolLocalDict setObject:fiatCode forKey:DICTIONARY_KEY_CODE];
+//        if (symbolLocalDict) {
+//            WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local = [CurrencySymbol symbolFromDict:symbolLocalDict];
+//        }
+//    }
+//
+//    {
+//        NSString *btcCode = WalletManager.sharedInstance.wallet.accountInfo[DICTIONARY_KEY_ACCOUNT_SETTINGS_CURRENCY_BTC];
+//        if (btcCode) {
+//            WalletManager.sharedInstance.latestMultiAddressResponse.symbol_btc = [CurrencySymbol btcSymbolFromCode:btcCode];
+//        }
+//    }
+//}
 
 //- (void)walletFailedToDecrypt
 //{
@@ -2429,12 +2441,12 @@ SideMenuViewController *sideMenuViewController;
     [self.tabControllerManager didUpdateEthPayment:ethPayment];
 }
 
-- (void)didFetchEthExchangeRate:(NSNumber *)rate
-{
-    [self reloadAfterMultiAddressResponse];
-
-    [self.tabControllerManager didFetchEthExchangeRate:rate];
-}
+//- (void)didFetchEthExchangeRate:(NSNumber *)rate
+//{
+//    [self reloadAfterMultiAddressResponse];
+//
+//    [self.tabControllerManager didFetchEthExchangeRate:rate];
+//}
 
 - (void)didSendEther
 {

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -447,7 +447,7 @@ BOOL displayingLocalSymbolSend;
         btcLabel.text = self.assetType == LegacyAssetTypeBitcoin ? WalletManager.sharedInstance.latestMultiAddressResponse.symbol_btc.symbol : CURRENCY_SYMBOL_BCH;
     }
     
-    if (app->symbolLocal && WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local && WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local.conversion > 0) {
+    if (BlockchainSettings.sharedAppInstance.symbolLocal && WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local && WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local.conversion > 0) {
         displayingLocalSymbol = TRUE;
         displayingLocalSymbolSend = TRUE;
     } else if (WalletManager.sharedInstance.latestMultiAddressResponse.symbol_btc) {
@@ -845,7 +845,7 @@ BOOL displayingLocalSymbolSend;
             [self enablePaymentButtons];
         } onResume:nil];
         
-        NSDecimalNumber *last = [NSDecimalNumber decimalNumberWithDecimal:[[NSDecimalNumber numberWithDouble:[[WalletManager.sharedInstance.wallet.currencySymbols objectForKey:DICTIONARY_KEY_USD][DICTIONARY_KEY_LAST] doubleValue]] decimalValue]];
+        NSDecimalNumber *last = [NSDecimalNumber decimalNumberWithDecimal:[[NSDecimalNumber numberWithDouble:[[WalletManager.sharedInstance.wallet.btcRates objectForKey:DICTIONARY_KEY_USD][DICTIONARY_KEY_LAST] doubleValue]] decimalValue]];
         NSDecimalNumber *conversionToUSD = [[NSDecimalNumber decimalNumberWithDecimal:[[NSDecimalNumber numberWithDouble:SATOSHI] decimalValue]] decimalNumberByDividingBy:last];
         NSDecimalNumber *feeConvertedToUSD = [(NSDecimalNumber *)[NSDecimalNumber numberWithLongLong:feeTotal] decimalNumberByDividingBy:conversionToUSD];
         

--- a/Blockchain/SendEtherViewController.m
+++ b/Blockchain/SendEtherViewController.m
@@ -215,7 +215,7 @@
         self.amountInputView.fiatLabel.text = WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local.code;
     }
     
-    self.displayingLocalSymbolSend = (app->symbolLocal && WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local && WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local.conversion > 0);
+    self.displayingLocalSymbolSend = (BlockchainSettings.sharedAppInstance.symbolLocal && WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local && WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local.conversion > 0);
 }
 
 - (void)setAddress:(NSString *)address

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -189,8 +189,8 @@ final class BlockchainSettings: NSObject {
             get {
                 return KeychainItemWrapper.sharedKey()
             }
-           
-            
+
+
             set {
                 guard let sharedKey = newValue else {
                     KeychainItemWrapper.removeSharedKeyFromKeychain()
@@ -199,7 +199,7 @@ final class BlockchainSettings: NSObject {
                 KeychainItemWrapper.setSharedKeyInKeychain(sharedKey)
             }
         }
-        
+
         @objc var shouldHideAllCards: Bool {
             get {
                 return defaults.bool(forKey: UserDefaults.Keys.shouldHideAllCards.rawValue)
@@ -208,7 +208,7 @@ final class BlockchainSettings: NSObject {
                 defaults.set(newValue, forKey: UserDefaults.Keys.shouldHideAllCards.rawValue)
             }
         }
-        
+
         @objc var shouldHideBuySellCard: Bool {
             get {
                 return defaults.bool(forKey: UserDefaults.Keys.shouldHideBuySellCard.rawValue)
@@ -256,6 +256,16 @@ final class BlockchainSettings: NSObject {
                     return
                 }
                 KeychainItemWrapper.setSwipeEtherAddress(etherAddress)
+            }
+        }
+
+        /// Number of labelled addresses for default account
+        @objc var defaultAccountLabelledAddressesCount: Int {
+            get {
+                return defaults.integer(forKey: UserDefaults.Keys.defaultAccountLabelledAddressesCount.rawValue)
+            }
+            set {
+                defaults.set(newValue, forKey: UserDefaults.Keys.defaultAccountLabelledAddressesCount.rawValue)
             }
         }
 

--- a/Blockchain/SettingsSelectorTableViewController.h
+++ b/Blockchain/SettingsSelectorTableViewController.h
@@ -11,5 +11,4 @@
 
 @interface SettingsSelectorTableViewController : UITableViewController
 @property (nonatomic, copy) NSDictionary *itemsDictionary;
-@property (nonatomic, copy) NSDictionary *allCurrencySymbolsDictionary;
 @end

--- a/Blockchain/SettingsTableViewController.m
+++ b/Blockchain/SettingsTableViewController.m
@@ -157,7 +157,7 @@ const int aboutPrivacyPolicy = 2;
 {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didGetCurrencySymbols) name:NOTIFICATION_KEY_GET_ALL_CURRENCY_SYMBOLS_SUCCESS object:nil];
 
-    [WalletManager.sharedInstance.wallet getAllCurrencySymbols];
+    [WalletManager.sharedInstance.wallet getBtcExchangeRates];
 }
 
 - (void)didGetCurrencySymbols
@@ -168,7 +168,7 @@ const int aboutPrivacyPolicy = 2;
 
 - (void)updateCurrencySymbols
 {
-    self.allCurrencySymbolsDictionary = WalletManager.sharedInstance.wallet.currencySymbols;
+    self.allCurrencySymbolsDictionary = WalletManager.sharedInstance.wallet.btcRates;
 
     [self reloadTableView];
 }
@@ -1020,7 +1020,6 @@ const int aboutPrivacyPolicy = 2;
     if ([segue.identifier isEqualToString:SEGUE_IDENTIFIER_CURRENCY]) {
         SettingsSelectorTableViewController *settingsSelectorTableViewController = segue.destinationViewController;
         settingsSelectorTableViewController.itemsDictionary = self.availableCurrenciesDictionary;
-        settingsSelectorTableViewController.allCurrencySymbolsDictionary = self.allCurrencySymbolsDictionary;
     } else if ([segue.identifier isEqualToString:SEGUE_IDENTIFIER_TWO_STEP]) {
         SettingsTwoStepViewController *twoStepViewController = (SettingsTwoStepViewController *)segue.destinationViewController;
         twoStepViewController.settingsController = self;

--- a/Blockchain/TabControllerManager.m
+++ b/Blockchain/TabControllerManager.m
@@ -65,6 +65,7 @@
 
 - (void)reload
 {
+    [_dashboardViewController reload];
     [_sendBitcoinViewController reload];
     [_sendEtherViewController reload];
     [_sendBitcoinCashViewController reload];

--- a/Blockchain/TransactionEtherTableViewCell.m
+++ b/Blockchain/TransactionEtherTableViewCell.m
@@ -40,7 +40,7 @@
     TabControllerManager *tabControllerManager = [AppCoordinator sharedInstance].tabControllerManager;
     self.ethButton.titleLabel.minimumScaleFactor = 0.75f;
     self.ethButton.titleLabel.adjustsFontSizeToFitWidth = YES;
-    [self.ethButton setTitle:app->symbolLocal ? [NSNumberFormatter formatEthToFiatWithSymbol:self.transaction.amount exchangeRate:tabControllerManager.latestEthExchangeRate] : [NSNumberFormatter formatEth: self.transaction.amountTruncated] forState:UIControlStateNormal];
+    [self.ethButton setTitle:BlockchainSettings.sharedAppInstance.symbolLocal ? [NSNumberFormatter formatEthToFiatWithSymbol:self.transaction.amount exchangeRate:tabControllerManager.latestEthExchangeRate] : [NSNumberFormatter formatEth: self.transaction.amountTruncated] forState:UIControlStateNormal];
     [self.ethButton addTarget:self action:@selector(ethButtonClicked) forControlEvents:UIControlEventTouchUpInside];
     
     if ([self.transaction.txType isEqualToString:TX_TYPE_TRANSFER]) {

--- a/Blockchain/TransactionsBitcoinViewController.m
+++ b/Blockchain/TransactionsBitcoinViewController.m
@@ -192,7 +192,7 @@
         }
 #endif
         // Balance
-        self.balance = [NSNumberFormatter formatMoney:[self getBalance] localCurrency:app->symbolLocal];
+        self.balance = [NSNumberFormatter formatMoney:[self getBalance] localCurrency:BlockchainSettings.sharedAppInstance.symbolLocal];
         [self changeFilterLabel:[self getFilterLabel]];
 
     }
@@ -201,7 +201,8 @@
         self.noTransactionsView.hidden = YES;
         
         // Balance
-        self.balance = [NSNumberFormatter formatMoney:[self getBalance] localCurrency:app->symbolLocal];
+        self.balance = [NSNumberFormatter formatMoney:[self getBalance] localCurrency: BlockchainSettings.sharedAppInstance.symbolLocal
+];
         [self changeFilterLabel:[self getFilterLabel]];
     }
 }

--- a/Blockchain/TransactionsEtherViewController.m
+++ b/Blockchain/TransactionsEtherViewController.m
@@ -74,7 +74,7 @@
     NSString *balance = [WalletManager.sharedInstance.wallet getEthBalanceTruncated];
 
     TabControllerManager *tabControllerManager = [AppCoordinator sharedInstance].tabControllerManager;
-    self.balance = app->symbolLocal ? [NSNumberFormatter formatEthToFiatWithSymbol:balance exchangeRate:tabControllerManager.latestEthExchangeRate] : [NSNumberFormatter formatEth:balance];
+    self.balance = BlockchainSettings.sharedAppInstance.symbolLocal ? [NSNumberFormatter formatEthToFiatWithSymbol:balance exchangeRate:tabControllerManager.latestEthExchangeRate] : [NSNumberFormatter formatEth:balance];
 }
 
 - (void)reloadSymbols

--- a/Blockchain/Wallet.h
+++ b/Blockchain/Wallet.h
@@ -140,14 +140,14 @@
 - (void)didShiftPayment:(NSDictionary *)info;
 - (void)showGetAssetsAlertForCurrencySymbol:(NSString *)currencySymbol;
 - (void)didCreateEthAccountForExchange;
-- (void)didGetBitcoinCashExchangeRates;
 - (void)didFetchBitcoinCashHistory;
 - (void)initializeWebView;
 - (void)wallet:(Wallet *)wallet didRequireTwoFactorAuthentication:(NSInteger)type;
 - (void)walletDidResendTwoFactorSMS:(Wallet *)wallet;
 - (void)walletDidRequireEmailAuthorization:(Wallet *)wallet;
 - (void)walletDidGetAccountInfo:(Wallet *)wallet;
-- (void)walletDidGetAllCurrencySymbols:(Wallet *)wallet;
+- (void)walletDidGetBtcExchangeRates:(Wallet *)wallet;
+- (void)walletDidGetAccountInfoAndExchangeRates:(Wallet *)wallet;
 @end
 
 @interface Wallet : NSObject <UIWebViewDelegate, SRWebSocketDelegate, ExchangeAccountDelegate> {
@@ -190,7 +190,7 @@
 @property BOOL isSyncing;
 @property BOOL isNew;
 @property NSString *twoFactorInput;
-@property (nonatomic) NSDictionary *currencySymbols;
+@property (nonatomic) NSDictionary *btcRates;
 
 @property (nonatomic) SRWebSocket *btcSocket;
 @property (nonatomic) SRWebSocket *bchSocket;
@@ -356,9 +356,11 @@
 - (int)getTwoStepType;
 - (BOOL)getEmailVerifiedStatus;
 
+- (void)getAccountInfoAndExchangeRates;
+
 - (void)changeEmail:(NSString *)newEmail;
 - (void)resendVerificationEmail:(NSString *)email;
-- (void)getAllCurrencySymbols;
+- (void)getBtcExchangeRates;
 - (void)changeMobileNumber:(NSString *)newMobileNumber;
 - (void)verifyMobileNumber:(NSString *)code;
 - (void)enableTwoStepVerificationForSMS;

--- a/Blockchain/Wallet/WalletAccountInfoAndExchangeRatesDelegate.swift
+++ b/Blockchain/Wallet/WalletAccountInfoAndExchangeRatesDelegate.swift
@@ -1,0 +1,16 @@
+//
+//  WalletAccountInfoAndExchangeRatesDelegate.swift
+//  Blockchain
+//
+//  Created by kevinwu on 5/17/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Temporary protocol to use in place of a completion handler that would be passed into getAccountInfoAndExchangeRates()
+@objc protocol WalletAccountInfoAndExchangeRatesDelegate: class {
+    
+    /// Method invoked after getting account info and exchange rates on startup
+    func didGetAccountInfoAndExchangeRates()
+}

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -1453,13 +1453,29 @@ MyWalletPhone.getAccountInfo = function () {
         console.log('Getting account info');
         var accountInfo = JSON.stringify(data, null, 2);
         objc_on_get_account_info_success(accountInfo);
+        return data;
     }
 
     var error = function (e) {
         console.log('Error getting account info: ' + e);
     };
 
-    MyWallet.wallet.fetchAccountInfo().then(success).catch(error);
+    return MyWallet.wallet.fetchAccountInfo().then(success).catch(error);
+}
+
+MyWalletPhone.getAccountInfoAndExchangeRates = function() {
+    
+    var success = function() {
+        objc_on_get_account_info_and_exchange_rates()
+    };
+    
+    MyWalletPhone.getAccountInfo().then(function(data) {
+        var getBtcExchangeRates = MyWalletPhone.getBtcExchangeRates()
+        var getBchExchangeRates = MyWalletPhone.bch.fetchExchangeRates()
+        var currency =  data.currency
+        var getEthExchangeRate = MyWalletPhone.getEthExchangeRate(currency)
+        Promise.all([getBtcExchangeRates, getBchExchangeRates, getEthExchangeRate]).then(success);
+    });
 }
 
 MyWalletPhone.getEmail = function () {
@@ -1613,12 +1629,13 @@ MyWalletPhone.changeBtcCurrency = function(code) {
     BlockchainSettingsAPI.changeBtcCurrency(code, success, error);
 }
 
-MyWalletPhone.getAllCurrencySymbols = function () {
+MyWalletPhone.getBtcExchangeRates = function () {
 
     var success = function (data) {
-        console.log('Getting all currency symbols');
+        console.log('Getting btc exchange rates');
         var currencySymbolData = JSON.stringify(data, null, 2);
-        objc_on_get_all_currency_symbols_success(currencySymbolData);
+        objc_on_get_btc_exchange_rates_success(currencySymbolData);
+        return data;
     };
 
     var error = function (e) {
@@ -1626,7 +1643,7 @@ MyWalletPhone.getAllCurrencySymbols = function () {
     };
 
     var promise = BlockchainAPI.getTicker();
-    promise.then(success, error);
+    return promise.then(success, error);
 }
 
 MyWalletPhone.getPasswordStrength = function(password) {
@@ -2360,6 +2377,7 @@ MyWalletPhone.getEthExchangeRate = function(currencyCode) {
     var success = function(result) {
         console.log('Success fetching eth exchange rate');
         objc_on_fetch_eth_exchange_rate_success(result, currencyCode);
+        return result;
     };
 
     var error = function(error) {
@@ -2368,7 +2386,7 @@ MyWalletPhone.getEthExchangeRate = function(currencyCode) {
         objc_on_fetch_eth_exchange_rate_error(error);
     };
 
-    BlockchainAPI.getExchangeRate(currencyCode, 'ETH').then(success).catch(error);
+    return BlockchainAPI.getExchangeRate(currencyCode, 'ETH').then(success).catch(error);
 }
 
 MyWalletPhone.getEthBalance = function() {
@@ -2902,14 +2920,14 @@ MyWalletPhone.bch = {
     
     fetchExchangeRates : function() {
         var success = function(result) {
-            objc_did_get_bitcoin_cash_exchange_rates(result, true);
+            objc_did_get_bitcoin_cash_exchange_rates(result);
             return result;
         }
         
         var error = function(e) {
             console.log(e);
         }
-        BlockchainAPI.getExchangeRate('USD', 'BCH').then(success).catch(error);
+        return BlockchainAPI.getExchangeRate('USD', 'BCH').then(success).catch(error);
     },
     
     getAvailableBalanceForAccount : function(accountIndex) {


### PR DESCRIPTION
Clean up the flow of methods on startup, which was previously the following:
```
Multiaddr
did_multiaddr
didGetMultiAddressResponse
getAccountInfo
reloadAfterGettingCurrencySymbols -> updateSymbols (BTC rates)
fetchBitcoinCashExchangeRates
getEthExchangeRate
```
