### PR TITLE
fix(tx): Removing delay when animating first cell.

### DIFF
--- a/Blockchain/TransactionsBitcoinViewController.m
+++ b/Blockchain/TransactionsBitcoinViewController.m
@@ -271,7 +271,7 @@
     [tableView reloadData];
     
     [self reloadNewTransactions];
-    
+
     [self animateFirstCell];
     
     [self reloadLastNumberOfTransactions];
@@ -321,10 +321,9 @@
 - (void)animateFirstCell
 {
     if (data.transactions.count > 0 && self.receivedTransactionMessage) {
-        
         self.receivedTransactionMessage = NO;
 
-        [self performSelector:@selector(didGetNewTransaction) withObject:nil afterDelay:0.1f];
+        [self didGetNewTransaction];
     } else {
         self.hasZeroTotalBalance = [WalletManager.sharedInstance.wallet getTotalActiveBalance] == 0;
     }


### PR DESCRIPTION
This fixes a bug (pasted below for more context) wherein an exception is triggered if you have the transactions list open while receiving a new transaction.

```
2018-06-07 11:58:32.555182-0700 Blockchain[498:77105] *** Assertion failure in -[UITableView _endCellAnimationsWithContext:], 
/BuildRoot/Library/Caches/com.apple.xbs/Sources/UIKit/UIKit-3698.54.4/UITableView.m:2012

2018-06-07 11:58:32.572747-0700 Blockchain[498:77564] +[UncaughtExceptionHandler logException:walletIsLoaded:walletIsInitialized:] [Line 111] Logging exception: 

<pre>App Version: Blockchain, Version 2.4.6 (24)
System Name: iOS -  System Version : 11.4
Active View Controller: TransactionsBitcoinViewController
Wallet State: JSLoaded = FALSE, isInitialized = TRUE
Device:  Language: en-US
GUID Hash: bc7022390cd96d652a626ce4efd6cb85e280f4ef174085d4d9a3f29a3e745443

Reason: 

Invalid update: invalid number of rows in section 0.  The number of rows contained in an existing section after the update (26) must be 
equal to the number of rows contained in that section before the update (25), plus or minus the number of rows inserted or deleted from 
that section (1 inserted, 1 deleted) and plus or minus the number of rows moved into or out of that section (0 moved in, 0 moved out).

Stacktrace:(
    "4   libc++abi.dylib                     0x000000018060d37c <redacted> + 16",
    "5   libc++abi.dylib                     0x000000018060cf78 __cxa_rethrow + 144",
    "6   libobjc.A.dylib                     0x000000018061c7ac objc_exception_rethrow + 44",
    "7   CoreFoundation                      0x0000000181328e18 CFRunLoopRunSpecific + 664",
    "8   GraphicsServices                    0x000000018330d020 GSEventRunModal + 100"
)</pre>

[LoadingViewPresenter]: Cannot hide busy view, already not shown.
[LoadingViewPresenter]: Cannot hide busy view, already not shown.

2018-06-07 11:58:32.680922-0700 Blockchain[498:77105] invalid mode 'kCFRunLoopCommonModes' provided to CFRunLoopRunSpecific - break on _CFRunLoopError_RunCalledWithInvalidMode to debug. This message will only appear once per execution.
2018-06-07 11:58:52.586850-0700 Blockchain[498:77105] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 

'Invalid update: invalid number of rows in section 0.  The number of rows contained in an existing section after the update (26) must be equal 
to the number of rows contained in that section before the update (25), plus or minus the number of rows inserted or deleted from that section 
(1 inserted, 1 deleted) and plus or minus the number of rows moved into or out of that section (0 moved in, 0 moved out).'

*** First throw call stack:
(0x181462d8c 0x18061c5ec 0x181462bf8 0x181e52fa0 0x18b197948 0x18b193db8 0x18b322b6c 0x100870c60 0x181e984ac 0x18140baa8 0x18140b76c 0x18140b010 0x181408b60 0x181328da8 0x18330d020 0x18b345758 0x100b12a94 0x180db9fc0)
libc++abi.dylib: terminating with uncaught exception of type NSException

```