### PR TITLE
fix(bch): showing BCH swipe address

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -270,6 +270,9 @@
 		AA722C1520B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */; };
 		AA722C1920B4BBA900262A5F /* AssetAddressRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */; };
 		AA722C1A20B4BBA900262A5F /* AssetAddressRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */; };
+		AA94965E20CB5FA600A9C2DD /* AssetAddressFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA94965D20CB5FA600A9C2DD /* AssetAddressFactory.swift */; };
+		AA94965F20CB5FA600A9C2DD /* AssetAddressFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA94965D20CB5FA600A9C2DD /* AssetAddressFactory.swift */; };
+		AA94966420CB613100A9C2DD /* AssetAddressFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA94966220CB613100A9C2DD /* AssetAddressFactoryTests.swift */; };
 		AAA3314E20893CE100BBD292 /* PairingInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */; };
 		AAA3316120895A9C00BBD292 /* LoadingViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */; };
 		AAA3316B2089650B00BBD292 /* AlertViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */; };
@@ -1319,6 +1322,8 @@
 		AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchainSettings.swift; sourceTree = "<group>"; };
 		AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwipeAddressDelegate.swift; sourceTree = "<group>"; };
 		AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressRepository.swift; sourceTree = "<group>"; };
+		AA94965D20CB5FA600A9C2DD /* AssetAddressFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressFactory.swift; sourceTree = "<group>"; };
+		AA94966220CB613100A9C2DD /* AssetAddressFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressFactoryTests.swift; sourceTree = "<group>"; };
 		AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingInstructionsView.swift; sourceTree = "<group>"; };
 		AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewPresenter.swift; sourceTree = "<group>"; };
 		AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewPresenter.swift; sourceTree = "<group>"; };
@@ -1836,6 +1841,7 @@
 				C7369222209A4FDF004F5438 /* NumberFormatter+AssetsTests.swift */,
 				AACE31B72092A87900B7B806 /* PinTests.swift */,
 				51C2ADD820BDEF9900D66108 /* String+EscapeJSTests.swift */,
+				AA94966120CB611F00A9C2DD /* Addresses */,
 				AACE3206209782DD00B7B806 /* Authentication */,
 				AACE320920978E9900B7B806 /* Mock */,
 				51A862E52092689500B338E0 /* Mock Data */,
@@ -2336,10 +2342,19 @@
 			children = (
 				51DC2F5B20B72F4900E03AF2 /* AddressValidator.swift */,
 				51A862E02092506600B338E0 /* AssetAddress.swift */,
+				AA94965D20CB5FA600A9C2DD /* AssetAddressFactory.swift */,
 				AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */,
 				51A862D820921E7600B338E0 /* BitcoinAddress.swift */,
 				51A862DB20921EBD00B338E0 /* BitcoinCashAddress.swift */,
 				51DC2F5F20B7312600E03AF2 /* EthereumAddress.swift */,
+			);
+			path = Addresses;
+			sourceTree = "<group>";
+		};
+		AA94966120CB611F00A9C2DD /* Addresses */ = {
+			isa = PBXGroup;
+			children = (
+				AA94966220CB613100A9C2DD /* AssetAddressFactoryTests.swift */,
 			);
 			path = Addresses;
 			sourceTree = "<group>";
@@ -3095,6 +3110,7 @@
 				AACE31CF2092A99B00B7B806 /* AuthenticationManager.swift in Sources */,
 				AA1E52322097CC230099BD10 /* WalletPinEntryDelegate.swift in Sources */,
 				51135707209CF68500056D65 /* BackupViewController.swift in Sources */,
+				AA94965F20CB5FA600A9C2DD /* AssetAddressFactory.swift in Sources */,
 				AACE31CA2092A99B00B7B806 /* AssetAddress.swift in Sources */,
 				51135702209CEEB900056D65 /* PushNotificationAuthPayload.swift in Sources */,
 				AA63F87820A39DCF002B719B /* AppFeature.swift in Sources */,
@@ -3157,6 +3173,7 @@
 				AACE3132209121B300B7B806 /* PushNotificationManager.swift in Sources */,
 				C74E865A20B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift in Sources */,
 				519435AC208E6279001EF882 /* CertificatePinnerTests.swift in Sources */,
+				AA94966420CB613100A9C2DD /* AssetAddressFactoryTests.swift in Sources */,
 				C76D732D20B2F5CD00040B57 /* WalletFiatAtTimeDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3383,6 +3400,7 @@
 				6780DB981A40BDF40048EED2 /* AccountInOut.m in Sources */,
 				51943596208E3005001EF882 /* BlockchainAPI+URL.swift in Sources */,
 				23BF733C1C455DDB00204503 /* AccountsAndAddressesViewController.m in Sources */,
+				AA94965E20CB5FA600A9C2DD /* AssetAddressFactory.swift in Sources */,
 				2322DCB41D771831000E5AC1 /* SRDelegateController.m in Sources */,
 				AACE31222091004A00B7B806 /* UIApplication+Suspend.m in Sources */,
 				AAE94F3F20C71379005A3595 /* AssetURLPayloadFactory.swift in Sources */,

--- a/Blockchain/Addresses/AssetAddressFactory.swift
+++ b/Blockchain/Addresses/AssetAddressFactory.swift
@@ -26,4 +26,22 @@ class AssetAddressFactory {
             return EthereumAddress(string: address)
         }
     }
+
+    /// Creates the appropriate concrete instances of an `AssetAddress` provided a string
+    /// array of addresses and the desired asset type.
+    ///
+    /// - Parameters:
+    ///   - address: the address of the asset
+    ///   - assetType: the type of the asset
+    /// - Returns: an array of the concrete AssetAddress instances
+    static func create(
+        fromAddressStringArray addressArray: [String],
+        assetType: AssetType
+    ) -> [AssetAddress] {
+        var createdAddresses = [AssetAddress]()
+        addressArray.forEach {
+            createdAddresses.append(create(fromAddressString: $0, assetType: assetType))
+        }
+        return createdAddresses
+    }
 }

--- a/Blockchain/Addresses/AssetAddressFactory.swift
+++ b/Blockchain/Addresses/AssetAddressFactory.swift
@@ -1,0 +1,29 @@
+//
+//  AssetAddressFactory.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 6/8/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+class AssetAddressFactory {
+    /// Creates the appropriate concrete instance of an `AssetAddress` provided an
+    /// address string and the desired asset type.
+    ///
+    /// - Parameters:
+    ///   - address: the address of the asset
+    ///   - assetType: the type of the asset
+    /// - Returns: the concrete AssetAddress
+    static func create(fromAddressString address: String, assetType: AssetType) -> AssetAddress {
+        switch assetType {
+        case .bitcoin:
+            return BitcoinAddress(string: address)
+        case .bitcoinCash:
+            return BitcoinCashAddress(string: address)
+        case .ethereum:
+            return EthereumAddress(string: address)
+        }
+    }
+}

--- a/Blockchain/Addresses/AssetAddressRepository.swift
+++ b/Blockchain/Addresses/AssetAddressRepository.swift
@@ -113,31 +113,32 @@ extension AssetAddressRepository {
     ///   - address: address to be checked with network request
     ///   - displayAddress: address to be shown to the user in text and in QR code
     /// (usually the same as address unless checking for corresponding BTC address for BCH
-    ///   - legacyAssetType: asset type for the address. Currently only supports BTC and BCH.
+    ///   - assetType: asset type for the address. Currently only supports BTC and BCH.
     ///   - successHandler: success handler to do something with the display address and whether the address has ever had a transaction
     ///   - errorHandler: error handler
     @objc func checkForUnusedAddress(
         _ address: String,
         displayAddress: String,
-        legacyAssetType: LegacyAssetType,
+        assetType: AssetType,
         successHandler: @escaping ((_ displayAddress: String, _ isUnused: Bool) -> Void),
         errorHandler: @escaping (() -> Void)
     ) {
-        var assetAddress: AssetAddress
-
-        let assetType = AssetType.from(legacyAssetType: legacyAssetType)
-
-        switch assetType {
-        case .bitcoin: assetAddress = BitcoinAddress(string: address)
-        case .bitcoinCash: assetAddress = BitcoinCashAddress(string: address)
-        case .ethereum: return
+        guard assetType != .ethereum else {
+            print("Ethereum addresses not supported for checking if it is unused.")
+            return
         }
 
-        guard
-            let urlString = BlockchainAPI.shared.suffixURL(address: assetAddress),
-            let url = URL(string: urlString) else {
-                return
+        var assetAddress = AssetAddressFactory.create(fromAddressString: address, assetType: assetType)
+        if let bchAddress = assetAddress as? BitcoinCashAddress,
+            let transformedBtcAddress = bchAddress.toBitcoinAddress(wallet: walletManager.wallet) {
+            assetAddress = transformedBtcAddress
         }
+
+        guard let urlString = BlockchainAPI.shared.suffixURL(address: assetAddress), let url = URL(string: urlString) else {
+            print("Cannot construct URL to check if the address '\(address)' is unused.")
+            return
+        }
+
         NetworkManager.shared.session.sessionDescription = url.host
         let task = NetworkManager.shared.session.dataTask(with: url, completionHandler: { data, _, error in
             guard error == nil else {

--- a/Blockchain/Addresses/AssetAddressRepository.swift
+++ b/Blockchain/Addresses/AssetAddressRepository.swift
@@ -66,16 +66,16 @@ import Foundation
     ///
     /// - Parameter assetType: the AssetType
     /// - Returns: the swipe addresses
-    @objc func swipeToReceiveAddresses(for assetType: AssetType) -> [String] {
+    @objc func swipeToReceiveAddresses(for assetType: AssetType) -> [AssetAddress] {
         if assetType == .ethereum {
-            if let swipeAddressForEther = BlockchainSettings.App.shared.swipeAddressForEther {
-                return [swipeAddressForEther]
-            } else {
+            guard let swipeAddressForEther = BlockchainSettings.App.shared.swipeAddressForEther else {
                 return []
             }
+            return [EthereumAddress(string: swipeAddressForEther)]
         }
 
-        return KeychainItemWrapper.getSwipeAddresses(for: assetType.legacy) as? [String] ?? []
+        let swipeAddresses = KeychainItemWrapper.getSwipeAddresses(for: assetType.legacy) as? [String] ?? []
+        return AssetAddressFactory.create(fromAddressStringArray: swipeAddresses, assetType: assetType)
     }
 
     /// Removes the first swipe address for assetType.

--- a/Blockchain/Addresses/BitcoinCashAddress.swift
+++ b/Blockchain/Addresses/BitcoinCashAddress.swift
@@ -30,3 +30,16 @@ public class BitcoinCashAddress: NSObject & AssetAddress {
         self.assetType = .bitcoinCash
     }
 }
+
+extension BitcoinCashAddress {
+    /// Transforms this BCH address to a `BitcoinAddress`
+    ///
+    /// - Parameter wallet: a Wallet instance
+    /// - Returns: the transformed BTC address
+    func toBitcoinAddress(wallet: Wallet) -> BitcoinAddress? {
+        guard let btcAddress = wallet.fromBitcoinCash(address) else {
+            return nil
+        }
+        return BitcoinAddress(string: btcAddress)
+    }
+}

--- a/Blockchain/Network/Extensions/BlockchainAPI+URLSuffix.swift
+++ b/Blockchain/Network/Extensions/BlockchainAPI+URLSuffix.swift
@@ -15,10 +15,10 @@ extension BlockchainAPI {
         switch address.assetType {
         case .bitcoin:
             guard let url = walletUrl else { return nil }
-            return "\(url)/address/\(address)?format=json"
+            return "\(url)/address/\(address.address)?format=json"
         case .bitcoinCash:
             guard let url = apiUrl else { return nil }
-            return "\(url)/bch/multiaddr?active=\(address)"
+            return "\(url)/bch/multiaddr?active=\(address.address)"
         default:
             return nil
         }

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -54,6 +54,7 @@ class WalletManager: NSObject {
         self.wallet = wallet
         super.init()
         self.wallet.delegate = self
+        self.wallet.loadJS()
     }
 
     /// Performs closing operations on the wallet. This should be called on logout and

--- a/BlockchainTests/Addresses/AssetAddressFactoryTests.swift
+++ b/BlockchainTests/Addresses/AssetAddressFactoryTests.swift
@@ -1,0 +1,30 @@
+//
+//  AssetAddressFactoryTests.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 6/8/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+@testable import Blockchain
+
+class AssetAddressFactoryTests: XCTestCase {
+
+    func testBitcoinAddressCorrectlyConstructed() {
+        let address = AssetAddressFactory.create(fromAddressString: "test", assetType: .bitcoin)
+        XCTAssertTrue(address is BitcoinAddress)
+    }
+
+    func testEtherAddressCorrectlyConstructed() {
+        let address = AssetAddressFactory.create(fromAddressString: "test", assetType: .ethereum)
+        XCTAssertTrue(address is EthereumAddress)
+    }
+
+    func testBitcoinCashAddressCorrectlyConstructed() {
+        let address = AssetAddressFactory.create(fromAddressString: "test", assetType: .bitcoinCash)
+        XCTAssertTrue(address is BitcoinCashAddress)
+    }
+}

--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -193,7 +193,7 @@ static PEViewController *VerifyController()
 
         AssetType type = [self assetTypeFromLegacyAssetType:assetType];
 
-        NSString *nextAddress = [[assetAddressRepository swipeToReceiveAddressesFor:type] firstObject];
+        NSString *nextAddress = [[assetAddressRepository swipeToReceiveAddressesFor:type] firstObject].address;
         
         if (nextAddress) {
             
@@ -229,7 +229,7 @@ static PEViewController *VerifyController()
             [swipeView updateAddress:nextAddress];
         }
     } else if (assetType == LegacyAssetTypeEther) {
-        NSString *etherAddress = [[assetAddressRepository swipeToReceiveAddressesFor:AssetTypeEthereum] firstObject];
+        NSString *etherAddress = [[assetAddressRepository swipeToReceiveAddressesFor:AssetTypeEthereum] firstObject].address;
         if (etherAddress) {
             [swipeView updateAddress:etherAddress];
         }

--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -220,7 +220,11 @@ static PEViewController *VerifyController()
                     self.errorAlert = nil;
                 }
             };
-            [[AssetAddressRepository sharedInstance] checkForUnusedAddress:nextAddress displayAddress:nextAddress legacyAssetType:assetType successHandler:success errorHandler:error];
+            [[AssetAddressRepository sharedInstance] checkForUnusedAddress:nextAddress
+                                                            displayAddress:nextAddress
+                                                                 assetType:[self assetTypeFromLegacyAssetType:assetType]
+                                                            successHandler:success
+                                                              errorHandler:error];
         } else {
             [swipeView updateAddress:nextAddress];
         }


### PR DESCRIPTION
BCH swipe address was not correctly showing because we were not transforming the BCH address to a BTC address before passing it to the `https://api.blockchain.info/bch/multiaddr` endpoint.