### PR TITLE
fix(swipe): fix invalid bitcoin address when scanning swipe to receive QR code.

### DIFF
--- a/Blockchain/Addresses/AssetAddressRepository.swift
+++ b/Blockchain/Addresses/AssetAddressRepository.swift
@@ -140,11 +140,13 @@ extension AssetAddressRepository {
         }
         NetworkManager.shared.session.sessionDescription = url.host
         let task = NetworkManager.shared.session.dataTask(with: url, completionHandler: { data, _, error in
-            if let error = error {
-                DispatchQueue.main.async { errorHandler() }; return
+            guard error == nil else {
+                DispatchQueue.main.async {
+                    errorHandler()
+                }
+                return
             }
-            guard
-                let json = try? JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: AnyObject],
+            guard let json = try? JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: AnyObject],
                 let transactions = json!["txs"] as? [NSDictionary] else {
                     // TODO: call error handler
                     return

--- a/Blockchain/QRCodeGenerator.m
+++ b/Blockchain/QRCodeGenerator.m
@@ -13,7 +13,7 @@
 
 - (UIImage *)qrImageFromAddress:(NSString *)address
 {
-    NSString *addressURL = [NSString stringWithFormat:@"%@%@", [ConstantsObjcBridge bitcoinUriPrefix], address];
+    NSString *addressURL = [NSString stringWithFormat:@"%@:%@", [ConstantsObjcBridge bitcoinUriPrefix], address];
     
     return [self createQRImageFromString:addressURL];
 }
@@ -22,7 +22,7 @@
 {
     NSString *amountString = [[NSNumberFormatter assetFormatterWithUSLocale] stringFromNumber:[NSNumber numberWithDouble:amount]];
     
-    NSString *addressURL = [NSString stringWithFormat:@"%@%@?amount=%@", [ConstantsObjcBridge bitcoinUriPrefix], address, amountString];
+    NSString *addressURL = [NSString stringWithFormat:@"%@:%@?amount=%@", [ConstantsObjcBridge bitcoinUriPrefix], address, amountString];
     
     return [self createQRImageFromString:addressURL];
 }

--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -141,8 +141,7 @@ static PEViewController *VerifyController()
         return;
     }
 
-    if (self.verifyOnly &&
-        BlockchainSettings.sharedAppInstance.swipeToReceiveEnabled) {
+    if (self.verifyOnly && BlockchainSettings.sharedAppInstance.swipeToReceiveEnabled) {
         
         for (NSNumber *key in self.swipeViews) {
             BCSwipeAddressView *swipeView = [self.swipeViews objectForKey:key];


### PR DESCRIPTION
The generated QR code was parsing to a string that was missing a ":". So instead of "bitcoin: 1GefAXn7FH3Bi49XGemJdqcQd3YtBWvdgW" it was "bitcoin 1GefAXn7FH3Bi49XGemJdqcQd3YtBWvdgW"