### PR TITLE
iPhone X Support for Pair Wallet Screen

### DIFF
--- a/Blockchain/BCChartMarkerView.swift
+++ b/Blockchain/BCChartMarkerView.swift
@@ -12,7 +12,11 @@ class BCChartMarkerView: MarkerView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.layer.borderWidth = 3.0
-        self.layer.borderColor = Constants.Colors.BlockchainLightestBlue.cgColor
+        if #available(iOS 11.0, *) {
+            self.layer.borderColor = UIColor(named: "ColorBrandTertiary")?.cgColor
+        } else {
+            self.layer.borderColor = Constants.Colors.ColorBrandTertiary.cgColor
+        }
         self.layer.cornerRadius = self.frame.width / 2
         self.layer.masksToBounds = true
         self.backgroundColor = UIColor.white

--- a/Blockchain/BCModalView.m
+++ b/Blockchain/BCModalView.m
@@ -10,44 +10,60 @@
 #import "LocalizationConstants.h"
 #import "Blockchain-Swift.h"
 
+// TODO: deprecate BCModalView
 @implementation BCModalView
 
 - (id)initWithCloseType:(ModalCloseType)closeType showHeader:(BOOL)showHeader headerText:(NSString *)headerText
 {
     UIWindow *window = [UIApplication sharedApplication].keyWindow;
+    //: Pre iOS 11 devices only need to consider the status bar (20pt)
+    CGFloat safeAreaInsetTop = 20;
+    if (@available(iOS 11.0, *)) {
+        safeAreaInsetTop = window.rootViewController.view.safeAreaInsets.top;
+    }
     
     self = [super initWithFrame:CGRectMake(0, 0, window.frame.size.width, window.frame.size.height)];
     
     if (self) {
         self.backgroundColor = [UIColor whiteColor];
         self.closeType = closeType;
-        
+
         if (showHeader) {
-            UIView *topBarView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, window.frame.size.width, DEFAULT_HEADER_HEIGHT)];
+            // TODO: use UINavigationBar & autolayout
+            CGFloat topBarHeight = [ConstantsObjcBridge defaultNavigationBarHeight] + safeAreaInsetTop;
+            UIView *topBarView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, window.frame.size.width, topBarHeight)];
             topBarView.backgroundColor = COLOR_BLOCKCHAIN_BLUE;
             [self addSubview:topBarView];
-            
-            UILabel *headerLabel = [[UILabel alloc] initWithFrame:FRAME_HEADER_LABEL];
+
+            UILabel *headerLabel = [[UILabel alloc] initWithFrame:CGRectZero];
             headerLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_TOP_BAR_TEXT];
             headerLabel.textColor = [UIColor whiteColor];
             headerLabel.textAlignment = NSTextAlignmentCenter;
             headerLabel.adjustsFontSizeToFitWidth = YES;
             headerLabel.text = headerText;
-            headerLabel.center = CGPointMake(topBarView.center.x, headerLabel.center.y);
+            [headerLabel sizeToFit];
+            CGFloat labelPosX = (topBarView.frame.size.width / 2) - (headerLabel.frame.size.width / 2);
+            CGFloat labelPosY = (topBarView.frame.size.height / 2) - (headerLabel.frame.size.height / 2) + (safeAreaInsetTop / 2);
+            CGFloat labelWidth = headerLabel.frame.size.width;
+            CGFloat labelHeight = headerLabel.frame.size.height;
+            CGRect frame = CGRectMake(labelPosX, labelPosY, labelWidth, labelHeight);
+            [headerLabel setFrame:frame];
             [topBarView addSubview:headerLabel];
             
+            // TODO: update ModalCloseTypeClose and ModalCloseTypeDone button image edge insets
             if (closeType == ModalCloseTypeBack) {
                 self.backButton = [UIButton buttonWithType:UIButtonTypeCustom];
-                self.backButton.frame = FRAME_BACK_BUTTON;
+                CGFloat buttonHeight = topBarView.frame.size.height - safeAreaInsetTop;
+                CGFloat buttonPosY = topBarView.frame.size.height - buttonHeight;
+                self.backButton.frame = CGRectMake(0, buttonPosY, 85, buttonHeight);
                 self.backButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
-                self.backButton.imageEdgeInsets = IMAGE_EDGE_INSETS_BACK_BUTTON_CHEVRON;
+                self.backButton.imageEdgeInsets = UIEdgeInsetsMake(0, 8, 0, 0);
                 [self.backButton.titleLabel setFont:[UIFont systemFontOfSize:FONT_SIZE_MEDIUM]];
                 [self.backButton setImage:[UIImage imageNamed:@"back_chevron_icon"] forState:UIControlStateNormal];
                 [self.backButton setTitleColor:[UIColor colorWithWhite:0.56 alpha:1.0] forState:UIControlStateHighlighted];
                 [self.backButton addTarget:self action:@selector(closeModalClicked:) forControlEvents:UIControlEventTouchUpInside];
                 [topBarView addSubview:self.backButton];
-            }
-            else if (closeType == ModalCloseTypeClose) {
+            } else if (closeType == ModalCloseTypeClose) {
                 self.closeButton = [[UIButton alloc] initWithFrame:CGRectMake(self.frame.size.width - 80, 15, 80, 51)];
                 self.closeButton.imageEdgeInsets = IMAGE_EDGE_INSETS_CLOSE_BUTTON_X;
                 self.closeButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
@@ -55,8 +71,7 @@
                 self.closeButton.center = CGPointMake(self.closeButton.center.x, headerLabel.center.y);
                 [self.closeButton addTarget:self action:@selector(closeModalClicked:) forControlEvents:UIControlEventTouchUpInside];
                 [topBarView addSubview:self.closeButton];
-            }
-            else if (closeType == ModalCloseTypeDone) {
+            } else if (closeType == ModalCloseTypeDone) {
                 self.closeButton = [[UIButton alloc] initWithFrame:CGRectMake(self.frame.size.width - 80, 15, 80, 51)];
                 self.closeButton.titleEdgeInsets = IMAGE_EDGE_INSETS_CLOSE_BUTTON_X;
                 self.closeButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
@@ -66,16 +81,28 @@
                 [self.closeButton addTarget:self action:@selector(closeModalClicked:) forControlEvents:UIControlEventTouchUpInside];
                 [topBarView addSubview:self.closeButton];
             }
-            
-            self.myHolderView = [[UIView alloc] initWithFrame:CGRectMake(0, DEFAULT_HEADER_HEIGHT, window.frame.size.width, window.frame.size.height - DEFAULT_HEADER_HEIGHT)];
-            
+
+            if (@available(iOS 11.0, *)) {
+                CGRect frame = window.rootViewController.view.safeAreaLayoutGuide.layoutFrame;
+                CGFloat topInset = window.rootViewController.view.safeAreaInsets.top;
+                CGFloat posX = frame.origin.x;
+                CGFloat posY = topBarView.frame.size.height;
+                CGFloat height = frame.size.height - topBarView.frame.size.height + topInset;
+                CGFloat width = frame.size.width;
+                self.myHolderView = [[UIView alloc] initWithFrame:CGRectMake(posX, posY, width, height)];
+            } else {
+                self.myHolderView = [[UIView alloc] initWithFrame:CGRectMake(0, topBarView.frame.size.height, window.frame.size.width, window.frame.size.height - DEFAULT_HEADER_HEIGHT)];
+            }
+
             [self addSubview:self.myHolderView];
             
             [self bringSubviewToFront:topBarView];
-        }
-        else {
-            self.myHolderView = [[UIView alloc] initWithFrame:CGRectMake(0, 20, window.frame.size.width, window.frame.size.height - 20)];
-            
+        } else {
+            if (@available(iOS 11.0, *)) {
+                self.myHolderView = [[UIView alloc] initWithFrame:window.rootViewController.view.safeAreaLayoutGuide.layoutFrame];
+            } else {
+                self.myHolderView = [[UIView alloc] initWithFrame:CGRectMake(0, safeAreaInsetTop, window.frame.size.width, window.frame.size.height - safeAreaInsetTop)];
+            }
             [self addSubview:self.myHolderView];
         }
     }

--- a/Blockchain/BCSecureTextField.swift
+++ b/Blockchain/BCSecureTextField.swift
@@ -42,7 +42,11 @@ import UIKit
         onePixelLine.frame = self.superview!.convert(onePixelLine.frame, from: self)
 
         onePixelLine.isUserInteractionEnabled = false
-        onePixelLine.backgroundColor = Constants.Colors.TextFieldBorderGray
+        if #available(iOS 11.0, *) {
+            onePixelLine.backgroundColor = UIColor(named: "ColorGray2")
+        } else {
+            onePixelLine.backgroundColor = Constants.Colors.ColorGray2
+        }
 
         self.superview!.addSubview(onePixelLine)
     }

--- a/Blockchain/BackupNavigationViewController.swift
+++ b/Blockchain/BackupNavigationViewController.swift
@@ -49,7 +49,11 @@ import UIKit
         super.viewDidLoad()
         let viewWidth = self.view.frame.size.width
         topBar = UIView(frame: CGRect(x: 0, y: 0, width: viewWidth, height: Constants.Measurements.DefaultHeaderHeight))
-        topBar.backgroundColor = Constants.Colors.BlockchainBlue
+        if #available(iOS 11.0, *) {
+            topBar.backgroundColor = UIColor(named: "ColorBrandPrimary")
+        } else {
+            topBar.backgroundColor = Constants.Colors.ColorBrandPrimary
+        }
         self.view.addSubview(topBar)
 
         setUpHeaderLabel()

--- a/Blockchain/BackupVerifyViewController.swift
+++ b/Blockchain/BackupVerifyViewController.swift
@@ -71,7 +71,11 @@ class BackupVerifyViewController: UIViewController, UITextFieldDelegate, SecondP
         verifyButton = UIButton(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 46))
         verifyButton?.setTitle(NSLocalizedString("Verify", comment: ""), for: UIControlState())
         verifyButton?.setTitle(NSLocalizedString("Verify", comment: ""), for: .disabled)
-        verifyButton?.backgroundColor = Constants.Colors.SecondaryGray
+        if #available(iOS 11.0, *) {
+            verifyButton?.backgroundColor = UIColor(named: "ColorGray1")
+        } else {
+            verifyButton?.backgroundColor = Constants.Colors.ColorGray1
+        }
         verifyButton?.setTitleColor(UIColor.lightGray, for: .disabled)
         verifyButton?.titleLabel!.font = UIFont(name: "Montserrat-Regular", size: Constants.FontSizes.Medium)
 
@@ -118,15 +122,27 @@ class BackupVerifyViewController: UIViewController, UITextFieldDelegate, SecondP
                 valid = false
             } else { // Don't mark words as invalid until the user has entered all three
                 if word1.text != randomWord1 {
-                    word1.textColor = Constants.Colors.WarningRed
+                    if #available(iOS 11.0, *) {
+                        word1.textColor = UIColor(named: "ColorError")
+                    } else {
+                        word1.textColor = Constants.Colors.ColorError
+                    }
                     valid = false
                 }
                 if word2.text != randomWord2 {
-                    word2.textColor = Constants.Colors.WarningRed
+                    if #available(iOS 11.0, *) {
+                        word2.textColor = UIColor(named: "ColorError")
+                    } else {
+                        word2.textColor = Constants.Colors.ColorError
+                    }
                     valid = false
                 }
                 if word3.text != randomWord3 {
-                    word3.textColor = Constants.Colors.WarningRed
+                    if #available(iOS 11.0, *) {
+                        word3.textColor = UIColor(named: "ColorError")
+                    } else {
+                        word3.textColor = Constants.Colors.ColorError
+                    }
                     valid = false
                 }
                 if !valid {
@@ -149,7 +165,11 @@ class BackupVerifyViewController: UIViewController, UITextFieldDelegate, SecondP
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        textField.textColor = Constants.Colors.DarkGray
+        if #available(iOS 11.0, *) {
+            textField.textColor = UIColor(named: "ColorGray5")
+        } else {
+            textField.textColor = Constants.Colors.ColorGray5
+        }
         return true
     }
 
@@ -169,11 +189,19 @@ class BackupVerifyViewController: UIViewController, UITextFieldDelegate, SecondP
 
     @objc func textFieldDidChange() {
         if !word1.text!.isEmpty && !word2.text!.isEmpty && !word3.text!.isEmpty {
-            verifyButton?.backgroundColor = Constants.Colors.BlockchainLightBlue
+            if #available(iOS 11.0, *) {
+                verifyButton?.backgroundColor = UIColor(named: "ColorBrandSecondary")
+            } else {
+                verifyButton?.backgroundColor = Constants.Colors.ColorBrandSecondary
+            }
             verifyButton?.isEnabled = true
             verifyButton?.setTitleColor(UIColor.white, for: UIControlState())
         } else if word1.text!.isEmpty || word2.text!.isEmpty || word3.text!.isEmpty {
-            verifyButton?.backgroundColor = Constants.Colors.SecondaryGray
+            if #available(iOS 11.0, *) {
+                verifyButton?.backgroundColor = UIColor(named: "ColorGray1")
+            } else {
+                verifyButton?.backgroundColor = Constants.Colors.ColorGray1
+            }
             verifyButton?.isEnabled = false
             verifyButton?.setTitleColor(UIColor.lightGray, for: .disabled)
         }

--- a/Blockchain/BackupViewController.swift
+++ b/Blockchain/BackupViewController.swift
@@ -41,7 +41,11 @@ import UIKit
         backupIconImageView.center = CGPoint(x: view.center.x, y: backupIconImageView.center.y)
         if let image = backupIconImageView.image {
             backupIconImageView.image? = image.withRenderingMode(.alwaysTemplate)
-            backupIconImageView.tintColor = Constants.Colors.WarningRed
+            if #available(iOS 11.0, *) {
+                backupIconImageView.tintColor = UIColor(named: "ColorError")
+            } else {
+                backupIconImageView.tintColor = Constants.Colors.ColorError
+            }
         }
 
         summaryLabel.text = NSLocalizedString("Backup Needed", comment: "")
@@ -56,7 +60,11 @@ import UIKit
             summaryLabel.text = NSLocalizedString("Backup Complete", comment: "")
             explanation.text = NSLocalizedString("Use your Recovery Phrase to restore your funds in case of a lost password.  Anyone with access to your Recovery Phrase can access your funds, so keep it offline somewhere safe and secure.", comment: "")
             backupIconImageView.image = UIImage(named: "success")?.withRenderingMode(.alwaysTemplate)
-            backupIconImageView.tintColor = Constants.Colors.SuccessGreen
+            if #available(iOS 11.0, *) {
+                backupIconImageView.tintColor = UIColor(named: "ColorSuccess")
+            } else {
+                backupIconImageView.tintColor = Constants.Colors.ColorSuccess
+            }
             backupWalletButton.setTitle(NSLocalizedString("BACKUP AGAIN", comment: ""), for: UIControlState())
 
             if wallet!.didUpgradeToHd() &&

--- a/Blockchain/BackupWordsViewController.swift
+++ b/Blockchain/BackupWordsViewController.swift
@@ -105,11 +105,19 @@ class BackupWordsViewController: UIViewController, SecondPasswordDelegate, UIScr
         if wordsPageControl.currentPage == 0 {
             previousWordButton.isEnabled = false
             previousWordButton.setTitleColor(UIColor.darkGray, for: UIControlState())
-            previousWordButton.backgroundColor = Constants.Colors.DisabledGray
+            if #available(iOS 11.0, *) {
+                previousWordButton.backgroundColor = UIColor(named: "ColorGray1")
+            } else {
+                previousWordButton.backgroundColor = Constants.Colors.ColorGray1
+            }
         } else {
             previousWordButton.isEnabled = true
             previousWordButton.setTitleColor(UIColor.white, for: UIControlState())
-            previousWordButton.backgroundColor = Constants.Colors.BlockchainLightBlue
+            if #available(iOS 11.0, *) {
+                previousWordButton.backgroundColor = UIColor(named: "ColorBrandSecondary")
+            } else {
+                previousWordButton.backgroundColor = Constants.Colors.ColorBrandSecondary
+            }
         }
     }
 
@@ -140,11 +148,19 @@ class BackupWordsViewController: UIViewController, SecondPasswordDelegate, UIScr
         wordsProgressLabel.text = progressLabelText
         if let count = wordLabels?.count {
             if wordsPageControl.currentPage == count-1 {
-                nextWordButton.backgroundColor = Constants.Colors.BlockchainBlue
+                if #available(iOS 11.0, *) {
+                    nextWordButton.backgroundColor = UIColor(named: "ColorBrandPrimary")
+                } else {
+                    nextWordButton.backgroundColor = Constants.Colors.ColorBrandPrimary
+                }
                 nextWordButton.setTitleColor(UIColor.white, for: UIControlState())
                 nextWordButton.setTitle(NSLocalizedString("Done", comment: ""), for: UIControlState())
             } else if wordsPageControl.currentPage == count-2 {
-                nextWordButton.backgroundColor = Constants.Colors.BlockchainLightBlue
+                if #available(iOS 11.0, *) {
+                    nextWordButton.backgroundColor = UIColor(named: "ColorBrandSecondary")
+                } else {
+                    nextWordButton.backgroundColor = Constants.Colors.ColorBrandSecondary
+                }
                 nextWordButton.setTitleColor(UIColor.white, for: UIControlState())
                 nextWordButton.setTitle(NSLocalizedString("NEXT", comment: ""), for: UIControlState())
             }

--- a/Blockchain/Base.lproj/MainWindow.xib
+++ b/Blockchain/Base.lproj/MainWindow.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -90,7 +90,7 @@
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="fI2-PD-Xwa">
                     <rect key="frame" x="0.0" y="430" width="320" height="50"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <color key="backgroundColor" red="0.90212953090667725" green="0.90210258960723877" blue="0.90211784839630127" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="backgroundColor" red="0.91764705882352937" green="0.91764705882352937" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="15"/>
                     <state key="normal" title="I can't access my camera">
                         <color key="titleColor" red="0.45901817083358765" green="0.45900446176528931" blue="0.45901218056678772" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -16,6 +16,7 @@
 
 #define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 
+// TODO: migrate to asset catalog
 #pragma mark - Colors
 
 #define UIColorFromRGB(rgbValue) [UIColor colorWithRed:((float)((rgbValue & 0xFF0000) >> 16))/255.0 \

--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -18,17 +18,19 @@ struct Constants {
         static let duration = 0.2
         static let durationLong = 0.5
     }
+    // TODO: remove once iOS < 11 is deprecated
+    //: Prefix colors with `Color` for easy filtering in asset catalog
+    //: Adding new color: create entry in Images.xcassets, then add constant here with same name
     struct Colors {
-        static let TextFieldBorderGray = UIColorFromRGB(0xcdcdcd)
-        static let BlockchainBlue = UIColorFromRGB(0x004a7c)
-        static let BlockchainLightBlue = UIColorFromRGB(0x10ade4)
-        static let BlockchainLightestBlue = UIColorFromRGB(0xb2d5e5)
-        static let SecondaryGray = UIColorFromRGB(0xebebeb)
-        static let SuccessGreen = UIColorFromRGB(0x199D69)
-        static let WarningRed = UIColorFromRGB(0xB83940)
-        static let SentRed = UIColorFromRGB(0xF26C57)
-        static let DisabledGray = UIColorFromRGB(0xEBEBEB)
-        static let DarkGray = UIColorFromRGB(0x4c4c4c)
+        static let ColorBrandPrimary = UIColorFromRGB(0x004A7C)   // previously BlockchainBlue
+        static let ColorBrandSecondary = UIColorFromRGB(0x10ADE4) // previously BlockchainLightBlue
+        static let ColorBrandTertiary = UIColorFromRGB(0xB2D5E5)  // previously BlockchainLightestBlue
+        static let ColorError = UIColorFromRGB(0xCA3A3C)          // previously WarningRed
+        static let ColorGray1 = UIColorFromRGB(0xEAEAEA)          // previously DisabledGray, SecondaryGray
+        static let ColorGray2 = UIColorFromRGB(0xCCCCCC)          // previously TextFieldBorderGray
+        static let ColorGray5 = UIColorFromRGB(0x545456)          // previously DarkGray
+        static let ColorSent = UIColorFromRGB(0xF26C57)           // previously SentRed
+        static let ColorSuccess = UIColorFromRGB(0x00A76F)        // previously SuccessGreen
     }
     struct Measurements {
         static let DefaultHeaderHeight: CGFloat = 65

--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -34,6 +34,8 @@ struct Constants {
     }
     struct Measurements {
         static let DefaultHeaderHeight: CGFloat = 65
+        // TODO: remove this once we use autolayout
+        static let DefaultNavigationBarHeight: CGFloat = 44
         static let BackupButtonCornerRadius: CGFloat = 4
         static let BusyViewLabelWidth: CGFloat = 230
         static let BusyViewLabelHeight: CGFloat = 30
@@ -186,6 +188,10 @@ struct Constants {
 
     @objc class func cookiePolicyURLString() -> String {
         return Constants.Url.cookiePolicy
+    }
+
+    @objc class func defaultNavigationBarHeight() -> CGFloat {
+        return Constants.Measurements.DefaultNavigationBarHeight
     }
 }
 

--- a/Blockchain/ModalPresenter.swift
+++ b/Blockchain/ModalPresenter.swift
@@ -150,6 +150,17 @@ typealias OnModalResumed = () -> Void
             height: modalViewToShow.myHolderView.frame.size.height
         )
 
+        //: The pairing instructions view requires a custom background color
+        //: due to bottom insets on the iPhone X
+        // TODO: remove this stopgap solution when the modal view presenter is deprecated
+        if content is PairingInstructionsView {
+            if #available(iOS 11.0, *) {
+                modalViewToShow.backgroundColor = UIColor(named: "ColorGray1")
+            } else {
+                modalViewToShow.backgroundColor = Constants.Colors.ColorGray1
+            }
+        }
+
         modalViewToShow.myHolderView.addSubview(content)
         topMostView?.addSubview(modalViewToShow)
         topMostView?.endEditing(true)

--- a/Blockchain/ModalPresenter.swift
+++ b/Blockchain/ModalPresenter.swift
@@ -139,10 +139,6 @@ typealias OnModalResumed = () -> Void
             modalContentView.prepareForModalPresentation()
         }
 
-        if #available(iOS 11.0, *), let topView = topMostView {
-            modalViewToShow.myHolderView.frame = topView.safeAreaLayoutGuide.layoutFrame
-        }
-
         content.frame = CGRect(
             x: 0,
             y: 0,

--- a/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
+++ b/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
@@ -120,7 +120,11 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
         self.view.frame = viewFrame
 
         let topBar = UIView(frame: CGRect(x: 0, y: 0, width: self.view.frame.size.width, height: Constants.Measurements.DefaultHeaderHeight))
-        topBar.backgroundColor = Constants.Colors.BlockchainBlue
+        if #available(iOS 11.0, *) {
+            topBar.backgroundColor = UIColor(named: "ColorBrandPrimary")
+        } else {
+            topBar.backgroundColor = Constants.Colors.ColorBrandPrimary
+        }
         self.view.addSubview(topBar)
 
         let headerLabel = UILabel(frame: CGRect(x: 60, y: 26, width: 200, height: 30))

--- a/Blockchain/SecondPasswordViewController.swift
+++ b/Blockchain/SecondPasswordViewController.swift
@@ -28,7 +28,11 @@ class SecondPasswordViewController: UIViewController, UITextFieldDelegate {
         super.viewDidLoad()
         let viewWidth = self.view.frame.size.width
         topBar = UIView(frame: CGRect(x: 0, y: 0, width: viewWidth, height: Constants.Measurements.DefaultHeaderHeight))
-        topBar.backgroundColor = Constants.Colors.BlockchainBlue
+        if #available(iOS 11.0, *) {
+            topBar.backgroundColor = UIColor(named: "ColorBrandPrimary")
+        } else {
+            topBar.backgroundColor = Constants.Colors.ColorBrandPrimary
+        }
         self.view.addSubview(topBar)
 
         let headerLabel = UILabel(frame: CGRect(x: 60, y: 27, width: 200, height: 30))

--- a/Images.xcassets/ColorBitcoinOrange.colorset/Contents.json
+++ b/Images.xcassets/ColorBitcoinOrange.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xF6",
+          "alpha" : "1.000",
+          "blue" : "0x35",
+          "green" : "0x93"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorBrandPrimary.colorset/Contents.json
+++ b/Images.xcassets/ColorBrandPrimary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x00",
+          "alpha" : "1.000",
+          "blue" : "0x7C",
+          "green" : "0x4A"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorBrandSecondary.colorset/Contents.json
+++ b/Images.xcassets/ColorBrandSecondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x10",
+          "alpha" : "1.000",
+          "blue" : "0xE4",
+          "green" : "0xAD"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorBrandTertiary.colorset/Contents.json
+++ b/Images.xcassets/ColorBrandTertiary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xB2",
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0xD5"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorBrandYellow.colorset/Contents.json
+++ b/Images.xcassets/ColorBrandYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xFF",
+          "alpha" : "1.000",
+          "blue" : "0x62",
+          "green" : "0xCF"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorBrandYellowLighter.colorset/Contents.json
+++ b/Images.xcassets/ColorBrandYellowLighter.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xFF",
+          "alpha" : "1.000",
+          "blue" : "0xB4",
+          "green" : "0xE6"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorError.colorset/Contents.json
+++ b/Images.xcassets/ColorError.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xCA",
+          "alpha" : "1.000",
+          "blue" : "0x3C",
+          "green" : "0x3A"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorGray1.colorset/Contents.json
+++ b/Images.xcassets/ColorGray1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xEA",
+          "alpha" : "1.000",
+          "blue" : "0xEA",
+          "green" : "0xEA"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorGray2.colorset/Contents.json
+++ b/Images.xcassets/ColorGray2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xCC",
+          "alpha" : "1.000",
+          "blue" : "0xCC",
+          "green" : "0xCC"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorGray3.colorset/Contents.json
+++ b/Images.xcassets/ColorGray3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x99",
+          "alpha" : "1.000",
+          "blue" : "0x9E",
+          "green" : "0x9B"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorGray4.colorset/Contents.json
+++ b/Images.xcassets/ColorGray4.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x75",
+          "alpha" : "1.000",
+          "blue" : "0x79",
+          "green" : "0x76"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorGray5.colorset/Contents.json
+++ b/Images.xcassets/ColorGray5.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x54",
+          "alpha" : "1.000",
+          "blue" : "0x56",
+          "green" : "0x54"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorGray6.colorset/Contents.json
+++ b/Images.xcassets/ColorGray6.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x38",
+          "alpha" : "1.000",
+          "blue" : "0x38",
+          "green" : "0x38"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorMarketingPrimary.colorset/Contents.json
+++ b/Images.xcassets/ColorMarketingPrimary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x35",
+          "alpha" : "1.000",
+          "blue" : "0xA8",
+          "green" : "0x58"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorMarketingSecondary.colorset/Contents.json
+++ b/Images.xcassets/ColorMarketingSecondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x15",
+          "alpha" : "1.000",
+          "blue" : "0x62",
+          "green" : "0x3A"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorReceived.colorset/Contents.json
+++ b/Images.xcassets/ColorReceived.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x00",
+          "alpha" : "1.000",
+          "blue" : "0xBC",
+          "green" : "0xBA"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorSent.colorset/Contents.json
+++ b/Images.xcassets/ColorSent.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xF2",
+          "alpha" : "1.000",
+          "blue" : "0x57",
+          "green" : "0x6C"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorSuccess.colorset/Contents.json
+++ b/Images.xcassets/ColorSuccess.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x00",
+          "alpha" : "1.000",
+          "blue" : "0x6F",
+          "green" : "0xA7"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorTransferred.colorset/Contents.json
+++ b/Images.xcassets/ColorTransferred.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x79",
+          "alpha" : "1.000",
+          "blue" : "0xB2",
+          "green" : "0x9E"
+        }
+      }
+    }
+  ]
+}

--- a/Images.xcassets/ColorWhite.colorset/Contents.json
+++ b/Images.xcassets/ColorWhite.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xFF",
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Highlights in this PR:
- Adds iPhone X support to the **Pair Wallet Screen**.
- Reads & stores colors using the `Images.xcassets` catalog.

Note:
Migration of the colors is not yet complete and *only* colors used by Swift in `Constants.swift` have been migrated so far.