### PR TITLE
iPhone X support for Exchange Screens

### DIFF
--- a/Blockchain/BCNavigationController.m
+++ b/Blockchain/BCNavigationController.m
@@ -63,8 +63,9 @@
     [self.topBar addSubview:self.closeButton];
     
     self.backButton = [[UIButton alloc] initWithFrame:CGRectZero];
-    self.backButton.imageEdgeInsets = IMAGE_EDGE_INSETS_BACK_BUTTON_CHEVRON;
-    self.backButton.frame = FRAME_BACK_BUTTON;
+    self.backButton.imageEdgeInsets = UIEdgeInsetsMake(5, 8, 5, 0);
+    self.backButton.frame = CGRectMake(0, 0, 85, 51);
+    self.backButton.center = CGPointMake(self.backButton.center.x, self.headerLabel.center.y);
     self.backButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     [self.backButton setTitle:@"" forState:UIControlStateNormal];
     [self.backButton setImage:[UIImage imageNamed:@"back_chevron_icon"] forState:UIControlStateNormal];

--- a/Blockchain/ConfirmStateViewController.m
+++ b/Blockchain/ConfirmStateViewController.m
@@ -31,21 +31,28 @@
 
 - (void)viewDidLoad
 {
-    CGFloat windowWidth = WINDOW_WIDTH;
-    CGFloat tableViewYPosition = DEFAULT_HEADER_HEIGHT;
-    UITableView *oneRowTableView = [[UITableView alloc] initWithFrame:CGRectMake(0, tableViewYPosition, windowWidth, self.view.frame.size.height - tableViewYPosition) style:UITableViewStyleGrouped];
+    UIWindow *window = UIApplication.sharedApplication.keyWindow;
+    CGFloat safeAreaInsetTop;
+    if (@available(iOS 11.0, *)) {
+        safeAreaInsetTop = window.rootViewController.view.safeAreaInsets.top;
+    } else {
+        safeAreaInsetTop = 20;
+    }
+    CGFloat topBarHeight = ConstantsObjcBridge.defaultNavigationBarHeight + safeAreaInsetTop;
+
+    UITableView *oneRowTableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height - topBarHeight) style:UITableViewStyleGrouped];
     oneRowTableView.dataSource = self;
     oneRowTableView.delegate = self;
     [self.view addSubview:oneRowTableView];
     self.tableView = oneRowTableView;
     
-    UIButton *button = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, windowWidth - 32, BUTTON_HEIGHT)];
+    UIButton *button = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width - 32, BUTTON_HEIGHT)];
     button.backgroundColor = COLOR_BLOCKCHAIN_LIGHT_BLUE;
     button.layer.cornerRadius = CORNER_RADIUS_BUTTON;
     [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
     button.titleLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:17.0];
     [button setTitle:BC_STRING_CONFIRM forState:UIControlStateNormal];
-    button.center = CGPointMake(self.view.center.x, self.view.frame.size.height - 24 - BUTTON_HEIGHT/2);
+    button.center = CGPointMake(self.view.center.x, self.view.frame.size.height - topBarHeight - 24 - BUTTON_HEIGHT/2);
     [self.view addSubview:button];
     [button addTarget:self action:@selector(confirmButtonClicked) forControlEvents:UIControlEventTouchUpInside];
 }

--- a/Blockchain/ConfirmStateViewController.m
+++ b/Blockchain/ConfirmStateViewController.m
@@ -101,7 +101,7 @@
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
-    CGFloat windowWidth = WINDOW_WIDTH;
+    CGFloat windowWidth = self.view.frame.size.width;
     
     UIView *containerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, windowWidth, 50)];
     

--- a/Blockchain/ContinueButtonInputAccessoryView.m
+++ b/Blockchain/ContinueButtonInputAccessoryView.m
@@ -16,7 +16,7 @@
 
 - (id)init
 {
-    CGFloat windowWidth = WINDOW_WIDTH;
+    CGFloat windowWidth = UIApplication.sharedApplication.keyWindow.rootViewController.view.frame.size.width;
     if (self = [super initWithFrame:CGRectMake(0, 0, windowWidth, BUTTON_HEIGHT)]) {
         UIButton *continueButton = [[UIButton alloc] initWithFrame:self.bounds];
         [continueButton setTitle:BC_STRING_CONTINUE forState:UIControlStateNormal];

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -127,8 +127,8 @@
 {
     self.view.backgroundColor = COLOR_EXCHANGE_BACKGROUND_GRAY;
     
-    CGFloat windowWidth = WINDOW_WIDTH;
-    FromToView *fromToView = [[FromToView alloc] initWithFrame:CGRectMake(0, DEFAULT_HEADER_HEIGHT + 16, windowWidth, 96) enableToTextField:NO];
+    CGFloat windowWidth = self.view.frame.size.width;
+    FromToView *fromToView = [[FromToView alloc] initWithFrame:CGRectMake(0, 16, windowWidth, 96) enableToTextField:NO];
     fromToView.delegate = self;
     [self.view addSubview:fromToView];
     self.fromToView = fromToView;

--- a/Blockchain/StateSelectorViewController.m
+++ b/Blockchain/StateSelectorViewController.m
@@ -8,6 +8,7 @@
 
 #import "StateSelectorViewController.h"
 #import "BCNavigationController.h"
+#import "Blockchain-Swift.h"
 #import "UIView+ChangeFrameAttribute.h"
 
 @interface StateSelectorViewController () <UISearchBarDelegate, UITableViewDelegate, UITableViewDataSource>
@@ -54,7 +55,7 @@
 
 - (void)setupTableView
 {
-    UISearchBar *searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0, DEFAULT_HEADER_HEIGHT, self.view.frame.size.width, 44)];
+    UISearchBar *searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 44)];
     searchBar.placeholder = BC_STRING_SEARCH;
     searchBar.layer.borderColor = [COLOR_BLOCKCHAIN_BLUE CGColor];
     searchBar.layer.borderWidth = 1;
@@ -69,8 +70,20 @@
     searchBar.delegate = self;
     [self.view addSubview:searchBar];
     self.searchBar = searchBar;
+
+    UIWindow *window = UIApplication.sharedApplication.keyWindow;
+    CGFloat safeAreaInsetTop;
+    CGFloat safeAreaInsetBottom;
+    if (@available(iOS 11.0, *)) {
+        safeAreaInsetTop = window.rootViewController.view.safeAreaInsets.top;
+        safeAreaInsetBottom = window.rootViewController.view.safeAreaInsets.bottom;
+    } else {
+        safeAreaInsetTop = 20;
+        safeAreaInsetBottom = 0;
+    }
+    CGFloat topBarHeight = ConstantsObjcBridge.defaultNavigationBarHeight + safeAreaInsetTop;
     
-    self.tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, searchBar.frame.origin.y + searchBar.frame.size.height, self.view.frame.size.width, self.view.frame.size.height - DEFAULT_HEADER_HEIGHT) style:UITableViewStylePlain];
+    self.tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, searchBar.frame.origin.y + searchBar.frame.size.height, self.view.frame.size.width, self.view.frame.size.height - topBarHeight - searchBar.frame.size.height) style:UITableViewStylePlain];
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];
     self.tableView.sectionIndexColor = COLOR_BLOCKCHAIN_BLUE;
     self.tableView.delegate = self;


### PR DESCRIPTION
Includes iPhone X support for:
* select your state confirm screen
* state selection screen
* exchange create screen

Screenshots:

iPhone X:
![simulator screen shot - iphone x - 2018-06-18 at 14 42 27](https://user-images.githubusercontent.com/38220701/41563911-f929b006-7305-11e8-9d27-c096c59d8ad0.png)
![simulator screen shot - iphone x - 2018-06-18 at 15 06 22](https://user-images.githubusercontent.com/38220701/41564868-3098f382-7309-11e8-9eb0-701409380f64.png)
![simulator screen shot - iphone x - 2018-06-18 at 15 27 52](https://user-images.githubusercontent.com/38220701/41565876-975f44dc-730d-11e8-91f6-3a487984f679.png)

iPhone 5s:
![simulator screen shot - iphone 5s - 2018-06-18 at 14 43 26](https://user-images.githubusercontent.com/38220701/41563918-fe141688-7305-11e8-958d-d8a06cc2613f.png)
![simulator screen shot - iphone 5s - 2018-06-18 at 15 06 24](https://user-images.githubusercontent.com/38220701/41564875-34073876-7309-11e8-96de-9e3d3fc7ed5e.png)
![simulator screen shot - iphone 5s - 2018-06-18 at 15 36 21](https://user-images.githubusercontent.com/38220701/41565882-9beb5450-730d-11e8-811c-3e42c31b5751.png)

