### PR TITLE
refactor(TabControllerManager): move exchange delegate methods to exc…

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -361,6 +361,8 @@
 		C74E21CD2028A61F00A9FBB1 /* BCPriceChartContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C74E21CC2028A61F00A9FBB1 /* BCPriceChartContainerViewController.m */; };
 		C74E865220B3043E00F7263D /* WalletHistoryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74E865120B3043E00F7263D /* WalletHistoryDelegate.swift */; };
 		C74E865320B3043E00F7263D /* WalletHistoryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74E865120B3043E00F7263D /* WalletHistoryDelegate.swift */; };
+		C74E865920B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74E865820B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift */; };
+		C74E865A20B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74E865820B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift */; };
 		C74FEA232093B38A007CAB5D /* JSContextWithDOM.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74FEA222093B38A007CAB5D /* JSContextWithDOM.swift */; };
 		C74FEA2620979259007CAB5D /* JSContextWithDOMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74FEA2520979259007CAB5D /* JSContextWithDOMTests.swift */; };
 		C7559CAF1F55E874005B2375 /* BCConfirmPaymentViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = C7559CAE1F55E874005B2375 /* BCConfirmPaymentViewModel.m */; };
@@ -1364,6 +1366,7 @@
 		C74E21CB2028A61F00A9FBB1 /* BCPriceChartContainerViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BCPriceChartContainerViewController.h; sourceTree = "<group>"; };
 		C74E21CC2028A61F00A9FBB1 /* BCPriceChartContainerViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BCPriceChartContainerViewController.m; sourceTree = "<group>"; };
 		C74E865120B3043E00F7263D /* WalletHistoryDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletHistoryDelegate.swift; sourceTree = "<group>"; };
+		C74E865820B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletExchangeIntermediateDelegate.swift; sourceTree = "<group>"; };
 		C74FEA222093B38A007CAB5D /* JSContextWithDOM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSContextWithDOM.swift; sourceTree = "<group>"; };
 		C74FEA2520979259007CAB5D /* JSContextWithDOMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSContextWithDOMTests.swift; sourceTree = "<group>"; };
 		C7559CAD1F55E874005B2375 /* BCConfirmPaymentViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BCConfirmPaymentViewModel.h; sourceTree = "<group>"; };
@@ -2352,6 +2355,7 @@
 			isa = PBXGroup;
 			children = (
 				C74E865120B3043E00F7263D /* WalletHistoryDelegate.swift */,
+				C74E865820B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift */,
 				C76D730320B2052000040B57 /* WalletExchangeDelegate.swift */,
 				C77217E720AFCC3C0087836A /* WalletBackupDelegate.swift */,
 				C77217EC20AFCF940087836A /* WalletRecoveryDelegate.swift */,
@@ -3088,6 +3092,7 @@
 				AA63F85120A12DA6002B719B /* BitcoinURLPayload.swift in Sources */,
 				AACE31D32092A99B00B7B806 /* OnboardingCoordinator.swift in Sources */,
 				AACE3132209121B300B7B806 /* PushNotificationManager.swift in Sources */,
+				C74E865A20B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift in Sources */,
 				5168564D2098E5C00088FBEB /* WalletOptions.swift in Sources */,
 				519435AC208E6279001EF882 /* CertificatePinnerTests.swift in Sources */,
 			);
@@ -3323,6 +3328,7 @@
 				AA1E52382097D3C50099BD10 /* PutPinResponse.swift in Sources */,
 				6E2D90A21BBEC34800B719EC /* BCRecoveryView.m in Sources */,
 				A2599B9F1B0B5FC800C2EA81 /* BackupViewController.swift in Sources */,
+				C74E865920B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift in Sources */,
 				AAD279B0209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift in Sources */,
 				C9BE917C1945D8F600FD516D /* PEPinEntryController.m in Sources */,
 				239539831B486C7100989667 /* UILabel+MultiLineAutoSize.m in Sources */,

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -101,7 +101,7 @@
         [WalletManager.sharedInstance.wallet getBchBalance] > 0) {
         [self getRate];
     } else {
-        [app showGetAssetsAlert];
+        [[AppCoordinator sharedInstance].tabControllerManager showGetAssetsAlert];
     }
 }
 

--- a/Blockchain/ExchangeOverviewViewController.h
+++ b/Blockchain/ExchangeOverviewViewController.h
@@ -9,11 +9,5 @@
 #import <UIKit/UIKit.h>
 
 @interface ExchangeOverviewViewController : UIViewController
-- (void)didGetExchangeTrades:(NSArray *)trades;
-- (void)didGetExchangeRate:(NSDictionary *)result;
-- (void)didGetAvailableEthBalance:(NSDictionary *)result;
-- (void)didGetAvailableBtcBalance:(NSDictionary *)result;
-- (void)didBuildExchangeTrade:(NSDictionary *)tradeInfo;
-- (void)didShiftPayment:(NSDictionary *)info;
 - (void)reloadSymbols;
 @end

--- a/Blockchain/ExchangeOverviewViewController.m
+++ b/Blockchain/ExchangeOverviewViewController.m
@@ -78,6 +78,11 @@
     self.didFinishShift = NO;
 }
 
+- (void)reloadSymbols
+{
+    [self.tableView reloadData];
+}
+
 - (void)setupSubviewsIfNeeded
 {
     if (!self.tableView) {

--- a/Blockchain/ExchangeOverviewViewController.m
+++ b/Blockchain/ExchangeOverviewViewController.m
@@ -24,7 +24,7 @@
 
 #define CELL_IDENTIFIER_EXCHANGE_CELL @"exchangeCell"
 
-@interface ExchangeOverviewViewController () <UITableViewDelegate, UITableViewDataSource, CloseButtonDelegate, ConfirmStateDelegate>
+@interface ExchangeOverviewViewController () <UITableViewDelegate, UITableViewDataSource, CloseButtonDelegate, ConfirmStateDelegate, WalletExchangeDelegate>
 @property (nonatomic) UITableView *tableView;
 @property (nonatomic) NSArray *trades;
 @property (nonatomic) ExchangeCreateViewController *createViewController;
@@ -53,6 +53,8 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+    
+    [WalletManager sharedInstance].exchangeDelegate = self;
     
     BCNavigationController *navigationController = (BCNavigationController *)self.navigationController;
     navigationController.headerTitle = BC_STRING_EXCHANGE;
@@ -178,7 +180,9 @@
     self.createViewController = createViewController;
 }
 
-- (void)didGetExchangeTrades:(NSArray *)trades
+#pragma mark - Wallet Exchange Delegate
+
+- (void)didGetExchangeTradesWithTrades:(NSArray * _Nonnull)trades
 {
     [[LoadingViewPresenter sharedInstance] hideBusyView];
     
@@ -202,27 +206,27 @@
     }
 }
 
-- (void)didGetExchangeRate:(NSDictionary *)result
+- (void)didGetExchangeRateWithRate:(NSDictionary * _Nonnull)rate
 {
-    [self.createViewController didGetExchangeRate:result];
+    [self.createViewController didGetExchangeRate:rate];
 }
 
-- (void)didGetAvailableEthBalance:(NSDictionary *)result
+- (void)didGetAvailableEthBalanceWithResult:(NSDictionary * _Nonnull)result
 {
     [self.createViewController didGetAvailableEthBalance:result];
 }
 
-- (void)didGetAvailableBtcBalance:(NSDictionary *)result
+- (void)didGetAvailableBtcBalanceWithResult:(NSDictionary * _Nonnull)result
 {
     [self.createViewController didGetAvailableBtcBalance:result];
 }
 
-- (void)didBuildExchangeTrade:(NSDictionary *)tradeInfo
+- (void)didBuildExchangeTradeWithTradeInfo:(NSDictionary * _Nonnull)tradeInfo
 {
     [self.createViewController didBuildExchangeTrade:tradeInfo];
 }
 
-- (void)didShiftPayment:(NSDictionary *)info
+- (void)didShiftPaymentWithInfo:(NSDictionary * _Nonnull)info
 {
     BCNavigationController *navigationController = (BCNavigationController *)self.navigationController;
     [navigationController hideBusyView];
@@ -235,11 +239,6 @@
         self.createViewController.navigationController.viewControllers = @[self, self.createViewController];
     }
     [self.navigationController presentViewController:modalViewController animated:YES completion:nil];
-}
-
-- (void)reloadSymbols
-{
-    [self.tableView reloadData];
 }
 
 #pragma mark - Confirm State delegate

--- a/Blockchain/ExchangeOverviewViewController.m
+++ b/Blockchain/ExchangeOverviewViewController.m
@@ -38,6 +38,8 @@
 {
     [super viewDidLoad];
     
+    [WalletManager sharedInstance].exchangeDelegate = self;
+    
     self.view.backgroundColor = COLOR_TABLE_VIEW_BACKGROUND_LIGHT_GRAY;
     
     NSArray *availableStates = [WalletManager.sharedInstance.wallet availableUSStates];
@@ -53,8 +55,6 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
-    [WalletManager sharedInstance].exchangeDelegate = self;
     
     BCNavigationController *navigationController = (BCNavigationController *)self.navigationController;
     navigationController.headerTitle = BC_STRING_EXCHANGE;

--- a/Blockchain/TabControllerManager.h
+++ b/Blockchain/TabControllerManager.h
@@ -117,4 +117,5 @@
 - (void)updateBadgeNumber:(NSInteger)number forSelectedIndex:(int)index;
 
 - (void)exchangeClicked;
+- (void)showGetAssetsAlert;
 @end

--- a/Blockchain/TabControllerManager.h
+++ b/Blockchain/TabControllerManager.h
@@ -117,12 +117,4 @@
 - (void)updateBadgeNumber:(NSInteger)number forSelectedIndex:(int)index;
 
 - (void)exchangeClicked;
-- (void)didCreateEthAccountForExchange;
-- (void)didGetExchangeTrades:(NSArray *)trades;
-- (void)didGetExchangeRate:(NSDictionary *)result;
-- (void)didGetAvailableBtcBalance:(NSDictionary *)result;
-- (void)didGetAvailableEthBalance:(NSDictionary *)result;
-- (void)didBuildExchangeTrade:(NSDictionary *)tradeInfo;
-- (void)didShiftPayment:(NSDictionary *)info;
-- (void)showGetAssetsAlert;
 @end

--- a/Blockchain/TabControllerManager.m
+++ b/Blockchain/TabControllerManager.m
@@ -736,36 +736,6 @@
     [self exchangeClicked];
 }
 
-- (void)didGetExchangeTrades:(NSArray *)trades
-{
-    [self.exchangeOverviewViewController didGetExchangeTrades:trades];
-}
-
-- (void)didGetExchangeRate:(NSDictionary *)result
-{
-    [self.exchangeOverviewViewController didGetExchangeRate:result];
-}
-
-- (void)didGetAvailableEthBalance:(NSDictionary *)result
-{
-    [self.exchangeOverviewViewController didGetAvailableEthBalance:result];
-}
-
-- (void)didGetAvailableBtcBalance:(NSDictionary *)result
-{
-    [self.exchangeOverviewViewController didGetAvailableBtcBalance:result];
-}
-
-- (void)didBuildExchangeTrade:(NSDictionary *)tradeInfo
-{
-    [self.exchangeOverviewViewController didBuildExchangeTrade:tradeInfo];
-}
-
-- (void)didShiftPayment:(NSDictionary *)info
-{
-    [self.exchangeOverviewViewController didShiftPayment:info];
-}
-
 - (void)showGetAssetsAlert
 {
     UIAlertController *showGetAssetsAlert = [UIAlertController alertControllerWithTitle:BC_STRING_NO_FUNDS_TO_EXCHANGE_TITLE message:BC_STRING_NO_FUNDS_TO_EXCHANGE_MESSAGE preferredStyle:UIAlertControllerStyleAlert];
@@ -802,36 +772,6 @@
     }]];
     
     [self.tabViewController.presentedViewController presentViewController:showGetAssetsAlert animated:YES completion:nil];
-}
-
-- (void)didBuildExchangeTradeWithTradeInfo:(NSDictionary * _Nonnull)tradeInfo
-{
-    [self.exchangeOverviewViewController didBuildExchangeTrade:tradeInfo];
-}
-
-- (void)didGetAvailableBtcBalanceWithResult:(NSDictionary * _Nonnull)result
-{
-    [self.exchangeOverviewViewController didGetAvailableBtcBalance:result];
-}
-
-- (void)didGetAvailableEthBalanceWithResult:(NSDictionary * _Nonnull)result
-{
-    [self.exchangeOverviewViewController didGetAvailableEthBalance:result];
-}
-
-- (void)didGetExchangeRateWithRate:(NSDictionary * _Nonnull)rate
-{
-    [self.exchangeOverviewViewController didGetExchangeRate:rate];
-}
-
-- (void)didGetExchangeTradesWithTrades:(NSArray * _Nonnull)trades
-{
-    [self.exchangeOverviewViewController didGetExchangeTrades:trades];
-}
-
-- (void)didShiftPaymentWithInfo:(NSDictionary * _Nonnull)info
-{
-    [self.exchangeOverviewViewController didShiftPayment:info];
 }
 
 @end

--- a/Blockchain/TabControllerManager.m
+++ b/Blockchain/TabControllerManager.m
@@ -11,7 +11,7 @@
 #import "Transaction.h"
 #import "Blockchain-Swift.h"
 
-@interface TabControllerManager () <WalletSettingsDelegate, WalletSendBitcoinDelegate, WalletSendEtherDelegate, WalletExchangeDelegate, WalletTransactionDelegate>
+@interface TabControllerManager () <WalletSettingsDelegate, WalletSendBitcoinDelegate, WalletSendEtherDelegate, WalletExchangeIntermediateDelegate, WalletTransactionDelegate>
 @end
 @implementation TabControllerManager
 
@@ -29,7 +29,7 @@
         walletManager.settingsDelegate = self;
         walletManager.sendBitcoinDelegate = self;
         walletManager.sendEtherDelegate = self;
-        walletManager.exchangeDelegate = self;
+        walletManager.exchangeIntermediateDelegate = self;
         walletManager.transactionDelegate = self;
     }
     return self;

--- a/Blockchain/Wallet.h
+++ b/Blockchain/Wallet.h
@@ -138,7 +138,6 @@
 - (void)didGetAvailableBtcBalance:(NSDictionary *)result;
 - (void)didBuildExchangeTrade:(NSDictionary *)tradeInfo;
 - (void)didShiftPayment:(NSDictionary *)info;
-- (void)showGetAssetsAlertForCurrencySymbol:(NSString *)currencySymbol;
 - (void)didCreateEthAccountForExchange;
 - (void)didFetchBitcoinCashHistory;
 - (void)initializeWebView;

--- a/Blockchain/Wallet/WalletExchangeDelegate.swift
+++ b/Blockchain/Wallet/WalletExchangeDelegate.swift
@@ -28,9 +28,6 @@ import Foundation
     /// Method invoked when a shift payment has been submitted
     func didShiftPayment(info: NSDictionary)
 
-    /// Method invoked when no funds are available
-    func showGetAssetsAlert()
-
     /// Method invoked when eth account is created when exchange is opened
     func didCreateEthAccountForExchange()
 }

--- a/Blockchain/Wallet/WalletExchangeDelegate.swift
+++ b/Blockchain/Wallet/WalletExchangeDelegate.swift
@@ -27,7 +27,4 @@ import Foundation
 
     /// Method invoked when a shift payment has been submitted
     func didShiftPayment(info: NSDictionary)
-
-    /// Method invoked when eth account is created when exchange is opened
-    func didCreateEthAccountForExchange()
 }

--- a/Blockchain/Wallet/WalletExchangeIntermediateDelegate.swift
+++ b/Blockchain/Wallet/WalletExchangeIntermediateDelegate.swift
@@ -1,0 +1,14 @@
+//
+//  WalletExchangeIntermediateDelegate.swift
+//  Blockchain
+//
+//  Created by kevinwu on 5/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+protocol WalletExchangeIntermediateDelegate: class {
+    /// Method invoked when eth account is created when exchange is opened
+    func didCreateEthAccountForExchange()
+}

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -41,6 +41,7 @@ class WalletManager: NSObject {
     @objc weak var sendBitcoinDelegate: WalletSendBitcoinDelegate?
     @objc weak var sendEtherDelegate: WalletSendEtherDelegate?
     @objc weak var exchangeDelegate: WalletExchangeDelegate?
+    @objc weak var exchangeIntermediateDelegate: WalletExchangeIntermediateDelegate?
     @objc weak var transactionDelegate: WalletTransactionDelegate?
 
     init(wallet: Wallet = Wallet()!) {
@@ -404,7 +405,7 @@ extension WalletManager: WalletDelegate {
     }
 
     func didCreateEthAccountForExchange() {
-        exchangeDelegate?.didCreateEthAccountForExchange()
+        exchangeIntermediateDelegate?.didCreateEthAccountForExchange()
     }
 
     // MARK: - History


### PR DESCRIPTION
…hange overview controller

It doesn't seem to make sense to move `didCreateEthAccountForExchange` to `ExchangeOverviewController` because it won't exist at that point. `showGetAssetsAlert` requires a lot of navigation so it would also be a stretch to move to `ExchangeOverviewController`. Should these be in a separate protocol?