### PR TITLE
refactor(RootService): set app coordinator as transfer all delegate

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -363,6 +363,8 @@
 		C74E865320B3043E00F7263D /* WalletHistoryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74E865120B3043E00F7263D /* WalletHistoryDelegate.swift */; };
 		C74E865920B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74E865820B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift */; };
 		C74E865A20B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74E865820B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift */; };
+		C74E866120B3272B00F7263D /* TransferAllCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74E866020B3272B00F7263D /* TransferAllCoordinator.swift */; };
+		C74E866220B3272B00F7263D /* TransferAllCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74E866020B3272B00F7263D /* TransferAllCoordinator.swift */; };
 		C74FEA232093B38A007CAB5D /* JSContextWithDOM.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74FEA222093B38A007CAB5D /* JSContextWithDOM.swift */; };
 		C74FEA2620979259007CAB5D /* JSContextWithDOMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74FEA2520979259007CAB5D /* JSContextWithDOMTests.swift */; };
 		C7559CAF1F55E874005B2375 /* BCConfirmPaymentViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = C7559CAE1F55E874005B2375 /* BCConfirmPaymentViewModel.m */; };
@@ -378,6 +380,8 @@
 		C769B2DA1FC4ABA9009632B6 /* ContinueButtonInputAccessoryView.m in Sources */ = {isa = PBXBuildFile; fileRef = C769B2D91FC4ABA9009632B6 /* ContinueButtonInputAccessoryView.m */; };
 		C76D730420B2052000040B57 /* WalletExchangeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76D730320B2052000040B57 /* WalletExchangeDelegate.swift */; };
 		C76D730520B2052000040B57 /* WalletExchangeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76D730320B2052000040B57 /* WalletExchangeDelegate.swift */; };
+		C76D731720B24B5400040B57 /* WalletTransferAllDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76D731620B24B5300040B57 /* WalletTransferAllDelegate.swift */; };
+		C76D731820B24B5400040B57 /* WalletTransferAllDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76D731620B24B5300040B57 /* WalletTransferAllDelegate.swift */; };
 		C77217CF20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77217CE20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift */; };
 		C77217D020AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77217CE20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift */; };
 		C77217E820AFCC3C0087836A /* WalletBackupDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77217E720AFCC3C0087836A /* WalletBackupDelegate.swift */; };
@@ -1367,6 +1371,7 @@
 		C74E21CC2028A61F00A9FBB1 /* BCPriceChartContainerViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BCPriceChartContainerViewController.m; sourceTree = "<group>"; };
 		C74E865120B3043E00F7263D /* WalletHistoryDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletHistoryDelegate.swift; sourceTree = "<group>"; };
 		C74E865820B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletExchangeIntermediateDelegate.swift; sourceTree = "<group>"; };
+		C74E866020B3272B00F7263D /* TransferAllCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferAllCoordinator.swift; sourceTree = "<group>"; };
 		C74FEA222093B38A007CAB5D /* JSContextWithDOM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSContextWithDOM.swift; sourceTree = "<group>"; };
 		C74FEA2520979259007CAB5D /* JSContextWithDOMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSContextWithDOMTests.swift; sourceTree = "<group>"; };
 		C7559CAD1F55E874005B2375 /* BCConfirmPaymentViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BCConfirmPaymentViewModel.h; sourceTree = "<group>"; };
@@ -1391,6 +1396,7 @@
 		C769B2D81FC4ABA9009632B6 /* ContinueButtonInputAccessoryView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContinueButtonInputAccessoryView.h; sourceTree = "<group>"; };
 		C769B2D91FC4ABA9009632B6 /* ContinueButtonInputAccessoryView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ContinueButtonInputAccessoryView.m; sourceTree = "<group>"; };
 		C76D730320B2052000040B57 /* WalletExchangeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletExchangeDelegate.swift; sourceTree = "<group>"; };
+		C76D731620B24B5300040B57 /* WalletTransferAllDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransferAllDelegate.swift; sourceTree = "<group>"; };
 		C77217CE20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAccountInfoAndExchangeRatesDelegate.swift; sourceTree = "<group>"; };
 		C77217E720AFCC3C0087836A /* WalletBackupDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletBackupDelegate.swift; sourceTree = "<group>"; };
 		C77217EC20AFCF940087836A /* WalletRecoveryDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletRecoveryDelegate.swift; sourceTree = "<group>"; };
@@ -1435,6 +1441,7 @@
 		C79672831FDEF4CC00F07C69 /* NSDateFormatter+VerboseString.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDateFormatter+VerboseString.m"; sourceTree = "<group>"; };
 		C799B278205383DD00CC522D /* BCSwipeAddressView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BCSwipeAddressView.h; sourceTree = "<group>"; };
 		C799B279205383DD00CC522D /* BCSwipeAddressView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BCSwipeAddressView.m; sourceTree = "<group>"; };
+		C79A239720B3520D000D96B9 /* DestinationAddressSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DestinationAddressSource.h; sourceTree = "<group>"; };
 		C79B27B020A6215B0061D0F2 /* WalletSendEtherDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSendEtherDelegate.swift; sourceTree = "<group>"; };
 		C79EEFC01E898E380087DDCD /* WalletSetupViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WalletSetupViewController.h; sourceTree = "<group>"; };
 		C79EEFC11E898E380087DDCD /* WalletSetupViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WalletSetupViewController.m; sourceTree = "<group>"; };
@@ -2013,6 +2020,7 @@
 		9F765F3A14BC7C3100048EFB /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				C79A239720B3520D000D96B9 /* DestinationAddressSource.h */,
 				C78893E420A36572003C0A8F /* Trade.swift */,
 				6780DB961A40BDF40048EED2 /* AccountInOut.h */,
 				6780DB971A40BDF40048EED2 /* AccountInOut.m */,
@@ -2320,6 +2328,7 @@
 		AAA33338208811460019AD55 /* Coordinators */ = {
 			isa = PBXGroup;
 			children = (
+				C74E866020B3272B00F7263D /* TransferAllCoordinator.swift */,
 				AAA3333C208813040019AD55 /* OnboardingCoordinator.swift */,
 				AA69F6582086A2720054EFCE /* AppCoordinator.swift */,
 				AAA3333A2088115C0019AD55 /* Coordinator.swift */,
@@ -2356,6 +2365,7 @@
 			children = (
 				C74E865120B3043E00F7263D /* WalletHistoryDelegate.swift */,
 				C74E865820B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift */,
+				C76D731620B24B5300040B57 /* WalletTransferAllDelegate.swift */,
 				C76D730320B2052000040B57 /* WalletExchangeDelegate.swift */,
 				C77217E720AFCC3C0087836A /* WalletBackupDelegate.swift */,
 				C77217EC20AFCF940087836A /* WalletRecoveryDelegate.swift */,
@@ -3012,6 +3022,7 @@
 				AACE31C42092A99B00B7B806 /* Constants.swift in Sources */,
 				C7369223209A4FDF004F5438 /* NumberFormatter+AssetsTests.swift in Sources */,
 				AACE31382091220300B7B806 /* HTTPCookieStorage.swift in Sources */,
+				C74E866220B3272B00F7263D /* TransferAllCoordinator.swift in Sources */,
 				51A862BE2090DD6400B338E0 /* PairingInstructionsView.swift in Sources */,
 				511356E4209CAFC600056D65 /* NetworkManager+PushNotifications.swift in Sources */,
 				AAD27A29209CFE2100C0EAFC /* PasswordConfirmView.swift in Sources */,
@@ -3031,6 +3042,7 @@
 				AA63F84C20A12AE9002B719B /* URLs.swift in Sources */,
 				519435A1208E61F3001EF882 /* BlockchainTests.swift in Sources */,
 				5113570A209CF6CE00056D65 /* BCSecureTextField.swift in Sources */,
+				C76D731820B24B5400040B57 /* WalletTransferAllDelegate.swift in Sources */,
 				AACE31D52092A99B00B7B806 /* Coordinator.swift in Sources */,
 				AACE32082097835F00B7B806 /* AuthenticationManagerTests.swift in Sources */,
 				5185E11C208E7F7C00A26B64 /* BlockchainSettings.swift in Sources */,
@@ -3181,6 +3193,7 @@
 				23B731D31E01AC1100129770 /* ReminderModalViewController.m in Sources */,
 				23444F9F1DCD221A00573C8C /* BTCProtocolSerialization.m in Sources */,
 				AA1E522F2097CC010099BD10 /* WalletAuthDelegate.swift in Sources */,
+				C74E866120B3272B00F7263D /* TransferAllCoordinator.swift in Sources */,
 				84FC02FA1981452D00B97D5B /* NSString+JSONParser_NSString.m in Sources */,
 				9F765F3D14BC7C4F00048EFB /* Transaction.m in Sources */,
 				5185E124208F6E5E00A26B64 /* Enum+RawValued.swift in Sources */,
@@ -3341,6 +3354,7 @@
 				2322DCC11D771831000E5AC1 /* SRSIMDHelpers.m in Sources */,
 				9F2780B715343A7D0015F83F /* UncaughtExceptionHandler.m in Sources */,
 				673107F219F6D49F00BE6899 /* PrivateKeyReader.m in Sources */,
+				C76D731720B24B5400040B57 /* WalletTransferAllDelegate.swift in Sources */,
 				C7559CAF1F55E874005B2375 /* BCConfirmPaymentViewModel.m in Sources */,
 				AA31A7D12099310B00FE6268 /* WalletBuySellDelegate.swift in Sources */,
 				84FC02FE19815F1B00B97D5B /* sha256.c in Sources */,

--- a/Blockchain/AccountsAndAddressesNavigationController.m
+++ b/Blockchain/AccountsAndAddressesNavigationController.m
@@ -221,7 +221,7 @@
         [[AppCoordinator sharedInstance] closeSideMenu];
     }];
     
-    [app setupTransferAllFunds];
+    [[AppCoordinator sharedInstance] setupTransferAllFunds];
 }
 
 #pragma mark - Navigation

--- a/Blockchain/AccountsAndAddressesNavigationController.m
+++ b/Blockchain/AccountsAndAddressesNavigationController.m
@@ -221,7 +221,7 @@
         [[AppCoordinator sharedInstance] closeSideMenu];
     }];
     
-    [[AppCoordinator sharedInstance] setupTransferAllFunds];
+    [[TransferAllCoordinator sharedInstance] startWithSendScreen];
 }
 
 #pragma mark - Navigation

--- a/Blockchain/BCBalancesChartView.m
+++ b/Blockchain/BCBalancesChartView.m
@@ -159,9 +159,10 @@
         dataSet.selectionShift = 5;
         self.chartView.highlightPerTapEnabled = NO;
     } else {
-        NSDictionary *btcChartEntryData = @{@"currency": BC_STRING_BITCOIN, @"symbol": self.fiatSymbol};
-        NSDictionary *ethChartEntryData = @{@"currency": BC_STRING_ETHER, @"symbol": self.fiatSymbol};
-        NSDictionary *bchChartEntryData = @{@"currency": BC_STRING_BITCOIN_CASH, @"symbol": self.fiatSymbol};
+        NSString *fiatSymbol = self.fiatSymbol ? : @"";
+        NSDictionary *btcChartEntryData = @{@"currency": BC_STRING_BITCOIN, @"symbol": fiatSymbol};
+        NSDictionary *ethChartEntryData = @{@"currency": BC_STRING_ETHER, @"symbol": fiatSymbol};
+        NSDictionary *bchChartEntryData = @{@"currency": BC_STRING_BITCOIN_CASH, @"symbol": fiatSymbol};
         ChartDataEntry *bitcoinValue = [[PieChartDataEntry alloc] initWithValue:self.bitcoinFiatBalance data:btcChartEntryData];
         ChartDataEntry *etherValue = [[PieChartDataEntry alloc] initWithValue:self.etherFiatBalance data:ethChartEntryData];
         ChartDataEntry *bitcoinCashValue = [[PieChartDataEntry alloc] initWithValue:self.bitcoinCashFiatBalance data:bchChartEntryData];

--- a/Blockchain/BackupViewController.swift
+++ b/Blockchain/BackupViewController.swift
@@ -65,8 +65,7 @@ import UIKit
                 let alertToTransferAll = UIAlertController(title: NSLocalizedString("Transfer imported addresses?", comment: ""), message: NSLocalizedString("Imported addresses are not backed up by your Recovery Phrase. To secure these funds, we recommend transferring these balances to include in your backup.", comment: ""), preferredStyle: .alert)
                 alertToTransferAll.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler: nil))
                 alertToTransferAll.addAction(UIAlertAction(title: NSLocalizedString("Transfer all", comment: ""), style: .default, handler: { _ in
-                    TransferAllCoordinator.shared.start()
-                    TransferAllCoordinator.shared.transferAllController?.delegate = self
+                    TransferAllCoordinator.shared.start(withDelegate: self)
                 }))
                 present(alertToTransferAll, animated: true, completion: nil)
             }

--- a/Blockchain/BackupViewController.swift
+++ b/Blockchain/BackupViewController.swift
@@ -65,15 +65,8 @@ import UIKit
                 let alertToTransferAll = UIAlertController(title: NSLocalizedString("Transfer imported addresses?", comment: ""), message: NSLocalizedString("Imported addresses are not backed up by your Recovery Phrase. To secure these funds, we recommend transferring these balances to include in your backup.", comment: ""), preferredStyle: .alert)
                 alertToTransferAll.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler: nil))
                 alertToTransferAll.addAction(UIAlertAction(title: NSLocalizedString("Transfer all", comment: ""), style: .default, handler: { _ in
-                    let transferAllController = TransferAllFundsViewController()
-                    transferAllController.delegate = self
-                    let navigationController = BCNavigationController(
-                        rootViewController: transferAllController,
-                        title: NSLocalizedString("Transfer All Funds",
-                        comment: "")
-                    )
-                    app.transferAllFundsModalController = transferAllController
-                    self.present(navigationController!, animated: true, completion: nil)
+                    TransferAllCoordinator.shared.start()
+                    TransferAllCoordinator.shared.transferAllController?.delegate = self
                 }))
                 present(alertToTransferAll, animated: true, completion: nil)
             }

--- a/Blockchain/Blockchain-Bridging-Header.h
+++ b/Blockchain/Blockchain-Bridging-Header.h
@@ -32,3 +32,4 @@
 #import "Wallet.h"
 #import "WebLoginViewController.h"
 #import "MultiAddressResponse.h"
+#import "Transaction.h"

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -264,7 +264,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 // TODO: Move these in Constants.NotificationKeys
 #define NOTIFICATION_KEY_LOADING_TEXT @"SetLoadingText"
 #define NOTIFICATION_KEY_RELOAD_ACCOUNTS_AND_ADDRESSES @"reloadAccountsAndAddresses"
-#define NOTIFICATION_KEY_MULTIADDRESS_RESPONSE_RELOAD @"multiaddressResponseReload"
 #define NOTIFICATION_KEY_GET_FIAT_AT_TIME @"getFiatAtTime"
 
 #define NOTIFICATION_KEY_SHARE_CONTACT_LINK @"shareContactLink"

--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -65,6 +65,7 @@ struct Constants {
         static let modalViewDismissed = NSNotification.Name("modalViewDismissed")
         static let reloadToDismissViews = NSNotification.Name("reloadToDismissViews")
         static let newAddress = NSNotification.Name("newAddress")
+        static let multiAddressResponseReload = NSNotification.Name("multiaddressResponseReload")
         static let appEnteredBackground = NSNotification.Name("applicationDidEnterBackground")
         static let backupSuccess = NSNotification.Name("backupSuccess")
     }
@@ -118,6 +119,10 @@ struct Constants {
 
     @objc class func notificationKeyNewAddress() -> String {
         return Constants.NotificationKeys.newAddress.rawValue
+    }
+
+    @objc class func notificationKeyMultiAddressResponseReload() -> String {
+        return Constants.NotificationKeys.multiAddressResponseReload.rawValue
     }
 
     @objc class func notificationKeyBackupSuccess() -> String {

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -202,12 +202,6 @@ import Foundation
         slidingViewController.resetTopView(animated: true)
     }
 
-    @objc func setupTransferAllFunds() {
-        let coordinator = TransferAllCoordinator.shared
-        coordinator.transferAllController = nil
-        tabControllerManager.setupTransferAllFunds()
-    }
-
     /// Reloads contained view controllers
     @objc func reload() {
         tabControllerManager.reload()

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -202,6 +202,12 @@ import Foundation
         slidingViewController.resetTopView(animated: true)
     }
 
+    @objc func setupTransferAllFunds() {
+        let coordinator = TransferAllCoordinator.shared
+        coordinator.transferAllController = nil
+        tabControllerManager.setupTransferAllFunds()
+    }
+
     /// Reloads contained view controllers
     @objc func reload() {
         tabControllerManager.reload()
@@ -234,6 +240,24 @@ import Foundation
             self.accountsAndAddressesNavigationController.reload()
             self.sideMenuViewController.reload()
         }
+    }
+
+    func reloadAfterMultiAddressResponse() {
+        if WalletManager.shared.wallet.didReceiveMessageForLastTransaction {
+            WalletManager.shared.wallet.didReceiveMessageForLastTransaction = false
+            if let transaction = WalletManager.shared.latestMultiAddressResponse?.transactions.firstObject as? Transaction {
+                tabControllerManager.receiveBitcoinViewController?.paymentReceived(UInt64(abs(transaction.amount)), showBackupReminder: false)
+            }
+        }
+
+        tabControllerManager.reloadAfterMultiAddressResponse()
+        settingsNavigationController.reloadAfterMultiAddressResponse()
+        accountsAndAddressesNavigationController.reload()
+        sideMenuViewController.reload()
+
+        NotificationCenter.default.post(name: Constants.NotificationKeys.reloadToDismissViews, object: nil)
+        NotificationCenter.default.post(name: Constants.NotificationKeys.newAddress, object: nil)
+        NotificationCenter.default.post(name: Constants.NotificationKeys.multiAddressResponseReload, object: nil)
     }
 }
 
@@ -397,7 +421,7 @@ extension AppCoordinator: TabControllerDelegate {
 extension AppCoordinator: WalletAccountInfoAndExchangeRatesDelegate {
     func didGetAccountInfoAndExchangeRates() {
         LoadingViewPresenter.shared.hideBusyView()
-        reload()
+        reloadAfterMultiAddressResponse()
     }
 }
 

--- a/Blockchain/Coordinators/TransferAllCoordinator.swift
+++ b/Blockchain/Coordinators/TransferAllCoordinator.swift
@@ -16,7 +16,6 @@ class TransferAllCoordinator: Coordinator {
         WalletManager.shared.transferAllDelegate = self
     }
 
-    weak var transferDelegate: TransferAllPromptDelegate?
     var transferAllController: TransferAllFundsViewController?
 
     func start() {

--- a/Blockchain/Coordinators/TransferAllCoordinator.swift
+++ b/Blockchain/Coordinators/TransferAllCoordinator.swift
@@ -1,0 +1,63 @@
+//
+//  TransferAllCoordinator.swift
+//  Blockchain
+//
+//  Created by kevinwu on 5/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Coordinator for the transfer all flow.
+class TransferAllCoordinator: Coordinator {
+    static let shared = TransferAllCoordinator()
+
+    private init() {
+        WalletManager.shared.transferAllDelegate = self
+    }
+
+    weak var transferDelegate: TransferAllPromptDelegate?
+    var transferAllController: TransferAllFundsViewController?
+
+    func start() {
+        transferAllController = TransferAllFundsViewController()
+        let navigationController = BCNavigationController(
+            rootViewController: transferAllController,
+            title: NSLocalizedString("Transfer All Funds",
+                                     comment: "")
+        )
+        let tabViewController = AppCoordinator.shared.tabControllerManager.tabViewController
+        tabViewController?.topMostViewController!.present(navigationController!, animated: true, completion: nil)
+    }
+}
+
+extension TransferAllCoordinator: WalletTransferAllDelegate {
+    func updateTransferAll(amount: NSNumber, fee: NSNumber, addressesUsed: NSArray) {
+        if transferAllController != nil {
+            transferAllController?.updateTransferAllAmount(amount, fee: fee, addressesUsed: addressesUsed as! [Any])
+        } else {
+            AppCoordinator.shared.tabControllerManager.updateTransferAllAmount(amount, fee: fee, addressesUsed: addressesUsed as! [Any])
+        }
+    }
+
+    func showSummaryForTransferAll() {
+        if transferAllController != nil {
+            transferAllController?.showSummaryForTransferAll()
+            LoadingViewPresenter.shared.hideBusyView()
+        } else {
+            AppCoordinator.shared.tabControllerManager.showSummaryForTransferAll()
+        }
+    }
+
+    func sendDuringTransferAll(secondPassword: String?) {
+        if transferAllController != nil {
+            transferAllController?.sendDuringTransferAll(secondPassword)
+        } else {
+            AppCoordinator.shared.tabControllerManager.sendDuringTransferAll(secondPassword)
+        }
+    }
+
+    func didErrorDuringTransferAll(error: String, secondPassword: String?) {
+        AppCoordinator.shared.tabControllerManager.didErrorDuringTransferAll(error, secondPassword: secondPassword)
+    }
+}

--- a/Blockchain/Coordinators/TransferAllCoordinator.swift
+++ b/Blockchain/Coordinators/TransferAllCoordinator.swift
@@ -9,14 +9,20 @@
 import Foundation
 
 /// Coordinator for the transfer all flow.
-class TransferAllCoordinator: Coordinator {
+@objc class TransferAllCoordinator: NSObject, Coordinator {
     static let shared = TransferAllCoordinator()
 
-    private init() {
+    // class function declared so that the TransferAllCoordinator singleton can be accessed from obj-C
+    @objc class func sharedInstance() -> TransferAllCoordinator {
+        return TransferAllCoordinator.shared
+    }
+    
+    private override init() {
+        super.init()
         WalletManager.shared.transferAllDelegate = self
     }
 
-    var transferAllController: TransferAllFundsViewController?
+    private var transferAllController: TransferAllFundsViewController?
 
     func start() {
         transferAllController = TransferAllFundsViewController()
@@ -27,6 +33,16 @@ class TransferAllCoordinator: Coordinator {
         )
         let tabViewController = AppCoordinator.shared.tabControllerManager.tabViewController
         tabViewController?.topMostViewController!.present(navigationController!, animated: true, completion: nil)
+    }
+    
+    @objc func start(withDelegate delegate: TransferAllPromptDelegate) {
+        start()
+        transferAllController?.delegate = delegate
+    }
+    
+    @objc func startWithSendScreen() {
+        transferAllController = nil
+        AppCoordinator.shared.tabControllerManager.setupTransferAllFunds()
     }
 }
 

--- a/Blockchain/DestinationAddressSource.h
+++ b/Blockchain/DestinationAddressSource.h
@@ -1,0 +1,21 @@
+//
+//  DestinationAddressSource.h
+//  Blockchain
+//
+//  Created by kevinwu on 5/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+#ifndef DestinationAddressSource_h
+#define DestinationAddressSource_h
+
+typedef enum {
+    DestinationAddressSourceNone,
+    DestinationAddressSourceQR,
+    DestinationAddressSourcePaste,
+    DestinationAddressSourceURI,
+    DestinationAddressSourceDropDown,
+    DestinationAddressSourceContact
+} DestinationAddressSource;
+
+#endif /* DestinationAddressSource_h */

--- a/Blockchain/EtherAmountInputViewController.h
+++ b/Blockchain/EtherAmountInputViewController.h
@@ -8,7 +8,8 @@
 
 #import <UIKit/UIKit.h>
 #import "QRCodeScannerSendViewController.h"
+#import "DestinationAddressSource.h"
 
 @interface EtherAmountInputViewController : QRCodeScannerSendViewController <UITextFieldDelegate>
-
+@property (nonatomic, readonly) DestinationAddressSource addressSource;
 @end

--- a/Blockchain/EtherAmountInputViewController.m
+++ b/Blockchain/EtherAmountInputViewController.m
@@ -20,6 +20,7 @@
 @property (nonatomic) NSDecimalNumber *ethAmount;
 @property (nonatomic) NSDecimalNumber *ethAvailable;
 @property (nonatomic) BOOL displayingLocalSymbolSend;
+@property (nonatomic, readwrite) DestinationAddressSource addressSource;
 @end
 
 @implementation EtherAmountInputViewController
@@ -107,6 +108,7 @@
         return YES;
     } else if (textField == self.toField) {
         self.toAddress = [textField.text stringByReplacingCharactersInRange:range withString:string];
+        self.addressSource = DestinationAddressSourcePaste;
         if (self.toAddress && [self isEtherAddress:self.toAddress]) {
             [self selectToAddress:self.toAddress];
             return NO;

--- a/Blockchain/NSNumberFormatter+Currencies.m
+++ b/Blockchain/NSNumberFormatter+Currencies.m
@@ -84,6 +84,9 @@
     NSString *returnValue;
     
     if (localCurrency) {
+        
+        if (!WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local) return nil;
+        
         @try {
             NSDecimalNumber *number = [(NSDecimalNumber*)[NSDecimalNumber numberWithLongLong:amount] decimalNumberByDividingBy:(NSDecimalNumber*)[NSDecimalNumber numberWithDouble:(double)WalletManager.sharedInstance.latestMultiAddressResponse.symbol_local.conversion]];
             

--- a/Blockchain/RootService.h
+++ b/Blockchain/RootService.h
@@ -94,7 +94,7 @@
 //@property (strong, nonatomic) IBOutlet BCModalView *modalView;
 //@property (strong, nonatomic) NSMutableArray *modalChain;
 
-@property (strong, nonatomic) TransferAllFundsViewController *transferAllFundsModalController;
+//@property (strong, nonatomic) TransferAllFundsViewController *transferAllFundsModalController;
 
 @property(nonatomic) NSString *deviceToken;
 @property (nonatomic) BuyBitcoinViewController *buyBitcoinViewController;

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -677,25 +677,25 @@ SideMenuViewController *sideMenuViewController;
 //    [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_KEY_NEW_ADDRESS object:nil userInfo:nil];
 //}
 //
-- (void)reloadAfterMultiAddressResponse
-{
-    if (WalletManager.sharedInstance.wallet.didReceiveMessageForLastTransaction) {
-        WalletManager.sharedInstance.wallet.didReceiveMessageForLastTransaction = NO;
-        Transaction *transaction = WalletManager.sharedInstance.latestMultiAddressResponse.transactions.firstObject;
-        [self.tabControllerManager.receiveBitcoinViewController paymentReceived:ABS(transaction.amount) showBackupReminder:NO];
-    }
-
-    [self.tabControllerManager reloadAfterMultiAddressResponse];
-    [_settingsNavigationController reloadAfterMultiAddressResponse];
-    [_accountsAndAddressesNavigationController reload];
-
-    [sideMenuViewController reload];
-
-    [[NSNotificationCenter defaultCenter] postNotificationName:ConstantsObjcBridge.notificationKeyReloadToDismissViews object:nil];
-    // Legacy code for generating new addresses
-    [[NSNotificationCenter defaultCenter] postNotificationName:ConstantsObjcBridge.notificationKeyNewAddress object:nil userInfo:nil];
-    [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_KEY_MULTIADDRESS_RESPONSE_RELOAD object:nil];
-}
+//- (void)reloadAfterMultiAddressResponse
+//{
+//    if (WalletManager.sharedInstance.wallet.didReceiveMessageForLastTransaction) {
+//        WalletManager.sharedInstance.wallet.didReceiveMessageForLastTransaction = NO;
+//        Transaction *transaction = WalletManager.sharedInstance.latestMultiAddressResponse.transactions.firstObject;
+//        [self.tabControllerManager.receiveBitcoinViewController paymentReceived:ABS(transaction.amount) showBackupReminder:NO];
+//    }
+//
+//    [self.tabControllerManager reloadAfterMultiAddressResponse];
+//    [_settingsNavigationController reloadAfterMultiAddressResponse];
+//    [_accountsAndAddressesNavigationController reload];
+//
+//    [sideMenuViewController reload];
+//
+//    [[NSNotificationCenter defaultCenter] postNotificationName:ConstantsObjcBridge.notificationKeyReloadToDismissViews object:nil];
+//    // Legacy code for generating new addresses
+//    [[NSNotificationCenter defaultCenter] postNotificationName:ConstantsObjcBridge.notificationKeyNewAddress object:nil userInfo:nil];
+//    [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_KEY_MULTIADDRESS_RESPONSE_RELOAD object:nil];
+//}
 
 //- (void)reloadSideMenu
 //{
@@ -1970,39 +1970,39 @@ SideMenuViewController *sideMenuViewController;
 //    [self.tabControllerManager updateSendBalance:balance fees:fees];
 //}
 
-- (void)updateTransferAllAmount:(NSNumber *)amount fee:(NSNumber *)fee addressesUsed:(NSArray *)addressesUsed
-{
-    if (self.transferAllFundsModalController) {
-        [self.transferAllFundsModalController updateTransferAllAmount:amount fee:fee addressesUsed:addressesUsed];
-        [LoadingViewPresenter.sharedInstance hideBusyView];
-    } else {
-        [self.tabControllerManager updateTransferAllAmount:amount fee:fee addressesUsed:addressesUsed];
-    }
-}
-
-- (void)showSummaryForTransferAll
-{
-    if (self.transferAllFundsModalController) {
-        [self.transferAllFundsModalController showSummaryForTransferAll];
-        [LoadingViewPresenter.sharedInstance hideBusyView];
-    } else {
-        [self.tabControllerManager showSummaryForTransferAll];
-    }
-}
-
-- (void)sendDuringTransferAll:(NSString *)secondPassword
-{
-    if (self.transferAllFundsModalController) {
-        [self.transferAllFundsModalController sendDuringTransferAll:secondPassword];
-    } else {
-        [self.tabControllerManager sendDuringTransferAll:secondPassword];
-    }
-}
-
-- (void)didErrorDuringTransferAll:(NSString *)error secondPassword:(NSString *)secondPassword
-{
-    [self.tabControllerManager didErrorDuringTransferAll:error secondPassword:secondPassword];
-}
+//- (void)updateTransferAllAmount:(NSNumber *)amount fee:(NSNumber *)fee addressesUsed:(NSArray *)addressesUsed
+//{
+//    if (self.transferAllFundsModalController) {
+//        [self.transferAllFundsModalController updateTransferAllAmount:amount fee:fee addressesUsed:addressesUsed];
+//        [LoadingViewPresenter.sharedInstance hideBusyView];
+//    } else {
+//        [self.tabControllerManager updateTransferAllAmount:amount fee:fee addressesUsed:addressesUsed];
+//    }
+//}
+//
+//- (void)showSummaryForTransferAll
+//{
+//    if (self.transferAllFundsModalController) {
+//        [self.transferAllFundsModalController showSummaryForTransferAll];
+//        [LoadingViewPresenter.sharedInstance hideBusyView];
+//    } else {
+//        [self.tabControllerManager showSummaryForTransferAll];
+//    }
+//}
+//
+//- (void)sendDuringTransferAll:(NSString *)secondPassword
+//{
+//    if (self.transferAllFundsModalController) {
+//        [self.transferAllFundsModalController sendDuringTransferAll:secondPassword];
+//    } else {
+//        [self.tabControllerManager sendDuringTransferAll:secondPassword];
+//    }
+//}
+//
+//- (void)didErrorDuringTransferAll:(NSString *)error secondPassword:(NSString *)secondPassword
+//{
+//    [self.tabControllerManager didErrorDuringTransferAll:error secondPassword:secondPassword];
+//}
 
 - (void)updateLoadedAllTransactions:(NSNumber *)loadedAll
 {
@@ -2276,41 +2276,41 @@ SideMenuViewController *sideMenuViewController;
 //    [self.tabControllerManager showTransactionDetailForHash:txHash];
 //}
 
-- (void)didPushTransaction
-{
-    DestinationAddressSource source = [self.tabControllerManager getSendAddressSource];
-    NSString *eventName;
-
-    if (source == DestinationAddressSourceQR) {
-        eventName = WALLET_EVENT_TX_FROM_QR;
-    } else if (source == DestinationAddressSourcePaste) {
-        eventName = WALLET_EVENT_TX_FROM_PASTE;
-    } else if (source == DestinationAddressSourceURI) {
-        eventName = WALLET_EVENT_TX_FROM_URI;
-    } else if (source == DestinationAddressSourceDropDown) {
-        eventName = WALLET_EVENT_TX_FROM_DROPDOWN;
-    } else if (source == DestinationAddressSourceContact) {
-        eventName = WALLET_EVENT_TX_FROM_CONTACTS;
-    } else if (source == DestinationAddressSourceNone) {
-        DLog(@"Destination address source none");
-        return;
-    } else {
-        DLog(@"Unknown destination address source %d", source);
-        return;
-    }
-
-    NSURL *URL = [NSURL URLWithString:[[[BlockchainAPI sharedInstance] walletUrl] stringByAppendingFormat:URL_SUFFIX_EVENT_NAME_ARGUMENT, eventName]];
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:URL];
-    request.HTTPMethod = @"POST";
-
-    NSURLSessionDataTask *dataTask = [[[NetworkManager sharedInstance] session] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        if (error) {
-            DLog(@"Error saving address input: %@", [error localizedDescription]);
-        }
-    }];
-
-    [dataTask resume];
-}
+//- (void)didPushTransaction
+//{
+//    DestinationAddressSource source = [self.tabControllerManager getSendAddressSource];
+//    NSString *eventName;
+//
+//    if (source == DestinationAddressSourceQR) {
+//        eventName = WALLET_EVENT_TX_FROM_QR;
+//    } else if (source == DestinationAddressSourcePaste) {
+//        eventName = WALLET_EVENT_TX_FROM_PASTE;
+//    } else if (source == DestinationAddressSourceURI) {
+//        eventName = WALLET_EVENT_TX_FROM_URI;
+//    } else if (source == DestinationAddressSourceDropDown) {
+//        eventName = WALLET_EVENT_TX_FROM_DROPDOWN;
+//    } else if (source == DestinationAddressSourceContact) {
+//        eventName = WALLET_EVENT_TX_FROM_CONTACTS;
+//    } else if (source == DestinationAddressSourceNone) {
+//        DLog(@"Destination address source none");
+//        return;
+//    } else {
+//        DLog(@"Unknown destination address source %d", source);
+//        return;
+//    }
+//
+//    NSURL *URL = [NSURL URLWithString:[[[BlockchainAPI sharedInstance] walletUrl] stringByAppendingFormat:URL_SUFFIX_EVENT_NAME_ARGUMENT, eventName]];
+//    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:URL];
+//    request.HTTPMethod = @"POST";
+//
+//    NSURLSessionDataTask *dataTask = [[[NetworkManager sharedInstance] session] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+//        if (error) {
+//            DLog(@"Error saving address input: %@", [error localizedDescription]);
+//        }
+//    }];
+//
+//    [dataTask resume];
+//}
 
 //- (void)didSendPaymentRequest:(NSDictionary *)info amount:(uint64_t)amount name:(NSString *)name requestId:(NSString *)requestId
 //{
@@ -3066,13 +3066,13 @@ SideMenuViewController *sideMenuViewController;
 //}
 
 
-- (void)setupTransferAllFunds
-{
-    self.transferAllFundsModalController = nil;
-//    app.topViewControllerDelegate = nil;
-
-    [self.tabControllerManager setupTransferAllFunds];
-}
+//- (void)setupTransferAllFunds
+//{
+//    self.transferAllFundsModalController = nil;
+////    app.topViewControllerDelegate = nil;
+//
+//    [self.tabControllerManager setupTransferAllFunds];
+//}
 
 //- (void)loginMainPassword
 //{

--- a/Blockchain/SendBitcoinViewController.h
+++ b/Blockchain/SendBitcoinViewController.h
@@ -25,6 +25,7 @@
 #import "FeeTypes.h"
 #import "QRCodeScannerSendViewController.h"
 #import "Assets.h"
+#import "DestinationAddressSource.h"
 
 @class Wallet;
 
@@ -80,15 +81,6 @@
 @property (nonatomic) LegacyAssetType assetType;
 
 @property (strong, nonatomic) BCConfirmPaymentView *confirmPaymentView;
-
-typedef enum {
-    DestinationAddressSourceNone,
-    DestinationAddressSourceQR,
-    DestinationAddressSourcePaste,
-    DestinationAddressSourceURI,
-    DestinationAddressSourceDropDown,
-    DestinationAddressSourceContact
-} DestinationAddressSource;
 
 @property (nonatomic, readonly) DestinationAddressSource addressSource;
 

--- a/Blockchain/SendEtherViewController.h
+++ b/Blockchain/SendEtherViewController.h
@@ -11,6 +11,7 @@
 
 @interface SendEtherViewController : EtherAmountInputViewController
 @property (nonatomic) NSString *addressToSet;
+@property (nonatomic, readonly) DestinationAddressSource addressSource;
 - (void)reload;
 - (void)reloadAfterMultiAddressResponse;
 - (void)getHistory;

--- a/Blockchain/SendEtherViewController.m
+++ b/Blockchain/SendEtherViewController.m
@@ -29,6 +29,7 @@
 @property (nonatomic) NSDecimalNumber *ethAmount;
 @property (nonatomic) NSDecimalNumber *ethAvailable;
 @property (nonatomic) BOOL displayingLocalSymbolSend;
+@property (nonatomic, readwrite) DestinationAddressSource addressSource;
 
 - (void)doCurrencyConversion;
 @end
@@ -467,6 +468,7 @@
                 [self selectToAddress:address];
                 DLog(@"toAddress: %@", address);
                 
+                self.addressSource = DestinationAddressSourceQR;
             });
         }
     }

--- a/Blockchain/TabControllerManager.h
+++ b/Blockchain/TabControllerManager.h
@@ -85,7 +85,7 @@
 - (void)updateTransferAllAmount:(NSNumber *)amount fee:(NSNumber *)fee addressesUsed:(NSArray *)addressesUsed;
 - (void)showSummaryForTransferAll;
 - (void)sendDuringTransferAll:(NSString *)secondPassword;
-- (void)didErrorDuringTransferAll:(NSString *)error secondPassword:(NSString *)secondPassword;
+- (void)didErrorDuringTransferAll:(NSString *)error secondPassword:(NSString *_Nullable)secondPassword;
 - (void)updateLoadedAllTransactions:(NSNumber *)loadedAll;
 - (void)receivedTransactionMessage;
 - (DestinationAddressSource)getSendAddressSource;

--- a/Blockchain/Wallet.h
+++ b/Blockchain/Wallet.h
@@ -99,8 +99,8 @@
 - (void)updateSendBalance:(NSNumber *)balance fees:(NSDictionary *)fees;
 - (void)updateTransferAllAmount:(NSNumber *)amount fee:(NSNumber *)fee addressesUsed:(NSArray *)addressesUsed;
 - (void)showSummaryForTransferAll;
-- (void)sendDuringTransferAll:(NSString *)secondPassword;
-- (void)didErrorDuringTransferAll:(NSString *)error secondPassword:(NSString *)secondPassword;
+- (void)sendDuringTransferAll:(NSString *_Nullable)secondPassword;
+- (void)didErrorDuringTransferAll:(NSString *)error secondPassword:(NSString *_Nullable)secondPassword;
 - (void)updateLoadedAllTransactions:(NSNumber *)loadedAll;
 - (void)receivedTransactionMessage;
 - (void)paymentReceivedOnPINScreen:(NSString *)amount assetType:(LegacyAssetType)assetType;

--- a/Blockchain/Wallet/WalletExchangeIntermediateDelegate.swift
+++ b/Blockchain/Wallet/WalletExchangeIntermediateDelegate.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol WalletExchangeIntermediateDelegate: class {
+@objc protocol WalletExchangeIntermediateDelegate: class {
     /// Method invoked when eth account is created when exchange is opened
     func didCreateEthAccountForExchange()
 }

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -43,6 +43,7 @@ class WalletManager: NSObject {
     @objc weak var exchangeDelegate: WalletExchangeDelegate?
     @objc weak var exchangeIntermediateDelegate: WalletExchangeIntermediateDelegate?
     @objc weak var transactionDelegate: WalletTransactionDelegate?
+    @objc weak var transferAllDelegate: WalletTransferAllDelegate?
 
     init(wallet: Wallet = Wallet()!) {
         self.wallet = wallet
@@ -147,9 +148,9 @@ class WalletManager: NSObject {
         }
         self.latestMultiAddressResponse?.symbol_btc = CurrencySymbol.btcSymbol(fromCode: code)
     }
-    
+
     private func reloadAfterMultiaddressResponse() {
-        AppCoordinator.shared.tabControllerManager.reloadAfterMultiAddressResponse()
+        AppCoordinator.shared.reloadAfterMultiAddressResponse()
     }
 }
 
@@ -352,7 +353,6 @@ extension WalletManager: WalletDelegate {
 
     // MARK: ETH Exchange Rate
     func didFetchEthExchangeRate(_ rate: NSNumber!) {
-        reloadAfterMultiaddressResponse()
         AppCoordinator.shared.tabControllerManager.didFetchEthExchangeRate(rate)
     }
 
@@ -419,6 +419,10 @@ extension WalletManager: WalletDelegate {
 
     // MARK: - Transaction
 
+    func didPushTransaction() {
+        self.transactionDelegate?.didPushTransaction()
+    }
+
     func receivedTransactionMessage() {
         DispatchQueue.main.async { [unowned self] in
             self.transactionDelegate?.onTransactionReceived()
@@ -429,5 +433,22 @@ extension WalletManager: WalletDelegate {
         DispatchQueue.main.async { [unowned self] in
             self.transactionDelegate?.onPaymentReceived(amount: amount, assetType: AssetType.from(legacyAssetType: assetType))
         }
+    }
+
+    // MARK: - Transfer all
+    func updateTransferAllAmount(_ amount: NSNumber!, fee: NSNumber!, addressesUsed: [Any]!) {
+        transferAllDelegate?.updateTransferAll(amount: amount, fee: fee, addressesUsed: addressesUsed as NSArray)
+    }
+
+    func showSummaryForTransferAll() {
+        transferAllDelegate?.showSummaryForTransferAll()
+    }
+
+    func sendDuringTransferAll(_ secondPassword: String?) {
+        transferAllDelegate?.sendDuringTransferAll(secondPassword: secondPassword)
+    }
+
+    func didErrorDuringTransferAll(_ error: String!, secondPassword: String?) {
+        transferAllDelegate?.didErrorDuringTransferAll(error: error, secondPassword: secondPassword)
     }
 }

--- a/Blockchain/Wallet/WalletTransactionDelegate.swift
+++ b/Blockchain/Wallet/WalletTransactionDelegate.swift
@@ -21,4 +21,7 @@ import Foundation
     /// Method invoked when a transaction is received (only invoked when there is an
     /// active websocket connection when the transaction was received)
     func onTransactionReceived()
+
+    /// Method invoked after pushing a transaction to the network
+    func didPushTransaction()
 }

--- a/Blockchain/Wallet/WalletTransferAllDelegate.swift
+++ b/Blockchain/Wallet/WalletTransferAllDelegate.swift
@@ -1,0 +1,24 @@
+//
+//  WalletTransferAllDelegate.swift
+//  Blockchain
+//
+//  Created by kevinwu on 5/20/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+@objc protocol WalletTransferAllDelegate: class {
+
+    /// Method invoked when calculation of total amount to transfer is completed
+    func updateTransferAll(amount: NSNumber, fee: NSNumber, addressesUsed: NSArray)
+
+    /// Method invoked when a user is ready to transfer all
+    func showSummaryForTransferAll()
+
+    /// Method invoked when user confirms to transfer all
+    func sendDuringTransferAll(secondPassword: String?)
+
+    /// Method invoked when an error occurs while transferring all
+    func didErrorDuringTransferAll(error: String, secondPassword: String?)
+}


### PR DESCRIPTION
Some other changes:
- Re-implemented `reloadAfterMultiAddressResponse` inside `AppCoordinator`
- If `symbol_local` is nil, changed to return nil for local currency conversion. This seems to be happening due to `backup_wallet_success` calling `reload` before `getAccountInfoAndExchangeRates` has a chance to set `symbol_local` after `latestMultiAddressResponse` has been reset. If possible we should store `symbol_local` separately from `latestMultiAddressResponse`.
- Created `DestinationAddressSource.h` and added to `SendEtherViewController`. Tried making a swift enum multiple times (added to both main and test target) and the compiler couldn't find `Blockchain-Swift.h`