### PR TITLE
fix(loading): Loading presentation

### DIFF
--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -499,6 +499,9 @@ import Foundation
 
 extension AuthenticationCoordinator: ManualPairViewDelegate {
     func manualPairView(_ manualPairView: BCManualPairView!, didContinueWithGuid guid: String!, andPassword password: String!) {
+
+        LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.Authentication.downloadingWallet)
+
         let payload = PasscodePayload(guid: guid, password: password, sharedKey: "")
         AuthenticationManager.shared.authenticate(using: payload) { [weak self] isAuthenticated, twoFAtype, error in
             guard let strongSelf = self else { return }

--- a/Blockchain/LoadingViewPresenter.swift
+++ b/Blockchain/LoadingViewPresenter.swift
@@ -33,21 +33,19 @@ import Foundation
     }
 
     @objc func hideBusyView() {
-        DispatchQueue.main.async { [unowned self] in
-            let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
+        let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
 
-            if let topViewController = topMostViewController as? TopViewController {
-                topViewController.hideBusyView?()
-                return
-            }
-
-            guard self.isLoadingShown else {
-                return
-            }
-
-            // After fading out is completed, it will also be removed from the superview
-            self.busyView.fadeOut()
+        if let topViewController = topMostViewController as? TopViewController {
+            topViewController.hideBusyView?()
+            return
         }
+
+        guard self.isLoadingShown else {
+            return
+        }
+
+        // After fading out is completed, it will also be removed from the superview
+        self.busyView.fadeOut()
     }
 
     // TODO: Show/hide/update methods can be called from any thread so we need to make sure to
@@ -55,45 +53,41 @@ import Foundation
     // show/hide/update logic should not be dispatched to the main thread and instead callers should
     // guarantee to call these methods in the main thread.
     @objc func showBusyView(withLoadingText text: String) {
-        DispatchQueue.main.async { [unowned self] in
-            let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
+        let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
 
-            if let topViewController = topMostViewController as? TopViewController {
-                topViewController.showBusyView?(withLoadingText: text)
-                return
-            }
-
-            if AppCoordinator.shared.tabControllerManager.isSending() && ModalPresenter.shared.modalView != nil {
-                print("Send progress modal is presented - will not show busy view")
-                return
-            }
-
-            guard !self.isLoadingShown else {
-                return
-            }
-
-            self.attachToMainWindow()
-
-            self.busyView.labelBusy.text = text
-            self.busyView.fadeIn()
+        if let topViewController = topMostViewController as? TopViewController {
+            topViewController.showBusyView?(withLoadingText: text)
+            return
         }
+
+        if AppCoordinator.shared.tabControllerManager.isSending() && ModalPresenter.shared.modalView != nil {
+            print("Send progress modal is presented - will not show busy view")
+            return
+        }
+
+        guard !self.isLoadingShown else {
+            return
+        }
+
+        self.attachToMainWindow()
+
+        self.busyView.labelBusy.text = text
+        self.busyView.fadeIn()
     }
 
     @objc func updateBusyViewLoadingText(text: String) {
-        DispatchQueue.main.async { [unowned self] in
-            let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
+        let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
 
-            if let topViewController = topMostViewController as? TopViewController {
-                topViewController.updateBusyViewLoadingText?(text)
-                return
-            }
-
-            guard self.isLoadingShown else {
-                return
-            }
-
-            self.busyView.labelBusy.text = text
+        if let topViewController = topMostViewController as? TopViewController {
+            topViewController.updateBusyViewLoadingText?(text)
+            return
         }
+
+        guard self.isLoadingShown else {
+            return
+        }
+
+        self.busyView.labelBusy.text = text
     }
 
     private func attachToMainWindow() {

--- a/Blockchain/LoadingViewPresenter.swift
+++ b/Blockchain/LoadingViewPresenter.swift
@@ -41,6 +41,7 @@ import Foundation
         }
 
         guard self.isLoadingShown else {
+            print("[LoadingViewPresenter]: Cannot hide busy view, already shown.")
             return
         }
 
@@ -48,10 +49,6 @@ import Foundation
         self.busyView.fadeOut()
     }
 
-    // TODO: Show/hide/update methods can be called from any thread so we need to make sure to
-    // explicitly dispatch the actions to the main thread. Once the wallet-rearch is completed, the
-    // show/hide/update logic should not be dispatched to the main thread and instead callers should
-    // guarantee to call these methods in the main thread.
     @objc func showBusyView(withLoadingText text: String) {
         let topMostViewController = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController
 
@@ -65,13 +62,15 @@ import Foundation
             return
         }
 
+        self.busyView.labelBusy.text = text
+
         guard !self.isLoadingShown else {
+            print("[LoadingViewPresenter]: cannot show busy view already shown.")
             return
         }
 
         self.attachToMainWindow()
 
-        self.busyView.labelBusy.text = text
         self.busyView.fadeIn()
     }
 
@@ -84,6 +83,7 @@ import Foundation
         }
 
         guard self.isLoadingShown else {
+            print("[LoadingViewPresenter]: Cannot update busy view with text: '\(text)', busy view should be shown.")
             return
         }
 

--- a/Blockchain/LoadingViewPresenter.swift
+++ b/Blockchain/LoadingViewPresenter.swift
@@ -41,7 +41,7 @@ import Foundation
         }
 
         guard self.isLoadingShown else {
-            print("[LoadingViewPresenter]: Cannot hide busy view, already shown.")
+            print("[LoadingViewPresenter]: Cannot hide busy view, already not shown.")
             return
         }
 

--- a/Blockchain/ModalPresenter.swift
+++ b/Blockchain/ModalPresenter.swift
@@ -35,10 +35,6 @@ typealias OnModalResumed = () -> Void
     @objc func closeAllModals() {
         LoadingViewPresenter.shared.hideBusyView()
 
-        // TODO: figure out why this is related to closing modals
-//        secondPasswordSuccess = nil;
-//        secondPasswordTextField.text = nil;
-
         WalletManager.shared.wallet.isSyncing = false
 
         guard let modalView = modalView else { return }

--- a/Blockchain/TabControllerManager.h
+++ b/Blockchain/TabControllerManager.h
@@ -86,7 +86,6 @@
 - (void)showSummaryForTransferAll;
 - (void)sendDuringTransferAll:(NSString *)secondPassword;
 - (void)didErrorDuringTransferAll:(NSString *)error secondPassword:(NSString *_Nullable)secondPassword;
-- (void)updateLoadedAllTransactions:(BOOL)loadedAll;
 - (void)receivedTransactionMessage;
 - (DestinationAddressSource)getSendAddressSource;
 - (void)setupSendToAddress:(NSString *)address;

--- a/Blockchain/TabControllerManager.m
+++ b/Blockchain/TabControllerManager.m
@@ -130,6 +130,12 @@
     [dataTask resume];
 }
 
+- (void)updateLoadedAllTransactionsWithLoadedAll:(BOOL)loadedAll
+{
+    // Should eventually apply to all asset types, but the fetching mechanism was never merged into My-Wallet-V3.
+    _transactionsBitcoinViewController.loadedAllTransactions = loadedAll;
+}
+
 #pragma mark - Reloading
 
 - (void)reload
@@ -343,14 +349,6 @@
     if (notice && self.tabViewController.selectedIndex == TAB_SEND && !LoadingViewPresenter.sharedInstance.isLoadingShown && !AuthenticationCoordinator.shared.pinEntryViewController && !self.tabViewController.presentedViewController) {
         [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:notice title:[LocalizationConstantsObjcBridge information] handler: nil];
     }
-}
-
-#pragma mark - Wallet Transactions Fetching Delegate
-
-- (void)updateLoadedAllTransactions:(BOOL)loadedAll
-{
-    // Should eventually apply to all asset types, but the fetching mechanism was never merged into My-Wallet-V3.
-    _transactionsBitcoinViewController.loadedAllTransactions = loadedAll;
 }
 
 #pragma mark - Eth Send

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -330,10 +330,6 @@
         [weakSelf on_pin_code_get_response:response];
     };
 
-    self.context[@"objc_loading_start_download_wallet"] = ^(){
-        [weakSelf loading_start_download_wallet];
-    };
-
     self.context[@"objc_loading_start_get_wallet_and_history"] = ^() {
         [weakSelf loading_start_get_wallet_and_history];
     };
@@ -2941,13 +2937,6 @@
 }
 
 #pragma mark - Callbacks from JS to Obj-C dealing with loading texts
-
-- (void)loading_start_download_wallet
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:LocalizationConstantsObjcBridge.downloadingWallet];
-    });
-}
 
 - (void)loading_start_decrypt_wallet
 {

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -2441,7 +2441,9 @@
 - (void)watchPendingTrades:(BOOL)shouldSync
 {
     if (shouldSync) {
-        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[LocalizationConstantsObjcBridge syncingWallet]];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[LocalizationConstantsObjcBridge syncingWallet]];
+        });
     }
 
     [self.context evaluateScript:[NSString stringWithFormat:@"MyWalletPhone.getPendingTrades(%d)", shouldSync]];
@@ -2942,73 +2944,101 @@
 
 - (void)loading_start_download_wallet
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:LocalizationConstantsObjcBridge.downloadingWallet];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:LocalizationConstantsObjcBridge.downloadingWallet];
+    });
 }
 
 - (void)loading_start_decrypt_wallet
 {
-    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_DECRYPTING_WALLET];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_DECRYPTING_WALLET];
+    });
 }
 
 - (void)loading_start_build_wallet
 {
-    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_BUILD_HD_WALLET];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_BUILD_HD_WALLET];
+    });
 }
 
 - (void)loading_start_multiaddr
 {
-    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    });
 }
 
 - (void)loading_start_get_history
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
+    });
 }
 
 - (void)loading_start_get_wallet_and_history
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CHECKING_WALLET_UPDATES];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CHECKING_WALLET_UPDATES];
+    });
 }
 
 - (void)loading_start_upgrade_to_hd
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_V3_WALLET];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_V3_WALLET];
+    });
 }
 
 - (void)loading_start_create_account
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING];
+    });
 }
 
 - (void)loading_start_new_account
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_WALLET];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_WALLET];
+    });
 }
 
 - (void)loading_start_create_new_address
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_NEW_ADDRESS];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_NEW_ADDRESS];
+    });
 }
 
 - (void)loading_start_generate_uuids
 {
-    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_RECOVERY_CREATING_WALLET];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_RECOVERY_CREATING_WALLET];
+    });
 }
 
 - (void)loading_start_recover_wallet
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_RECOVERING_WALLET];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_RECOVERING_WALLET];
+    });
 }
 
 - (void)loading_start_transfer_all:(NSNumber *)addressIndex totalAddresses:(NSNumber *)totalAddresses
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[NSString stringWithFormat:BC_STRING_TRANSFER_ALL_CALCULATING_AMOUNTS_AND_FEES_ARGUMENT_OF_ARGUMENT, addressIndex, totalAddresses]];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[NSString stringWithFormat:BC_STRING_TRANSFER_ALL_CALCULATING_AMOUNTS_AND_FEES_ARGUMENT_OF_ARGUMENT, addressIndex, totalAddresses]];
+    });
 }
 
 - (void)loading_stop
 {
     DLog(@"Stop loading");
-    [[LoadingViewPresenter sharedInstance] hideBusyView];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] hideBusyView];
+    });
 }
 
 - (void)upgrade_success
@@ -3760,7 +3790,9 @@
 
     [self subscribeToXPub:[self getXpubForAccount:[self getActiveAccountsCount:LegacyAssetTypeBitcoin] - 1 assetType:LegacyAssetTypeBitcoin] assetType:LegacyAssetTypeBitcoin];
 
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[LocalizationConstantsObjcBridge syncingWallet]];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[LocalizationConstantsObjcBridge syncingWallet]];
+    });
 }
 
 - (void)on_error_add_new_account:(NSString*)error
@@ -3812,14 +3844,16 @@
 {
     uint64_t fundsInAccount = [finalBalance longLongValue];
 
-    if ([totalReceived longLongValue] == 0) {
-        self.emptyAccountIndex++;
-        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:[NSString stringWithFormat:BC_STRING_LOADING_RECOVERING_WALLET_CHECKING_ARGUMENT_OF_ARGUMENT, self.emptyAccountIndex, self.emptyAccountIndex > RECOVERY_ACCOUNT_DEFAULT_NUMBER ? self.emptyAccountIndex : RECOVERY_ACCOUNT_DEFAULT_NUMBER]];
-    } else {
-        self.emptyAccountIndex = 0;
-        self.recoveredAccountIndex++;
-        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:[NSString stringWithFormat:BC_STRING_LOADING_RECOVERING_WALLET_ARGUMENT_FUNDS_ARGUMENT, self.recoveredAccountIndex, [NSNumberFormatter formatMoney:fundsInAccount]]];
-    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([totalReceived longLongValue] == 0) {
+            self.emptyAccountIndex++;
+            [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:[NSString stringWithFormat:BC_STRING_LOADING_RECOVERING_WALLET_CHECKING_ARGUMENT_OF_ARGUMENT, self.emptyAccountIndex, self.emptyAccountIndex > RECOVERY_ACCOUNT_DEFAULT_NUMBER ? self.emptyAccountIndex : RECOVERY_ACCOUNT_DEFAULT_NUMBER]];
+        } else {
+            self.emptyAccountIndex = 0;
+            self.recoveredAccountIndex++;
+            [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:[NSString stringWithFormat:BC_STRING_LOADING_RECOVERING_WALLET_ARGUMENT_FUNDS_ARGUMENT, self.recoveredAccountIndex, [NSNumberFormatter formatMoney:fundsInAccount]]];
+        }
+    });
 }
 
 - (void)on_error_downloading_account_settings
@@ -4211,10 +4245,12 @@
 
 - (void)on_shift_payment_error:(NSDictionary *)result
 {
-    [[LoadingViewPresenter sharedInstance] hideBusyView];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] hideBusyView];
 
-    NSString *errorMessage = [result objectForKey:DICTIONARY_KEY_MESSAGE];
-    [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:errorMessage title:BC_STRING_ERROR handler: nil];
+        NSString *errorMessage = [result objectForKey:DICTIONARY_KEY_MESSAGE];
+        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:errorMessage title:BC_STRING_ERROR handler: nil];
+    });
 }
 
 - (void)on_build_exchange_trade_success_from:(NSString *)from depositAmount:(NSString *)depositAmount fee:(NSNumber *)fee rate:(NSString *)rate minerFee:(NSString *)minerFee withdrawalAmount:(NSString *)withdrawalAmount expiration:(NSDate *)expirationDate
@@ -4584,7 +4620,9 @@
 
 - (void)crypto_scrypt:(id)_password salt:(id)salt n:(NSNumber*)N r:(NSNumber*)r p:(NSNumber*)p dkLen:(NSNumber*)derivedKeyLen success:(JSValue *)_success error:(JSValue *)_error
 {
-    [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_DECRYPTING_PRIVATE_KEY];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_DECRYPTING_PRIVATE_KEY];
+    });
 
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSData * data = [self _internal_crypto_scrypt:_password salt:salt n:[N unsignedLongLongValue] r:[r unsignedIntValue] p:[p unsignedIntValue] dkLen:[derivedKeyLen unsignedIntValue]];

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -330,6 +330,10 @@
         [weakSelf on_pin_code_get_response:response];
     };
 
+    self.context[@"objc_loading_start_download_wallet"] = ^(){
+        [weakSelf loading_start_download_wallet];
+    };
+
     self.context[@"objc_loading_start_get_wallet_and_history"] = ^() {
         [weakSelf loading_start_get_wallet_and_history];
     };
@@ -2938,25 +2942,24 @@
 
 #pragma mark - Callbacks from JS to Obj-C dealing with loading texts
 
+- (void)loading_start_download_wallet
+{
+    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:LocalizationConstantsObjcBridge.downloadingWallet];
+}
+
 - (void)loading_start_decrypt_wallet
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_DECRYPTING_WALLET];
-    });
+    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_DECRYPTING_WALLET];
 }
 
 - (void)loading_start_build_wallet
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_BUILD_HD_WALLET];
-    });
+    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_BUILD_HD_WALLET];
 }
 
 - (void)loading_start_multiaddr
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
-    });
+    [[LoadingViewPresenter sharedInstance] updateBusyViewLoadingTextWithText:BC_STRING_LOADING_LOADING_TRANSACTIONS];
 }
 
 - (void)loading_start_get_history

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -167,7 +167,13 @@ extension WalletManager: WalletDelegate {
     func walletDidDecrypt() {
         print("walletDidDecrypt()")
 
-        authDelegate?.didDecryptWallet(guid: wallet.guid, sharedKey: wallet.sharedKey, password: wallet.password)
+        DispatchQueue.main.async { [unowned self] in
+            self.authDelegate?.didDecryptWallet(
+                guid: self.wallet.guid,
+                sharedKey: self.wallet.sharedKey,
+                password: self.wallet.password
+            )
+        }
 
         didChangePassword = false
     }
@@ -179,46 +185,60 @@ extension WalletManager: WalletDelegate {
         wallet.bchSwipeAddressToSubscribe = nil
         wallet.twoFactorInput = nil
 
-        authDelegate?.authenticationCompleted()
+        DispatchQueue.main.async { [unowned self] in
+            self.authDelegate?.authenticationCompleted()
+        }
     }
 
     func walletFailedToDecrypt() {
         print("walletFailedToDecrypt()")
-        authDelegate?.authenticationError(error:
-            AuthenticationError(code: AuthenticationError.ErrorCode.errorDecryptingWallet.rawValue)
-        )
+        DispatchQueue.main.async { [unowned self] in
+            self.authDelegate?.authenticationError(error:
+                AuthenticationError(code: AuthenticationError.ErrorCode.errorDecryptingWallet.rawValue)
+            )
+        }
     }
 
     func walletFailedToLoad() {
         print("walletFailedToLoad()")
-        authDelegate?.authenticationError(error: AuthenticationError(
-            code: AuthenticationError.ErrorCode.failedToLoadWallet.rawValue
-        ))
+        DispatchQueue.main.async { [unowned self] in
+            self.authDelegate?.authenticationError(error: AuthenticationError(
+                code: AuthenticationError.ErrorCode.failedToLoadWallet.rawValue
+            ))
+        }
     }
 
     func walletDidRequireEmailAuthorization(_ wallet: Wallet!) {
-        authDelegate?.emailAuthorizationRequired()
+        DispatchQueue.main.async { [unowned self] in
+            self.authDelegate?.emailAuthorizationRequired()
+        }
     }
 
     func wallet(_ wallet: Wallet!, didRequireTwoFactorAuthentication type: Int) {
-        guard let twoFactorType = AuthenticationTwoFactorType(rawValue: type) else {
-            authDelegate?.authenticationError(error: AuthenticationError(
-                code: AuthenticationError.ErrorCode.invalidTwoFactorType.rawValue,
-                description: LocalizationConstants.Authentication.invalidTwoFactorAuthenticationType
-            ))
-            return
+        DispatchQueue.main.async { [unowned self] in
+            guard let twoFactorType = AuthenticationTwoFactorType(rawValue: type) else {
+                self.authDelegate?.authenticationError(error: AuthenticationError(
+                    code: AuthenticationError.ErrorCode.invalidTwoFactorType.rawValue,
+                    description: LocalizationConstants.Authentication.invalidTwoFactorAuthenticationType
+                ))
+                return
+            }
+            self.authDelegate?.didRequireTwoFactorAuth(withType: twoFactorType)
         }
-        authDelegate?.didRequireTwoFactorAuth(withType: twoFactorType)
     }
 
     func walletDidResendTwoFactorSMS(_ wallet: Wallet!) {
-        authDelegate?.didResendTwoFactorSMSCode()
+        DispatchQueue.main.async { [unowned self] in
+            self.authDelegate?.didResendTwoFactorSMSCode()
+        }
     }
 
     // MARK: - Buy/Sell
 
     func initializeWebView() {
-        buySellDelegate?.initializeWebView()
+        DispatchQueue.main.async { [unowned self] in
+            self.buySellDelegate?.initializeWebView()
+        }
     }
 
     func didCompleteTrade(_ tradeDict: [AnyHashable: Any]!) {
@@ -226,115 +246,170 @@ extension WalletManager: WalletDelegate {
             print("Failed to create Trade object.")
             return
         }
-        buySellDelegate?.didCompleteTrade(trade: trade)
+        DispatchQueue.main.async { [unowned self] in
+            self.buySellDelegate?.didCompleteTrade(trade: trade)
+        }
     }
 
     func showCompletedTrade(_ txHash: String) {
-        buySellDelegate?.showCompletedTrade(tradeHash: txHash)
+        DispatchQueue.main.async { [unowned self] in
+            self.buySellDelegate?.showCompletedTrade(tradeHash: txHash)
+        }
     }
 
     // MARK: - Pin Entry
 
     func didFailGetPinTimeout() {
-        pinEntryDelegate?.errorGetPinValueTimeout()
+        DispatchQueue.main.async { [unowned self] in
+            self.pinEntryDelegate?.errorGetPinValueTimeout()
+        }
     }
 
     func didFailGetPinNoResponse() {
-        pinEntryDelegate?.errorGetPinEmptyResponse()
+        DispatchQueue.main.async { [unowned self] in
+            self.pinEntryDelegate?.errorGetPinEmptyResponse()
+        }
     }
 
     func didFailGetPinInvalidResponse() {
-        pinEntryDelegate?.errorGetPinInvalidResponse()
+        DispatchQueue.main.async { [unowned self] in
+            self.pinEntryDelegate?.errorGetPinInvalidResponse()
+        }
     }
 
     func didFailPutPin(_ value: String!) {
-        pinEntryDelegate?.errorDidFailPutPin(errorMessage: value)
+        DispatchQueue.main.async { [unowned self] in
+            self.pinEntryDelegate?.errorDidFailPutPin(errorMessage: value)
+        }
     }
 
     func didPutPinSuccess(_ dictionary: [AnyHashable: Any]!) {
         let response = PutPinResponse(response: dictionary)
-        pinEntryDelegate?.putPinSuccess(response: response)
+        DispatchQueue.main.async { [unowned self] in
+            self.pinEntryDelegate?.putPinSuccess(response: response)
+        }
     }
 
     func didGetPinResponse(_ dictionary: [AnyHashable: Any]!) {
         let response = GetPinResponse(response: dictionary)
-        pinEntryDelegate?.getPinSuccess(response: response)
+        DispatchQueue.main.async { [unowned self] in
+            self.pinEntryDelegate?.getPinSuccess(response: response)
+        }
     }
 
     // MARK: - Send Bitcoin/Bitcoin Cash
     func didCheck(forOverSpending amount: NSNumber!, fee: NSNumber!) {
-        sendBitcoinDelegate?.didCheckForOverSpending(amount: amount, fee: fee)
+        DispatchQueue.main.async { [unowned self] in
+            self.sendBitcoinDelegate?.didCheckForOverSpending(amount: amount, fee: fee)
+        }
     }
 
     func didGetMaxFee(_ fee: NSNumber!, amount: NSNumber!, dust: NSNumber?, willConfirm: Bool) {
-        sendBitcoinDelegate?.didGetMaxFee(fee: fee, amount: amount, dust: dust, willConfirm: willConfirm)
+        DispatchQueue.main.async { [unowned self] in
+            self.sendBitcoinDelegate?.didGetMaxFee(fee: fee, amount: amount, dust: dust, willConfirm: willConfirm)
+        }
     }
 
     func didUpdateTotalAvailable(_ sweepAmount: NSNumber!, finalFee: NSNumber!) {
-        sendBitcoinDelegate?.didUpdateTotalAvailable(sweepAmount: sweepAmount, finalFee: finalFee)
+        DispatchQueue.main.async { [unowned self] in
+            self.sendBitcoinDelegate?.didUpdateTotalAvailable(sweepAmount: sweepAmount, finalFee: finalFee)
+        }
     }
 
     func didGetFee(_ fee: NSNumber!, dust: NSNumber?, txSize: NSNumber!) {
-        sendBitcoinDelegate?.didGetFee(fee: fee, dust: dust, txSize: txSize)
+        DispatchQueue.main.async { [unowned self] in
+            self.sendBitcoinDelegate?.didGetFee(fee: fee, dust: dust, txSize: txSize)
+        }
     }
 
     func didChangeSatoshiPerByte(_ sweepAmount: NSNumber!, fee: NSNumber!, dust: NSNumber?, updateType: FeeUpdateType) {
-        sendBitcoinDelegate?.didChangeSatoshiPerByte(sweepAmount: sweepAmount, fee: fee, dust: dust, updateType: updateType)
+        DispatchQueue.main.async { [unowned self] in
+            self.sendBitcoinDelegate?.didChangeSatoshiPerByte(
+                sweepAmount: sweepAmount,
+                fee: fee,
+                dust: dust,
+                updateType: updateType
+            )
+        }
     }
 
     func enableSendPaymentButtons() {
-        sendBitcoinDelegate?.enableSendPaymentButtons()
+        DispatchQueue.main.async { [unowned self] in
+            self.sendBitcoinDelegate?.enableSendPaymentButtons()
+        }
     }
 
     func updateSendBalance(_ balance: NSNumber!, fees: [AnyHashable: Any]!) {
-        sendBitcoinDelegate?.updateSendBalance(balance: balance, fees: fees as NSDictionary)
+        DispatchQueue.main.async { [unowned self] in
+            self.sendBitcoinDelegate?.updateSendBalance(balance: balance, fees: fees as NSDictionary)
+        }
     }
 
     func didReceivePaymentNotice(_ notice: String?) {
-        sendBitcoinDelegate?.didReceivePaymentNotice(notice: notice)
+        DispatchQueue.main.async { [unowned self] in
+            self.sendBitcoinDelegate?.didReceivePaymentNotice(notice: notice)
+        }
     }
 
     // MARK: - Send Ether
     func didUpdateEthPayment(_ payment: [AnyHashable: Any]!) {
-        sendEtherDelegate?.didUpdateEthPayment(payment: payment as NSDictionary)
+        DispatchQueue.main.async { [unowned self] in
+            self.sendEtherDelegate?.didUpdateEthPayment(payment: payment as NSDictionary)
+        }
     }
 
     func didSendEther() {
-        sendEtherDelegate?.didSendEther()
+        DispatchQueue.main.async { [unowned self] in
+            self.sendEtherDelegate?.didSendEther()
+        }
     }
 
     func didErrorDuringEtherSend(_ error: String!) {
-        sendEtherDelegate?.didErrorDuringEtherSend(error: error)
+        DispatchQueue.main.async { [unowned self] in
+            self.sendEtherDelegate?.didErrorDuringEtherSend(error: error)
+        }
     }
 
     func didGetEtherAddressWithSecondPassword() {
-        sendEtherDelegate?.didGetEtherAddressWithSecondPassword()
+        DispatchQueue.main.async { [unowned self] in
+            self.sendEtherDelegate?.didGetEtherAddressWithSecondPassword()
+        }
     }
 
     // MARK: - Addresses
 
     func didGenerateNewAddress() {
-        addressesDelegate?.didGenerateNewAddress()
+        DispatchQueue.main.async { [unowned self] in
+            self.addressesDelegate?.didGenerateNewAddress()
+        }
     }
 
     func returnToAddressesScreen() {
-        addressesDelegate?.didGenerateNewAddress()
+        DispatchQueue.main.async { [unowned self] in
+            self.addressesDelegate?.didGenerateNewAddress()
+        }
     }
 
     func didSetDefaultAccount() {
-        addressesDelegate?.didSetDefaultAccount()
+        DispatchQueue.main.async { [unowned self] in
+            self.addressesDelegate?.didSetDefaultAccount()
+        }
     }
 
     // MARK: - Account Info
 
     func walletDidGetAccountInfo(_ wallet: Wallet!) {
-        accountInfoDelegate?.didGetAccountInfo()
+        DispatchQueue.main.async { [unowned self] in
+            self.accountInfoDelegate?.didGetAccountInfo()
+        }
     }
 
     // MARK: - Currency Symbols
 
     func walletDidGetBtcExchangeRates(_ wallet: Wallet!) {
-        updateSymbols()
+        DispatchQueue.main.async { [unowned self] in
+            self.updateSymbols()
+        }
     }
 
     // MARK: - BTC Multiaddress
@@ -370,80 +445,114 @@ extension WalletManager: WalletDelegate {
     // MARK: - Backup
 
     func didBackupWallet() {
-        backupDelegate?.didBackupWallet()
+        DispatchQueue.main.async { [unowned self] in
+            self.backupDelegate?.didBackupWallet()
+        }
     }
 
     func didFailBackupWallet() {
-        backupDelegate?.didFailBackupWallet()
+        DispatchQueue.main.async { [unowned self] in
+            self.backupDelegate?.didFailBackupWallet()
+        }
     }
 
     // MARK: - Account Info and Exchange Rates on startup
 
     func walletDidGetAccountInfoAndExchangeRates(_ wallet: Wallet!) {
-        accountInfoAndExchangeRatesDelegate?.didGetAccountInfoAndExchangeRates()
+        DispatchQueue.main.async { [unowned self] in
+            self.accountInfoAndExchangeRatesDelegate?.didGetAccountInfoAndExchangeRates()
+        }
     }
 
     // MARK: - Recovery
 
     func didRecoverWallet() {
-        recoveryDelegate?.didRecoverWallet()
+        DispatchQueue.main.async { [unowned self] in
+            self.recoveryDelegate?.didRecoverWallet()
+        }
     }
 
     func didFailRecovery() {
-        recoveryDelegate?.didFailRecovery()
+        DispatchQueue.main.async { [unowned self] in
+            self.recoveryDelegate?.didFailRecovery()
+        }
     }
 
     // MARK: - Exchange
     func didGetExchangeTrades(_ trades: [Any]!) {
-        exchangeDelegate?.didGetExchangeTrades(trades: trades as NSArray)
+        DispatchQueue.main.async { [unowned self] in
+            self.exchangeDelegate?.didGetExchangeTrades(trades: trades as NSArray)
+        }
     }
 
     func didGetExchangeRate(_ result: [AnyHashable: Any]!) {
-        exchangeDelegate?.didGetExchangeRate(rate: result as NSDictionary)
+        DispatchQueue.main.async { [unowned self] in
+            self.exchangeDelegate?.didGetExchangeRate(rate: result as NSDictionary)
+        }
     }
 
     func didGetAvailableBtcBalance(_ result: [AnyHashable: Any]!) {
-        exchangeDelegate?.didGetAvailableBtcBalance(result: result as NSDictionary)
+        DispatchQueue.main.async { [unowned self] in
+            self.exchangeDelegate?.didGetAvailableBtcBalance(result: result as NSDictionary)
+        }
     }
 
     func didGetAvailableEthBalance(_ result: [AnyHashable: Any]!) {
-        exchangeDelegate?.didGetAvailableEthBalance(result: result as NSDictionary)
+        DispatchQueue.main.async { [unowned self] in
+            self.exchangeDelegate?.didGetAvailableEthBalance(result: result as NSDictionary)
+        }
     }
 
     func didBuildExchangeTrade(_ tradeInfo: [AnyHashable: Any]!) {
-        exchangeDelegate?.didBuildExchangeTrade(tradeInfo: tradeInfo as NSDictionary)
+        DispatchQueue.main.async { [unowned self] in
+            self.exchangeDelegate?.didBuildExchangeTrade(tradeInfo: tradeInfo as NSDictionary)
+        }
     }
 
     func didShiftPayment(_ info: [AnyHashable: Any]!) {
-        exchangeDelegate?.didShiftPayment(info: info as NSDictionary)
+        DispatchQueue.main.async { [unowned self] in
+            self.exchangeDelegate?.didShiftPayment(info: info as NSDictionary)
+        }
     }
 
     func didCreateEthAccountForExchange() {
-        exchangeIntermediateDelegate?.didCreateEthAccountForExchange()
+        DispatchQueue.main.async { [unowned self] in
+            self.exchangeIntermediateDelegate?.didCreateEthAccountForExchange()
+        }
     }
 
     // MARK: - History
     func didFailGetHistory(_ error: String?) {
-        historyDelegate?.didFailGetHistory(error: error)
+        DispatchQueue.main.async { [unowned self] in
+            self.historyDelegate?.didFailGetHistory(error: error)
+        }
     }
 
     func didFetchEthHistory() {
-        historyDelegate?.didFetchEthHistory()
+        DispatchQueue.main.async { [unowned self] in
+            self.historyDelegate?.didFetchEthHistory()
+        }
     }
 
     func didFetchBitcoinCashHistory() {
-        historyDelegate?.didFetchBitcoinCashHistory()
+        DispatchQueue.main.async { [unowned self] in
+            self.historyDelegate?.didFetchBitcoinCashHistory()
+        }
     }
 
     // MARK: - Watch Only Send
     func sendFromWatchOnlyAddress() {
-        watchOnlyDelegate?.sendFromWatchOnlyAddress()
+        DispatchQueue.main.async { [unowned self] in
+            self.watchOnlyDelegate?.sendFromWatchOnlyAddress()
+        }
     }
 
     // MARK: - Transaction
 
     func didPushTransaction() {
-        self.transactionDelegate?.didPushTransaction()
+        DispatchQueue.main.async { [unowned self] in
+            self.transactionDelegate?.didPushTransaction()
+        }
     }
 
     func receivedTransactionMessage() {
@@ -459,52 +568,80 @@ extension WalletManager: WalletDelegate {
     }
 
     func updateLoadedAllTransactions(_ loadedAll: Bool) {
-        self.transactionDelegate?.updateLoadedAllTransactions(loadedAll: loadedAll)
+        DispatchQueue.main.async { [unowned self] in
+            self.transactionDelegate?.updateLoadedAllTransactions(loadedAll: loadedAll)
+        }
     }
 
     // MARK: - Transfer all
     func updateTransferAllAmount(_ amount: NSNumber!, fee: NSNumber!, addressesUsed: [Any]!) {
-        transferAllDelegate?.updateTransferAll(amount: amount, fee: fee, addressesUsed: addressesUsed as NSArray)
+        DispatchQueue.main.async { [unowned self] in
+            self.transferAllDelegate?.updateTransferAll(
+                amount: amount,
+                fee: fee,
+                addressesUsed: addressesUsed as NSArray
+            )
+        }
     }
 
     func showSummaryForTransferAll() {
-        transferAllDelegate?.showSummaryForTransferAll()
+        DispatchQueue.main.async { [unowned self] in
+            self.transferAllDelegate?.showSummaryForTransferAll()
+        }
     }
 
     func sendDuringTransferAll(_ secondPassword: String?) {
-        transferAllDelegate?.sendDuringTransferAll(secondPassword: secondPassword)
+        DispatchQueue.main.async { [unowned self] in
+            self.transferAllDelegate?.sendDuringTransferAll(secondPassword: secondPassword)
+        }
     }
 
     func didErrorDuringTransferAll(_ error: String!, secondPassword: String?) {
-        transferAllDelegate?.didErrorDuringTransferAll(error: error, secondPassword: secondPassword)
+        DispatchQueue.main.async { [unowned self] in
+            self.transferAllDelegate?.didErrorDuringTransferAll(error: error, secondPassword: secondPassword)
+        }
     }
 
     // MARK: - Fiat at Time
     func didGetFiat(atTime fiatAmount: NSNumber!, currencyCode: String!, assetType: LegacyAssetType) {
-        fiatAtTimeDelegate?.didGetFiatAtTime(fiatAmount: fiatAmount, currencyCode: currencyCode, assetType: AssetType.from(legacyAssetType: assetType))
+        DispatchQueue.main.async { [unowned self] in
+            self.fiatAtTimeDelegate?.didGetFiatAtTime(
+                fiatAmount: fiatAmount,
+                currencyCode: currencyCode,
+                assetType: AssetType.from(legacyAssetType: assetType)
+            )
+        }
     }
 
     func didErrorWhenGettingFiat(atTime error: String?) {
-        fiatAtTimeDelegate?.didErrorWhenGettingFiatAtTime(error: error)
+        DispatchQueue.main.async { [unowned self] in
+            self.fiatAtTimeDelegate?.didErrorWhenGettingFiatAtTime(error: error)
+        }
     }
 
     // MARK: - Swipe Address
 
     func didGetSwipeAddresses(_ newSwipeAddresses: [Any]!, assetType: LegacyAssetType) {
-        swipeAddressDelegate?.onRetrievedSwipeToReceive(
-            addresses: newSwipeAddresses as! [String],
-            assetType: AssetType.from(legacyAssetType: assetType)
-        )
+        DispatchQueue.main.async { [unowned self] in
+            self.swipeAddressDelegate?.onRetrievedSwipeToReceive(
+                addresses: newSwipeAddresses as! [String],
+                assetType: AssetType.from(legacyAssetType: assetType)
+            )
+        }
     }
 
     // MARK: - Key Importing
 
     func askUserToAddWatchOnlyAddress(_ address: AssetAddress, then: @escaping () -> Void) {
-        keyImportDelegate?.askUserToAddWatchOnlyAddress(address, then: then)
+        DispatchQueue.main.async { [unowned self] in
+            self.keyImportDelegate?.askUserToAddWatchOnlyAddress(address, then: then)
+        }
     }
 
     @objc func scanPrivateKeyForWatchOnlyAddress(_ address: String) {
         let address = BitcoinAddress(string: address)!
-        keyImportDelegate?.scanPrivateKeyForWatchOnlyAddress(address)
+        DispatchQueue.main.async { [unowned self] in
+            self.keyImportDelegate?.scanPrivateKeyForWatchOnlyAddress(address)
+        }
     }
 }

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -749,6 +749,8 @@ MyWalletPhone.login = function(user_guid, shared_key, resend_code, inputedPasswo
         objc_show_email_authorization_alert();
     }
 
+    objc_loading_start_download_wallet();
+
     var credentials = {};
 
     credentials.twoFactor = twoFACode ? {type: WalletStore.get2FAType(), code : twoFACode} : null;

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -749,8 +749,6 @@ MyWalletPhone.login = function(user_guid, shared_key, resend_code, inputedPasswo
         objc_show_email_authorization_alert();
     }
 
-    objc_loading_start_download_wallet();
-
     var credentials = {};
 
     credentials.twoFactor = twoFACode ? {type: WalletStore.get2FAType(), code : twoFACode} : null;


### PR DESCRIPTION
The loading/busy view was not being presented in some areas (manual pairing, password required view, etc.) because the action was dispatched asynchronously to the GCD. So, if that queue is congested (like in the case of password auth since it does), the loading view may not be presented. This change fixes that issue by guaranteeing that an invocation to one of the `LoadingViewPresenter` methods execute on the main thread (previous was async and passed to the main queue).

As I brought up before, we want wallet delegate methods to always be invoked on the main thread (removes all the guesswork whether or not a callback is executed on the main or background thread). I went ahead and guaranteed that by calling the wallet delegate methods from within a block dispatched to GCD on the main queue. Also, we have some other LoadingViewPresenter references in the Wallet.m that I also wrapped inside a block that gets executed on the main thread.

Fixes #201 

Other change: implement the correct method for `WalletTransactionDelegate`.