### PR TITLE
fix(JS escaped string): Properly escaping double quote character.

### DIFF
--- a/Blockchain/String+EscapeJS.swift
+++ b/Blockchain/String+EscapeJS.swift
@@ -13,8 +13,8 @@ extension String {
         var output = self
         let insensitive = NSString.CompareOptions.caseInsensitive
         output = output
-            .replacingOccurrences(of: "\"", with: "\\\"", options: insensitive)    // Quotation mark
             .replacingOccurrences(of: "\\", with: "\\\\", options: insensitive)    // Reverse solidus
+            .replacingOccurrences(of: "\"", with: "\\\"", options: insensitive)    // Quotation mark
             .replacingOccurrences(of: "'", with: "\\'", options: insensitive)      // Single quote
             .replacingOccurrences(of: "\u{8}", with: "\\b", options: insensitive)  // Backspace
             .replacingOccurrences(of: "\u{12}", with: "\\f", options: insensitive) // Formfeed

--- a/BlockchainTests/String+EscapeJSTests.swift
+++ b/BlockchainTests/String+EscapeJSTests.swift
@@ -26,13 +26,17 @@ class StringEscapeJSTests: XCTestCase {
     }
 
 //    //: Quotation mark
-//    func testEscapedForJSWithDoubleQuote() {
-//        let input = "\"This string should escape the double quote (\") character.\""
-//        let input2 = NSString(string: "\"This string should escape the double quote (\") character.\"")
-//        let expected = "\"This string should escape the double quote (\") character.\""
-//        let result = input.escapedForJS()
-//        XCTAssertEqual(result, expected, "Expected strings to match")
-//    }
+    func testEscapedForJSWithDoubleQuote() {
+        let expected = "\\\"This string should escape the double quote (\\\") character.\\\""
+
+        let input = "\"This string should escape the double quote (\") character.\""
+        let result = input.escapedForJS()
+        XCTAssertEqual(result, expected, "Expected strings to match")
+
+        let input2 = NSString(string: "\"This string should escape the double quote (\") character.\"")
+        let result2 = input2.escapedForJS()
+        XCTAssertEqual(result2, expected, "Expected strings to match")
+    }
 
     //: Reverse solidus
     func testEscapedForJSWithBackslash() {


### PR DESCRIPTION
Bug was that the double quote character was being escaped before the backlash character which resulted in an extra backslash.