### PR TITLE
fix(tx): display correct tx received amount.

### DIFF
--- a/Blockchain/TransactionsBitcoinViewController.m
+++ b/Blockchain/TransactionsBitcoinViewController.m
@@ -272,7 +272,7 @@
     
     [self reloadNewTransactions];
 
-    [self animateFirstCell];
+    self.hasZeroTotalBalance = [WalletManager.sharedInstance.wallet getTotalActiveBalance] == 0;
     
     [self reloadLastNumberOfTransactions];
     
@@ -285,6 +285,8 @@
 - (void)updateData:(MultiAddressResponse *)newData
 {
     data = newData;
+    [self reloadData];
+    [self displayTransactionMessageIfNeeded];
 }
 
 - (void)reloadSymbols
@@ -318,14 +320,11 @@
     }
 }
 
-- (void)animateFirstCell
+- (void)displayTransactionMessageIfNeeded
 {
     if (data.transactions.count > 0 && self.receivedTransactionMessage) {
         self.receivedTransactionMessage = NO;
-
         [self didGetNewTransaction];
-    } else {
-        self.hasZeroTotalBalance = [WalletManager.sharedInstance.wallet getTotalActiveBalance] == 0;
     }
 }
 


### PR DESCRIPTION
Fixes bug where the received tx amount would occasionally show the incorrect tx (it would show the 2nd to last one). The reason for this is because there was a race condition between when the multiaddress response and when we were displaying the alert message. Fix is to only check if the alert should be displayed after `TransactionsBitcoinViewController` receives the multiaddress response.