### PR TITLE
fix(loading): make loading view visible over all views.

### DIFF
--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -15,14 +15,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: - Properties
 
-    lazy var busyView: BCFadeView? = {
-        guard let windowFrame = UIApplication.shared.keyWindow?.frame else {
-            return BCFadeView(frame: UIScreen.main.bounds)
-        }
-        print(windowFrame)
-        return BCFadeView(frame: windowFrame)
-    }()
-
     /// The overlay shown when the application resigns active state.
     lazy var privacyScreen: UIImageView? = {
         let launchImages = [

--- a/Blockchain/BCFadeView.m
+++ b/Blockchain/BCFadeView.m
@@ -26,28 +26,24 @@
 {
     [super awakeFromNib];
     self.labelBusy.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_SMALL_MEDIUM];
+    self.containerView.layer.cornerRadius = 5;
 }
 
 - (void)fadeIn {
-    self.containerView.layer.cornerRadius = 5;
-    
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:0.3];
-    [UIView setAnimationDelegate:self];
-    self.alpha = 1.0;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.3 animations:^{
+        self.alpha = 1.0;
+    }];
 }
 
 - (void)fadeOut {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:0.3];
-    [UIView setAnimationDidStopSelector:@selector(removeModalView)];
-    self.alpha = 0.0;
-    [UIView commitAnimations];
-}
-
-- (void)removeModalView {
-    [self removeFromSuperview];
+    [UIView animateWithDuration:0.3 animations:^{
+        self.alpha = 0.0;
+    }];
+    [UIView animateWithDuration:0.3 animations:^{
+        self.alpha = 0.0;
+    } completion:^(BOOL finished) {
+        [self removeFromSuperview];
+    }];
 }
 
 @end

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -92,9 +92,6 @@ import Foundation
         window.makeKeyAndVisible()
         tabControllerManager.dashBoardClicked(nil)
 
-        // Add busy view
-        LoadingViewPresenter.shared.initialize()
-
         // Display welcome screen if no wallet is authenticated
         if BlockchainSettings.App.shared.guid == nil || BlockchainSettings.App.shared.sharedKey == nil {
             OnboardingCoordinator.shared.start()

--- a/Blockchain/ModalPresenter.swift
+++ b/Blockchain/ModalPresenter.swift
@@ -98,8 +98,6 @@ typealias OnModalResumed = () -> Void
 
         if let previousModalView = modalChain.last {
             topMostView?.addSubview(previousModalView)
-            // TODO: handle busyView
-            // [[UIApplication sharedApplication].keyWindow.rootViewController.view bringSubviewToFront:busyView];
             topMostView?.endEditing(true)
 
             modalView.onResume?()

--- a/Blockchain/TabControllerManager.m
+++ b/Blockchain/TabControllerManager.m
@@ -340,7 +340,7 @@
 
 - (void)didReceivePaymentNoticeWithNotice:(NSString *_Nullable)notice
 {
-    if (notice && self.tabViewController.selectedIndex == TAB_SEND && LoadingViewPresenter.sharedInstance.busyView.alpha == 0 && !AuthenticationCoordinator.shared.pinEntryViewController && !self.tabViewController.presentedViewController) {
+    if (notice && self.tabViewController.selectedIndex == TAB_SEND && !LoadingViewPresenter.sharedInstance.isLoadingShown && !AuthenticationCoordinator.shared.pinEntryViewController && !self.tabViewController.presentedViewController) {
         [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:notice title:[LocalizationConstantsObjcBridge information] handler: nil];
     }
 }


### PR DESCRIPTION
* Adding busyView at the top-most window level. This way, no matter what views/view controllers are presented under, the loading view will always be displayed
* Making busyView `private`. We used to leak this state to external components to check if there is a loading view presented. Now, we can check if a loading view is displayed by querying `LoadingViewPresenter.shared.isLoadingShown`