### PR TITLE
fix(modal): prevent modal presentation on UIAlertViewController

### DIFF
--- a/Blockchain/UIViewController.swift
+++ b/Blockchain/UIViewController.swift
@@ -21,3 +21,11 @@ extension UINavigationController {
         return visibleViewController ?? self
     }
 }
+
+extension UIAlertController {
+
+    /// Overridden so that UIAlertControllers will never show up as the `topMostViewController`.
+    override var topMostViewController: UIViewController? {
+        return presentedViewController?.topMostViewController
+    }
+}


### PR DESCRIPTION
`PasswordRequiredView` sometimes gets presented in a cut-off way. This change fixes that.