### PR TITLE
fix(send): correctly handle different permutations of QR code addresses for all assets.

### DIFF
--- a/Blockchain/Addresses/AddressValidator.swift
+++ b/Blockchain/Addresses/AddressValidator.swift
@@ -39,7 +39,16 @@ public final class AddressValidator: NSObject {
             let possibleBTCAddress = BitcoinAddress(string: address.description)
             return validate(bitcoinAddress: possibleBTCAddress)
         }
-        return result.toBool()
+
+        let isValidBCHAddress = result.toBool()
+
+        // Fallback on BTC address validation for legacy BCH addresses
+        if !isValidBCHAddress {
+            let possibleBTCAddress = BitcoinAddress(string: address.description)
+            return validate(bitcoinAddress: possibleBTCAddress)
+        }
+
+        return isValidBCHAddress
     }
 
     // MARK: - Ethereum Address Validation

--- a/Blockchain/LocalizationConstants.h
+++ b/Blockchain/LocalizationConstants.h
@@ -262,8 +262,6 @@
 #define BC_STRING_SURVEY_ALERT_TITLE NSLocalizedString(@"Would you like to tell us about your experience with Blockchain?", nil)
 #define BC_STRING_SURVEY_ALERT_MESSAGE NSLocalizedString(@"You will be leaving the app.", nil)
 
-#define BC_STRING_INVALID_ADDRESS NSLocalizedString(@"Address is not valid", nil)
-#define BC_STRING_INVALID_ADDRESS_ARGUMENT NSLocalizedString(@"Invalid address: %@", nil)
 #define BC_STRING_INVALID_BITCOIN_ADDRESS_ARGUMENT NSLocalizedString(@"Invalid Bitcoin address: %@", nil)
 #define BC_STRING_INVALID_ETHER_ADDRESS_ARGUMENT NSLocalizedString(@"Invalid Ether address: %@", nil)
 

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -170,7 +170,10 @@ struct LocalizationConstants {
     }
 
     struct SendAsset {
-        static let invalidXAddressY = NSLocalizedString("Invalid %@ address: %@", comment: "")
+        static let invalidXAddressY = NSLocalizedString(
+            "Invalid %@ address: %@",
+            comment: "String presented to the user when they try to scan a QR code with an invalid address."
+        )
     }
 
     struct SendEther {

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -169,6 +169,10 @@ struct LocalizationConstants {
         static let addWatchOnlyAddressWarningPrompt = NSLocalizedString("These options are recommended for advanced users only. Continue?", comment: "")
     }
 
+    struct SendAsset {
+        static let invalidXAddressY = NSLocalizedString("Invalid %@ address: %@", comment: "")
+    }
+
     struct SendEther {
         static let waitingForPaymentToFinishTitle = NSLocalizedString("Waiting for payment", comment: "")
         static let waitingForPaymentToFinishMessage = NSLocalizedString("Please wait until your last ether transaction confirms.", comment: "")
@@ -251,4 +255,6 @@ struct LocalizationConstants {
     @objc class func loadingTransactions() -> String { return LocalizationConstants.Exchange.loadingTransactions }
 
     @objc class func xPaymentRequest() -> String { return LocalizationConstants.ReceiveAsset.xPaymentRequest }
+
+    @objc class func invalidXAddressY() -> String { return LocalizationConstants.SendAsset.invalidXAddressY }
 }

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -1973,11 +1973,15 @@ BOOL displayingLocalSymbolSend;
             
             // do something useful with results
             dispatch_sync(dispatch_get_main_queue(), ^{
-                id<AssetURLPayload> payload = [AssetURLPayloadFactory createFromString:[metadataObj stringValue] legacyAssetType:self.assetType];
-                NSString *address = payload.address;
+                AssetType type = [AssetTypeLegacyHelper convertFromLegacy:self.assetType];
+                id<AssetURLPayload> payload = [AssetURLPayloadFactory createFromString:[metadataObj stringValue] assetType:type];
 
-                if (address == nil || ![WalletManager.sharedInstance.wallet isValidAddress:address assetType:self.assetType]) {
-                    [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:[NSString stringWithFormat:BC_STRING_INVALID_BITCOIN_ADDRESS_ARGUMENT, address] title:BC_STRING_ERROR handler: nil];
+                NSString *address = payload.address;
+                NSString *scheme = [AssetURLPayloadFactory schemeForAssetType:type];
+                if (address == nil || ![payload.schemeCompat isEqualToString:scheme] || ![WalletManager.sharedInstance.wallet isValidAddress:address assetType:self.assetType]) {
+                    NSString *assetName = (type == AssetTypeBitcoin) ? @"Bitcoin" : @"Bitcoin Cash";
+                    NSString *errorMessage = [NSString stringWithFormat:LocalizationConstantsObjcBridge.invalidXAddressY, assetName, address];
+                    [AlertViewPresenter.sharedInstance standardErrorWithMessage:errorMessage title:LocalizationConstantsObjcBridge.error handler:nil];
                     return;
                 }
 

--- a/Blockchain/URL/AssetURLPayload.swift
+++ b/Blockchain/URL/AssetURLPayload.swift
@@ -16,6 +16,9 @@ import Foundation
     /// The asset's address (e.g. "1Amu4uPJnYbUXX2HhDFMNq7tSneDwWYDyv")
     @objc var address: String { get }
 
+    /// Same as scheme - mostly here for obj-c compatibility reasons
+    @objc var schemeCompat: String { get }
+
     /// The asset's scheme (e.g. "bitcoin")
     static var scheme: String { get }
 }

--- a/Blockchain/URL/AssetURLPayloadFactory.swift
+++ b/Blockchain/URL/AssetURLPayloadFactory.swift
@@ -10,7 +10,18 @@ import Foundation
 
 @objc class AssetURLPayloadFactory: NSObject {
 
-    @objc static func create(fromString string: String, legacyAssetType: LegacyAssetType) -> AssetURLPayload? {
+    @objc static func scheme(forAssetType type: AssetType) -> String? {
+        switch type {
+        case .bitcoin:
+            return BitcoinURLPayload.scheme
+        case .bitcoinCash:
+            return BitcoinCashURLPayload.scheme
+        default:
+            return nil
+        }
+    }
+
+    @objc static func create(fromString string: String, assetType: AssetType) -> AssetURLPayload? {
         if string.contains(":") {
             guard let url = URL(string: string) else {
                 print("Could not create payload from URL \(string)")
@@ -18,7 +29,7 @@ import Foundation
             }
             return create(from: url)
         } else {
-            switch legacyAssetType {
+            switch assetType {
             case .bitcoin:
                 return BitcoinURLPayload(address: string, amount: nil)
             case .bitcoinCash:

--- a/Blockchain/URL/BitcoinCashURLPayload.swift
+++ b/Blockchain/URL/BitcoinCashURLPayload.swift
@@ -15,6 +15,10 @@ import Foundation
         return Constants.Schemes.bitcoinCash
     }
 
+    @objc var schemeCompat: String {
+        return BitcoinCashURLPayload.scheme
+    }
+
     @objc var address: String
 
     @objc var amount: String?

--- a/Blockchain/URL/BitcoinURLPayload.swift
+++ b/Blockchain/URL/BitcoinURLPayload.swift
@@ -15,6 +15,10 @@ import Foundation
         return Constants.Schemes.bitcoin
     }
 
+    @objc var schemeCompat: String {
+        return BitcoinURLPayload.scheme
+    }
+
     @objc var address: String
 
     @objc var amount: String?

--- a/BlockchainTests/AddressValidatorTests.swift
+++ b/BlockchainTests/AddressValidatorTests.swift
@@ -72,6 +72,12 @@ class AddressValidatorTests: XCTestCase {
 
     // MARK: - Bitcoin Cash Address Validation
 
+    func testAddressValidatorWithValidLegacyBitcoinAddress() {
+        precondition(addressValidator != nil, "Address validator must not be nil!")
+        let address = BitcoinCashAddress(string: "1K43HTP8ayuJjfqAHG7azwVDDQaDwLtqtK")
+        XCTAssertTrue(addressValidator!.validate(bitcoinCashAddress: address), "Expected address to be invalid.")
+    }
+
     func testAddressValidatorWithValidBitcoinCashAddress() {
         precondition(addressValidator != nil, "Address validator must not be nil!")
         let address = BitcoinCashAddress(string: "qz2js9054gqxj4dww35kkc3jpf0ph4cfh53tld3zek")

--- a/BlockchainTests/URL/AssetURLPayloadFactoryTests.swift
+++ b/BlockchainTests/URL/AssetURLPayloadFactoryTests.swift
@@ -30,14 +30,14 @@ class AssetURLPayloadFactoryTests: XCTestCase {
 
     func testBitcoinNoFormat() {
         let address = "1Amu4uPJnYbUXX2HhDFMNq7tSneDwWYDyv"
-        let payload = AssetURLPayloadFactory.create(fromString: address, legacyAssetType: .bitcoin)
+        let payload = AssetURLPayloadFactory.create(fromString: address, assetType: .bitcoin)
         XCTAssertNotNil(payload)
         XCTAssertEqual(address, payload?.address)
     }
 
     func testBitcoinCashNoFormat() {
         let address = "qzufk542ghfu38582kz5y9kmlsrqfke5esgmzsd3lx"
-        let payload = AssetURLPayloadFactory.create(fromString: address, legacyAssetType: .bitcoinCash)
+        let payload = AssetURLPayloadFactory.create(fromString: address, assetType: .bitcoinCash)
         XCTAssertNotNil(payload)
         XCTAssertEqual(address, payload?.address)
     }


### PR DESCRIPTION
Tested all the following cases:

BITCOIN:
* Should accept BTC address with prefix bitcoin:1K43HTP8ayuJjfqAHG7azwVDDQaDwLtqtK
* Should accept BTC address without prefix 1K43HTP8ayuJjfqAHG7azwVDDQaDwLtqtK
* Should not accept addresses with other currency prefix or address

BITCOIN CASH:
* Should accept BCH address with prefix bitcoincash:qpheqxjud2p0yg85t679tnc7n05xffs5ks07zhg6y6
* Should accept BCH address without prefix qpheqxjud2p0yg85t679tnc7n05xffs5ks07zhg6y6
* Should accept BCH legacy address with prefix bitcoincash:1K43HTP8ayuJjfqAHG7azwVDDQaDwLtqtK
* Should accept BCH legacy address without prefix 1K43HTP8ayuJjfqAHG7azwVDDQaDwLtqtK
* Should not accept addresses with other currency prefix

ETHER:
* Should accept ETH address without prefix 0x6584EF6C986d82d9B48683312cFb66234896bF2c
* Should not accept addresses with other currency prefix or address