### PR TITLE
fix(2fa): fix 2FA flow

### DIFF
--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -353,17 +353,14 @@ import Foundation
         pinViewController.pinDelegate = self
 
         let viewControllerToPresentIn = viewController ?? UIApplication.shared.keyWindow!.rootViewController!
+
+        // presentedViewController could be non-nil if it is presenting an alert
+        if let presentedViewController = viewControllerToPresentIn.presentedViewController {
+            presentedViewController.dismiss(animated: false)
+        }
+
         if asModal {
-            // TODO handle settings navigation controller
-//            if ([_settingsNavigationController isBeingPresented]) {
-//                // Immediately after enabling touch ID, backgrounding the app while the Settings scren is still
-            // being presented results in failure to add the PIN screen back. Using a delay to allow animation to complete fixes this
-//                [[UIApplication sharedApplication].keyWindow.rootViewController.view
-            // performSelector:@selector(addSubview:) withObject:self.pinEntryViewController.view afterDelay:DELAY_KEYBOARD_DISMISSAL];
-//                [self performSelector:@selector(showStatusBar) withObject:nil afterDelay:DELAY_KEYBOARD_DISMISSAL];
-//            } else {
             viewControllerToPresentIn.view.addSubview(pinViewController.view)
-//            }
         } else {
             viewControllerToPresentIn.present(pinViewController, animated: true) { [weak self] in
                 guard let strongSelf = self else { return }

--- a/Blockchain/Authentication/AuthenticationManager.swift
+++ b/Blockchain/Authentication/AuthenticationManager.swift
@@ -323,7 +323,7 @@ extension AuthenticationManager: WalletAuthDelegate {
     }
 
     func emailAuthorizationRequired() {
-        failAuth(withError: AuthenticationError(
+        authHandler?(false, nil, AuthenticationError(
             code: AuthenticationError.ErrorCode.emailAuthorizationRequired.rawValue
         ))
     }

--- a/Blockchain/Authentication/AuthenticationManager.swift
+++ b/Blockchain/Authentication/AuthenticationManager.swift
@@ -318,10 +318,6 @@ extension AuthenticationManager: WalletAuthDelegate {
         authHandler?(false, type, nil)
     }
 
-    func incorrectTwoFactorCode() {
-        // TODO
-    }
-
     func emailAuthorizationRequired() {
         authHandler?(false, nil, AuthenticationError(
             code: AuthenticationError.ErrorCode.emailAuthorizationRequired.rawValue

--- a/Blockchain/BCManualPairView.m
+++ b/Blockchain/BCManualPairView.m
@@ -157,7 +157,8 @@
         verifyTwoFactorTextField.returnKeyType = UIReturnKeyDone;
         verifyTwoFactorTextField.placeholder = BC_STRING_ENTER_VERIFICATION_CODE;
     }];
-    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertForVerifyingMobileNumber animated:YES completion:nil];
+
+    [self presentAlertController:alertForVerifyingMobileNumber];
 }
 
 - (void)verifyTwoFactorGoogle
@@ -186,7 +187,19 @@
         verifyTwoFactorTextField.returnKeyType = UIReturnKeyDone;
         verifyTwoFactorTextField.placeholder = BC_STRING_ENTER_VERIFICATION_CODE;
     }];
-    [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:alertForVerifying animated:YES completion:nil];
+    [self presentAlertController:alertForVerifying];
+}
+
+-  (void)presentAlertController:(UIAlertController *)alertController
+{
+    UIViewController *presentingViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+
+    // presentingViewController might still have an alert presented, if so, dismiss that first before presenting alertController
+    if (presentingViewController.presentedViewController != nil) {
+        [presentingViewController.presentedViewController dismissViewControllerAnimated:false completion:nil];
+    }
+
+    [presentingViewController presentViewController:alertController animated:YES completion:nil];
 }
 
 @end

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -82,7 +82,7 @@ struct LocalizationConstants {
         static let manualPairing = NSLocalizedString("Manual Pairing", comment: "")
         static let invalidTwoFactorAuthenticationType = NSLocalizedString("Invalid two-factor authentication type", comment: "")
         static let manualPairingAuthorizationRequiredTitle = NSLocalizedString("Authorization Required", comment: "")
-        static let manualPairingAuthorizationRequiredMessage = NSLocalizedString("Please check your email. If you have already verified a login attempt, you should log in via our web wallet and pair your phone by scanning the QR code under Settings -> Wallet Information.", comment: "")
+        static let manualPairingAuthorizationRequiredMessage = NSLocalizedString("Please check your email and authorize this log-in attempt. After doing so, please return here and try logging in again", comment: "")
         static let secondPasswordRequired = NSLocalizedString("Second Password Required", comment: "")
         static let secondPasswordIncorrect = NSLocalizedString("Second Password Incorrect", comment: "")
         static let secondPasswordDefaultDescription = NSLocalizedString("This action requires the second password for your wallet. Please enter it below and press continue.", comment: "")

--- a/Blockchain/Wallet/WalletAuthDelegate.swift
+++ b/Blockchain/Wallet/WalletAuthDelegate.swift
@@ -19,9 +19,6 @@ protocol WalletAuthDelegate: class {
     /// Callback invoked when the SMS containing a code for 2FA was resent
     func didResendTwoFactorSMSCode()
 
-    /// Callback invoked when the provided two factor code is incorrect
-    func incorrectTwoFactorCode()
-
     /// Callback invoked when an email authorization is required (only for manual pairing)
     func emailAuthorizationRequired()
 


### PR DESCRIPTION
Fixes related to 2FA:
* SMS & Google Auth | fix issue where the 2FA verification dialog (sms & google auth) would not be presented if the email authentication alert is still presented
* Email Auth | update email authorization alert message to instruct the user to return to the app after they have authorized the log in attempt