### PR TITLE
fix(recover): display 'Recover Funds' header title.

### DIFF
--- a/Blockchain/Coordinators/OnboardingCoordinator.swift
+++ b/Blockchain/Coordinators/OnboardingCoordinator.swift
@@ -54,7 +54,7 @@ extension OnboardingCoordinator: BCWelcomeViewDelegate {
             withContent: createWallet!,
             closeType: ModalCloseTypeBack,
             showHeader: true,
-            headerText: LocalizationConstants.Onboarding.createNewWallet
+            headerText: title
         )
     }
 


### PR DESCRIPTION
Used to always display "Create New Wallet" when going through the recover funds flow.