### PR TITLE
fix(RawValued): fixing crash on release builds when using RawValued int enum

### DIFF
--- a/Blockchain/Extensions/Enum+RawValued.swift
+++ b/Blockchain/Extensions/Enum+RawValued.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+/// Protocol definition for an enum that is also a `RawValue`.
+/// Note: do not use this protocol on enums that are also Ints
+/// as there is a known buffer overflow issue with release builds
+/// See: https://github.com/blockchain/My-Wallet-V3-iOS/pull/264
 protocol RawValued: Hashable, RawRepresentable {
     static var rawValues: [RawValue] { get }
 }

--- a/Blockchain/Feature Configuration/AppFeature.swift
+++ b/Blockchain/Feature Configuration/AppFeature.swift
@@ -9,8 +9,15 @@
 import Foundation
 
 /// Enumerates app features that can be dynamically configured (e.g. enabled/disabled)
-@objc enum AppFeature: Int, RawValued {
+@objc enum AppFeature: Int {
     case touchId
     case swipeToReceive
     case transferFundsFromImportedAddress
+}
+
+extension AppFeature {
+    // Use CaseIterable once upgraded to Swift 4.2
+    static let allFeatures: [AppFeature] = [
+        .touchId, .swipeToReceive, .transferFundsFromImportedAddress
+    ]
 }

--- a/Blockchain/Feature Configuration/AppFeatureConfigurator.swift
+++ b/Blockchain/Feature Configuration/AppFeatureConfigurator.swift
@@ -19,9 +19,8 @@ import Foundation
     private override init() {
         super.init()
         // Enable all features by default
-        AppFeature.rawValues.forEach {
-            let feature = AppFeature(rawValue: $0)!
-            featureToConfigurations[feature] = AppFeatureConfiguration(isEnabled: true)
+        AppFeature.allFeatures.forEach {
+            featureToConfigurations[$0] = AppFeatureConfiguration(isEnabled: true)
         }
     }
 


### PR DESCRIPTION
Fixes crash on release builds when trying to first access `AppFeature`. 

Unclear why this is happening only on release builds but the operation `AppFeature.rawValues` would eventually cause a buffer overflow and crash the app (the `AnyIterator` inside the `rawValues` implementation will continue to iterate even though no further enums with such values exist). Also, this only happens on enums that are Ints (does not happen to other enums that are Strings). I wanted to fix this on the `RawValued` implementation but could not come up with a solution.

As a fix, I've defined a static `allFeatures` property. Once Swift 4.2 is supported, we can updated that enum and conform to `CaseIterable`.