### PR TITLE
refactor(swipe): creating AssetAddressRepository and WalletSwipeAddressDelegate.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -261,6 +261,10 @@
 		AA63F87B20A3A198002B719B /* AppFeatureConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87920A3A198002B719B /* AppFeatureConfigurator.swift */; };
 		AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F6582086A2720054EFCE /* AppCoordinator.swift */; };
 		AA69F65F2086A7500054EFCE /* BlockchainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */; };
+		AA722C1420B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */; };
+		AA722C1520B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */; };
+		AA722C1920B4BBA900262A5F /* AssetAddressRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */; };
+		AA722C1A20B4BBA900262A5F /* AssetAddressRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */; };
 		AAA3314E20893CE100BBD292 /* PairingInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */; };
 		AAA3316120895A9C00BBD292 /* LoadingViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */; };
 		AAA3316B2089650B00BBD292 /* AlertViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */; };
@@ -1294,6 +1298,8 @@
 		AA63F87920A3A198002B719B /* AppFeatureConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureConfigurator.swift; sourceTree = "<group>"; };
 		AA69F6582086A2720054EFCE /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchainSettings.swift; sourceTree = "<group>"; };
+		AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwipeAddressDelegate.swift; sourceTree = "<group>"; };
+		AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressRepository.swift; sourceTree = "<group>"; };
 		AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingInstructionsView.swift; sourceTree = "<group>"; };
 		AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewPresenter.swift; sourceTree = "<group>"; };
 		AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewPresenter.swift; sourceTree = "<group>"; };
@@ -2123,6 +2129,7 @@
 				AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */,
 				51E5C73020741A130000A7FD /* LocalizationConstants.swift */,
 				AAA3333E2088131D0019AD55 /* ModalPresenter.swift */,
+				AA722C1720B4BB8F00262A5F /* Addresses */,
 				AAA33169208964FC00BBD292 /* Alerts */,
 				511646C02081247700C43522 /* Assets */,
 				510EA1732080F58700A63AB8 /* Authentication */,
@@ -2322,6 +2329,14 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		AA722C1720B4BB8F00262A5F /* Addresses */ = {
+			isa = PBXGroup;
+			children = (
+				AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */,
+			);
+			path = Addresses;
+			sourceTree = "<group>";
+		};
 		AAA33169208964FC00BBD292 /* Alerts */ = {
 			isa = PBXGroup;
 			children = (
@@ -2387,6 +2402,7 @@
 				C78893ED20A4D690003C0A8F /* WalletSendBitcoinDelegate.swift */,
 				C79B27B020A6215B0061D0F2 /* WalletSendEtherDelegate.swift */,
 				C78893D920A34DF4003C0A8F /* WalletSettingsDelegate.swift */,
+				AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */,
 				AAC9FCED20AE456400E28B7A /* WalletTransactionDelegate.swift */,
 				C76D731620B24B5300040B57 /* WalletTransferAllDelegate.swift */,
 				C79DD06D20B3B74A00DF3684 /* WalletWatchOnlyDelegate.swift */,
@@ -3032,6 +3048,7 @@
 				AACE31382091220300B7B806 /* HTTPCookieStorage.swift in Sources */,
 				C74E866220B3272B00F7263D /* TransferAllCoordinator.swift in Sources */,
 				51A862BE2090DD6400B338E0 /* PairingInstructionsView.swift in Sources */,
+				AA722C1A20B4BBA900262A5F /* AssetAddressRepository.swift in Sources */,
 				511356E4209CAFC600056D65 /* NetworkManager+PushNotifications.swift in Sources */,
 				AAD27A29209CFE2100C0EAFC /* PasswordConfirmView.swift in Sources */,
 				AA1E523B2097E2190099BD10 /* Strings.swift in Sources */,
@@ -3092,6 +3109,7 @@
 				C78893DB20A34DF4003C0A8F /* WalletSettingsDelegate.swift in Sources */,
 				C7BD107C209A01690062269E /* NumberFormatter+Assets.swift in Sources */,
 				AACE31D12092A99B00B7B806 /* PasscodePayload.swift in Sources */,
+				AA722C1520B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */,
 				AA1E52352097CC2E0099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */,
 				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
 				511356E1209CA4BA00056D65 /* BlockchainAPI+PayloadTests.swift in Sources */,
@@ -3266,6 +3284,7 @@
 				23107F831BBEF0AC00A6A9D4 /* BCConfirmPaymentView.m in Sources */,
 				23FB5C131D9ABB8B0008C6AB /* TransactionDetailStatusCell.m in Sources */,
 				CFA0671F1E65D426008456C1 /* WebLoginViewController.m in Sources */,
+				AA722C1920B4BBA900262A5F /* AssetAddressRepository.swift in Sources */,
 				A2599BA51B0B725400C2EA81 /* BackupWordsViewController.swift in Sources */,
 				5185E12A208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */,
 				23444F7E1DCD213D00573C8C /* BTCKey.m in Sources */,
@@ -3278,6 +3297,7 @@
 				C7F041961E3BD4A6004E8B4A /* BuyBitcoinViewController.m in Sources */,
 				C7448A9C2034DDF80041947E /* AssetSelectorView.m in Sources */,
 				C7CE34B81F4DCB7E00032806 /* CardsViewController.m in Sources */,
+				AA722C1420B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */,
 				6780DB951A40BDCF0048EED2 /* InOut.m in Sources */,
 				5185B18A208697F1003C9AC2 /* BCPriceMarker.swift in Sources */,
 				516546F8208FCF800019EE63 /* Enum+Enumeratable.swift in Sources */,

--- a/Blockchain/AccountsAndAddressesNavigationController.m
+++ b/Blockchain/AccountsAndAddressesNavigationController.m
@@ -277,8 +277,8 @@
 
 - (void)didSetDefaultAccount
 {
-    [KeychainItemWrapper removeAllSwipeAddressesForAssetType:LegacyAssetTypeBitcoin];
-    [KeychainItemWrapper removeAllSwipeAddressesForAssetType:LegacyAssetTypeBitcoinCash];
+    [AssetAddressRepository.sharedInstance removeAllSwipeAddressesFor:AssetTypeBitcoin];
+    [AssetAddressRepository.sharedInstance removeAllSwipeAddressesFor:AssetTypeBitcoinCash];
     [AppCoordinator.sharedInstance.tabControllerManager didSetDefaultAccount];
 }
 

--- a/Blockchain/Addresses/AssetAddressRepository.swift
+++ b/Blockchain/Addresses/AssetAddressRepository.swift
@@ -1,0 +1,107 @@
+//
+//  AssetAddressRepository.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 5/22/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Repository for asset addresses
+@objc class AssetAddressRepository: NSObject {
+
+    static let shared = AssetAddressRepository()
+
+    /// Accessor for obj-c compatibility
+    @objc class func sharedInstance() -> AssetAddressRepository { return shared }
+
+    private let walletManager: WalletManager
+
+    init(walletManager: WalletManager = WalletManager.shared) {
+        self.walletManager = walletManager
+        super.init()
+        self.walletManager.swipeAddressDelegate = self
+    }
+
+    // TODO: move latest multiaddress response here
+
+    /// Fetches the swipe to receive addresses for all assets if possible
+    func fetchSwipeToReceiveAddressesIfNeeded() {
+
+        // Perform guard checks
+        let appSettings = BlockchainSettings.App.shared
+        guard appSettings.swipeToReceiveEnabled else {
+            print("Swipe to receive is disabled.")
+            return
+        }
+
+        let wallet = walletManager.wallet
+
+        guard wallet.isInitialized() else {
+            print("Wallet is not yet initialized.")
+            return
+        }
+
+        guard wallet.didUpgradeToHd() else {
+            print("Wallet has not yet been upgraded to HD.")
+            return
+        }
+
+        // Only one address for ethereum
+        appSettings.swipeAddressForEther = wallet.getEtherAddress()
+
+        // Retrieve swipe addresses for bitcoin and bitcoin cash
+        let assetTypesWithHDAddresses = [AssetType.bitcoin, AssetType.bitcoinCash]
+        assetTypesWithHDAddresses.forEach {
+            let swipeAddresses = swipeToReceiveAddresses(for: $0)
+            let numberOfAddressesToDerive = Constants.Wallet.swipeToReceiveAddressCount - swipeAddresses.count
+            if numberOfAddressesToDerive > 0 {
+                wallet.getSwipeAddresses(Int32(numberOfAddressesToDerive), assetType: $0.legacy)
+            }
+        }
+    }
+
+    /// Gets the swipe addresses for the provided asset type
+    ///
+    /// - Parameter assetType: the AssetType
+    /// - Returns: the swipe addresses
+    @objc func swipeToReceiveAddresses(for assetType: AssetType) -> [String] {
+        if assetType == .ethereum {
+            if let swipeAddressForEther = BlockchainSettings.App.shared.swipeAddressForEther {
+                return [swipeAddressForEther]
+            } else {
+                return []
+            }
+        }
+
+        return KeychainItemWrapper.getSwipeAddresses(for: assetType.legacy) as? [String] ?? []
+    }
+
+    /// Removes the first swipe address for assetType.
+    ///
+    /// - Parameter assetType: the AssetType
+    @objc func removeFirstSwipeAddress(for assetType: AssetType) {
+        KeychainItemWrapper.removeFirstSwipeAddress(for: assetType.legacy)
+    }
+
+    /// Removes all swipe addresses for all assets
+    @objc func removeAllSwipeAddresses() {
+        KeychainItemWrapper.removeAllSwipeAddresses()
+    }
+
+    /// removes all swipe addresses for the provided AssetType
+    ///
+    /// - Parameter assetType: the AssetType
+    @objc func removeAllSwipeAddresses(for assetType: AssetType) {
+        KeychainItemWrapper.removeAllSwipeAddresses(for: assetType.legacy)
+    }
+}
+
+extension AssetAddressRepository: WalletSwipeAddressDelegate {
+    func onRetrievedSwipeToReceive(addresses: [String], assetType: AssetType) {
+        addresses.forEach {
+            KeychainItemWrapper.addSwipeAddress($0, assetType: assetType.legacy)
+        }
+    }
+}

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -102,17 +102,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let appSettings = BlockchainSettings.App.shared
         let wallet = WalletManager.shared.wallet
 
-        if appSettings.swipeToReceiveEnabled && wallet.isInitialized() && wallet.didUpgradeToHd() {
+        AssetAddressRepository.shared.fetchSwipeToReceiveAddressesIfNeeded()
 
-            appSettings.swipeAddressForEther = wallet.getEtherAddress()
-
-            var numberOfBTCAddressesToDerive = Constants.Wallet.swipeToReceiveAddressCount
-            if let bitcoinSwipeAddresses = KeychainItemWrapper.getSwipeAddresses(for: .bitcoin) {
-                numberOfBTCAddressesToDerive -= bitcoinSwipeAddresses.count
-            }
-            wallet.getSwipeAddresses(Int32(numberOfBTCAddressesToDerive), assetType: .bitcoin)
-            NotificationCenter.default.post(name: Constants.NotificationKeys.appEnteredBackground, object: nil)
-        }
+        NotificationCenter.default.post(name: Constants.NotificationKeys.appEnteredBackground, object: nil)
 
         wallet.isFetchingTransactions = false
         wallet.isFilteringTransactions = false

--- a/Blockchain/Assets/AssetType.swift
+++ b/Blockchain/Assets/AssetType.swift
@@ -24,4 +24,15 @@ extension AssetType {
             return AssetType.ethereum
         }
     }
+
+    var legacy: LegacyAssetType {
+        switch self {
+        case .bitcoin:
+            return LegacyAssetType.bitcoin
+        case .bitcoinCash:
+            return LegacyAssetType.bitcoinCash
+        case .ethereum:
+            return LegacyAssetType.ether
+        }
+    }
 }

--- a/Blockchain/RootService.m
+++ b/Blockchain/RootService.m
@@ -2404,30 +2404,30 @@ RootService * app;
 //    [WalletManager.sharedInstance.wallet getMessages];
 //}
 
-- (void)didGetSwipeAddresses:(NSArray *)newSwipeAddresses assetType:(LegacyAssetType)assetType
-{
-    if (!newSwipeAddresses) {
-        DLog(@"Error: no new swipe addresses found!");
-        return;
-    }
-
-    for (NSString *swipeAddress in newSwipeAddresses) {
-        [KeychainItemWrapper addSwipeAddress:swipeAddress assetType:assetType];
-    }
-
-    if (assetType == LegacyAssetTypeBitcoin) {
-
-        int numberOfBitcoinCashAddressesToDerive = SWIPE_TO_RECEIVE_ADDRESS_COUNT;
-        NSArray *bitcoinCashSwipeAddresses = [KeychainItemWrapper getSwipeAddressesForAssetType:LegacyAssetTypeBitcoinCash];
-        if (bitcoinCashSwipeAddresses) {
-            numberOfBitcoinCashAddressesToDerive = SWIPE_TO_RECEIVE_ADDRESS_COUNT - (int)bitcoinCashSwipeAddresses.count;
-        }
-
-        [WalletManager.sharedInstance.wallet getSwipeAddresses:numberOfBitcoinCashAddressesToDerive assetType:LegacyAssetTypeBitcoinCash];
-    } else {
-        [self.pinEntryViewController setupQRCode];
-    }
-}
+//- (void)didGetSwipeAddresses:(NSArray *)newSwipeAddresses assetType:(LegacyAssetType)assetType
+//{
+//    if (!newSwipeAddresses) {
+//        DLog(@"Error: no new swipe addresses found!");
+//        return;
+//    }
+//
+//    for (NSString *swipeAddress in newSwipeAddresses) {
+//        [KeychainItemWrapper addSwipeAddress:swipeAddress assetType:assetType];
+//    }
+//
+//    if (assetType == LegacyAssetTypeBitcoin) {
+//
+//        int numberOfBitcoinCashAddressesToDerive = SWIPE_TO_RECEIVE_ADDRESS_COUNT;
+//        NSArray *bitcoinCashSwipeAddresses = [KeychainItemWrapper getSwipeAddressesForAssetType:LegacyAssetTypeBitcoinCash];
+//        if (bitcoinCashSwipeAddresses) {
+//            numberOfBitcoinCashAddressesToDerive = SWIPE_TO_RECEIVE_ADDRESS_COUNT - (int)bitcoinCashSwipeAddresses.count;
+//        }
+//
+//        [WalletManager.sharedInstance.wallet getSwipeAddresses:numberOfBitcoinCashAddressesToDerive assetType:LegacyAssetTypeBitcoinCash];
+//    } else {
+//        [self.pinEntryViewController setupQRCode];
+//    }
+//}
 
 //- (void)didFetchEthHistory
 //{

--- a/Blockchain/SettingsTableViewController.m
+++ b/Blockchain/SettingsTableViewController.m
@@ -557,7 +557,7 @@ const int aboutPrivacyPolicy = 2;
             BlockchainSettings.sharedAppInstance.swipeToReceiveEnabled = !swipeToReceiveEnabled;
             // Clear all swipe addresses in case default account has changed
             if (!swipeToReceiveEnabled) {
-                [KeychainItemWrapper removeAllSwipeAddresses];
+                [AssetAddressRepository.sharedInstance removeAllSwipeAddresses];
             }
         }]];
         [swipeToReceiveAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
@@ -569,7 +569,7 @@ const int aboutPrivacyPolicy = 2;
         BlockchainSettings.sharedAppInstance.swipeToReceiveEnabled = !swipeToReceiveEnabled;
         // Clear all swipe addresses in case default account has changed
         if (!swipeToReceiveEnabled) {
-            [KeychainItemWrapper removeAllSwipeAddresses];
+            [AssetAddressRepository.sharedInstance removeAllSwipeAddresses];
         }
     }
 }

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -46,6 +46,7 @@ class WalletManager: NSObject {
     @objc weak var transactionDelegate: WalletTransactionDelegate?
     @objc weak var transferAllDelegate: WalletTransferAllDelegate?
     @objc weak var watchOnlyDelegate: WalletWatchOnlyDelegate?
+    weak var swipeAddressDelegate: WalletSwipeAddressDelegate?
 
     init(wallet: Wallet = Wallet()!) {
         self.wallet = wallet
@@ -83,7 +84,7 @@ class WalletManager: NSObject {
 
         wallet.sessionToken = nil
 
-        KeychainItemWrapper.removeAllSwipeAddresses()
+        AssetAddressRepository.shared.removeAllSwipeAddresses()
         BlockchainSettings.App.shared.guid = nil
         BlockchainSettings.App.shared.sharedKey = nil
 
@@ -352,7 +353,7 @@ extension WalletManager: WalletDelegate {
 
         let newDefaultAccountLabeledAddressesCount = self.wallet.getDefaultAccountLabelledAddressesCount()
         if BlockchainSettings.App.shared.defaultAccountLabelledAddressesCount != newDefaultAccountLabeledAddressesCount {
-            KeychainItemWrapper.removeAllSwipeAddresses(for: .bitcoin)
+            AssetAddressRepository.shared.removeAllSwipeAddresses(for: .bitcoin)
         }
         let newCount = newDefaultAccountLabeledAddressesCount
         BlockchainSettings.App.shared.defaultAccountLabelledAddressesCount = Int(newCount)
@@ -475,5 +476,14 @@ extension WalletManager: WalletDelegate {
 
     func didErrorWhenGettingFiat(atTime error: String?) {
         fiatAtTimeDelegate?.didErrorWhenGettingFiatAtTime(error: error)
+    }
+
+    // MARK: - Swipe Address
+
+    func didGetSwipeAddresses(_ newSwipeAddresses: [Any]!, assetType: LegacyAssetType) {
+        swipeAddressDelegate?.onRetrievedSwipeToReceive(
+            addresses: newSwipeAddresses as! [String],
+            assetType: AssetType.from(legacyAssetType: assetType)
+        )
     }
 }

--- a/Blockchain/Wallet/WalletSwipeAddressDelegate.swift
+++ b/Blockchain/Wallet/WalletSwipeAddressDelegate.swift
@@ -1,0 +1,20 @@
+//
+//  WalletSwipeAddressDelegate.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 5/22/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol definition for the delegate related to swipe to receive addresses
+protocol WalletSwipeAddressDelegate: class {
+
+    /// Method invoked when swipe to receive addresses has been retrieved.
+    ///
+    /// - Parameters:
+    ///   - addresses: the addresses
+    ///   - assetType: the type of the asset for the retrieved addresses
+    func onRetrievedSwipeToReceive(addresses: [String], assetType: AssetType)
+}

--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -193,15 +193,7 @@ static PEViewController *VerifyController()
     AssetAddressRepository *assetAddressRepository = AssetAddressRepository.sharedInstance;
     if (assetType == LegacyAssetTypeBitcoin || assetType == LegacyAssetTypeBitcoinCash) {
 
-        AssetType type;
-        switch (assetType) {
-            case LegacyAssetTypeBitcoin:
-                type = AssetTypeBitcoin;
-            case LegacyAssetTypeBitcoinCash:
-                type = AssetTypeBitcoinCash;
-            case LegacyAssetTypeEther:
-                type = AssetTypeEthereum;
-        }
+        AssetType type = [self assetTypeFromLegacyAssetType:assetType];
 
         NSString *nextAddress = [[assetAddressRepository swipeToReceiveAddressesFor:type] firstObject];
         
@@ -242,17 +234,21 @@ static PEViewController *VerifyController()
     }
 }
 
+- (AssetType)assetTypeFromLegacyAssetType:(LegacyAssetType)legacyAssetType
+{
+    switch (legacyAssetType) {
+        case LegacyAssetTypeBitcoin:
+            return AssetTypeBitcoin;
+        case LegacyAssetTypeBitcoinCash:
+            return AssetTypeBitcoinCash;
+        case LegacyAssetTypeEther:
+            return AssetTypeEthereum;
+    }
+}
+
 - (void)paymentReceived:(LegacyAssetType)assetType
 {
-    AssetType type;
-    switch (assetType) {
-        case LegacyAssetTypeBitcoin:
-            type = AssetTypeBitcoin;
-        case LegacyAssetTypeBitcoinCash:
-            type = AssetTypeBitcoinCash;
-        case LegacyAssetTypeEther:
-            type = AssetTypeEthereum;
-    }
+    AssetType type = [self assetTypeFromLegacyAssetType: assetType];
 
     if (type != AssetTypeBitcoin && type != AssetTypeBitcoinCash) {
         return;


### PR DESCRIPTION
* Migrated out `didGetSwipeAddresses` from `RootService`.
* Created `AssetAddressRepository` component for retrieving addresses—would like to move latestMultiAddress response (currently in WalletManager) in there as well.
* Removed all direct references to the KeychainItemWrapper and instead reference the new `AssetAddressRepository`