### PR TITLE
fix(PrivateKeyReader): fix errors when trying to scan private key.

### DIFF
--- a/Blockchain/AccountsAndAddressesDetailViewController.m
+++ b/Blockchain/AccountsAndAddressesDetailViewController.m
@@ -466,6 +466,7 @@ typedef enum {
                 case 2: {
                     if (self.address) {
                         if ([WalletManager.sharedInstance.wallet isWatchOnlyLegacyAddress:self.address]) {
+                            [[KeyImportCoordinator sharedInstance] initialize];
                             [[WalletManager sharedInstance] scanPrivateKeyForWatchOnlyAddress:self.address];
                         } else {
                             [self toggleArchive];

--- a/Blockchain/AccountsAndAddressesViewController.m
+++ b/Blockchain/AccountsAndAddressesViewController.m
@@ -203,7 +203,7 @@
                                            assetType:self.assetType
                                     acceptPublicKeys:YES
                                          loadingText:[LocalizationConstantsObjcBridge loadingImportKey]
-                                           publicKey:nil];
+                                        assetAddress:nil];
 }
 
 #pragma mark - LegacyPrivateKeyDelegate

--- a/Blockchain/Coordinators/KeyImportCoordinator.swift
+++ b/Blockchain/Coordinators/KeyImportCoordinator.swift
@@ -41,6 +41,10 @@ import Foundation
     private init(walletManager: WalletManager = WalletManager.shared) {
         self.walletManager = walletManager
         super.init()
+        initialize()
+    }
+
+    @objc func initialize() {
         self.walletManager.keyImportDelegate = self
     }
 
@@ -51,8 +55,8 @@ import Foundation
                assetType: AssetType = .bitcoin,
                acceptPublicKeys: Bool = false,
                loadingText: String = LocalizationConstants.AddressAndKeyImport.loadingImportKey,
-               publicKey: String? = nil) {
-        privateKeyReader = PrivateKeyReader(assetType: assetType, acceptPublicKeys: acceptPublicKeys, publicKey: publicKey)
+               assetAddress: AssetAddress? = nil) {
+        privateKeyReader = PrivateKeyReader(assetType: assetType, acceptPublicKeys: acceptPublicKeys, assetAddress: assetAddress)
         guard privateKeyReader != nil else { return }
         privateKeyReader!.delegate = delegate
         privateKeyReader!.startReadingQRCode()
@@ -64,8 +68,8 @@ import Foundation
                      assetType: LegacyAssetType = .bitcoin,
                      acceptPublicKeys: Bool = false,
                      loadingText: String = LocalizationConstants.AddressAndKeyImport.loadingImportKey,
-                     publicKey: String? = nil) {
-        privateKeyReader = PrivateKeyReader(assetType: assetType, acceptPublicKeys: acceptPublicKeys, publicKey: publicKey)
+                     assetAddress: AssetAddress? = nil) {
+        privateKeyReader = PrivateKeyReader(assetType: assetType, acceptPublicKeys: acceptPublicKeys, assetAddress: assetAddress)
         guard privateKeyReader != nil else { return }
         privateKeyReader!.legacyDelegate = delegate
         privateKeyReader!.startReadingQRCode()
@@ -245,13 +249,13 @@ extension KeyImportCoordinator: WalletKeyImportDelegate {
             return
         }
 
-        guard let rootVC = UIApplication.shared.keyWindow?.rootViewController else {
-            fatalError("The rootViewController was not set!")
+        guard let topVC = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController else {
+            fatalError("topMostViewController is nil")
         }
-        start(with: self, in: rootVC)
+        start(with: self, in: topVC, assetAddress: address)
 
         // TODO: `lastScannedWatchOnlyAddress` needs to be of type AssetAddress, not String
-        walletManager.wallet.lastScannedWatchOnlyAddress = address.description
+        walletManager.wallet.lastScannedWatchOnlyAddress = address.address
     }
 }
 
@@ -259,7 +263,7 @@ extension KeyImportCoordinator: WalletKeyImportDelegate {
 
 extension KeyImportCoordinator: PrivateKeyReaderDelegate {
     func didFinishScanning(_ privateKey: String, for address: AssetAddress?) {
-        walletManager.wallet.addKey(privateKey, toWatchOnlyAddress: address?.description)
+        walletManager.wallet.addKey(privateKey, toWatchOnlyAddress: address?.address)
     }
 
     func didFinishScanningWithError(_ error: PrivateKeyReaderError) {

--- a/Blockchain/Extensions/UINavigationBar+TitleAttributes.swift
+++ b/Blockchain/Extensions/UINavigationBar+TitleAttributes.swift
@@ -12,5 +12,5 @@ extension UINavigationBar {
     @objc static let standardTitleTextAttributes = [
         NSAttributedStringKey.font: UIFont(name: "Montserrat-Regular", size: 20)!,
         NSAttributedStringKey.foregroundColor: UIColor.white
-    ]    
+    ]
 }

--- a/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
+++ b/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
@@ -52,7 +52,7 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
 
     private var acceptPublicKeys = false
 
-    private var publicKey: String?
+    private var assetAddress: AssetAddress?
 
     private var loadingText: String
 
@@ -62,11 +62,11 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
     ///   - assetType: the asset type used in the key import context
     ///   - acceptPublicKeys: accept public keys during scan
     ///   - publicKey: the public key used for scanning the respective private key
-    init?(assetType: AssetType, acceptPublicKeys: Bool, publicKey: String?) {
+    init?(assetType: AssetType, acceptPublicKeys: Bool, assetAddress: AssetAddress?) {
         self.assetType = assetType
         legacyAssetType = LegacyAssetType.bitcoin
         self.acceptPublicKeys = acceptPublicKeys
-        self.publicKey = publicKey
+        self.assetAddress = assetAddress
         loadingText = LocalizationConstants.AddressAndKeyImport.loadingImportKey
         super.init(nibName: nil, bundle: nil)
         self.modalTransitionStyle = .crossDissolve
@@ -76,11 +76,11 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
     }
 
     // TODO: remove once AccountsAndAddresses and SendBitcoinViewController are migrated to Swift
-    @objc init?(assetType: LegacyAssetType, acceptPublicKeys: Bool, publicKey: String?) {
+    @objc init?(assetType: LegacyAssetType, acceptPublicKeys: Bool, assetAddress: AssetAddress?) {
         legacyAssetType = assetType
         self.assetType = nil
         self.acceptPublicKeys = acceptPublicKeys
-        self.publicKey = publicKey
+        self.assetAddress = assetAddress
         loadingText = LocalizationConstants.AddressAndKeyImport.loadingImportKey
         super.init(nibName: nil, bundle: nil)
         self.modalTransitionStyle = .crossDissolve
@@ -193,7 +193,7 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
             LoadingViewPresenter.shared.showBusyView(withLoadingText: self.loadingText)
         }
 
-        self.dismiss(animated: true) {
+        self.dismiss(animated: true) { [unowned self] in
             let deadlineTime = DispatchTime.now() + Constants.Animation.duration
             DispatchQueue.main.asyncAfter(deadline: deadlineTime) {
                 let scheme = "\(Constants.Schemes.bitcoin):"
@@ -229,7 +229,7 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
                     return
                 }
                 //: Pass valid private key back via success handler
-                self.delegate?.didFinishScanning(scannedKey, for: nil)
+                self.delegate?.didFinishScanning(scannedKey, for: self.assetAddress)
                 // TODO: remove once LegacyPrivateKeyDelegate is deprecated
                 self.legacyDelegate?.didFinishScanning(scannedKey)
             }

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -1051,7 +1051,7 @@ BOOL displayingLocalSymbolSend;
                                            assetType:self.assetType
                                     acceptPublicKeys:NO
                                          loadingText:[LocalizationConstantsObjcBridge loadingProcessingKey]
-                                           publicKey:nil];
+                                        assetAddress:nil];
 }
 
 #pragma mark - LegacyPrivateKeyDelegate


### PR DESCRIPTION
Fixes 2 issues:
* bug wherein the QR code scanner was not being presented when tapping on "Scan Private Key"
* bug wherein the scanned private key was displaying the alert "Your wallet does not contain this address." even though the address is in your wallet

Tested this by creating a wallet on https://www.bitaddress.org/