### PR TITLE
fix(TabViewController): prevent navigation header from cutting off for large balances.

### DIFF
--- a/Blockchain/TabViewController.m
+++ b/Blockchain/TabViewController.m
@@ -233,6 +233,7 @@ UILabel *titleLabel;
 {
     titleLabel.text = text;
     titleLabel.font = [titleLabel.font fontWithSize:20];
+    titleLabel.adjustsFontSizeToFitWidth = NO;
     [self.navigationItem.titleView sizeToFit];
 }
 
@@ -240,6 +241,7 @@ UILabel *titleLabel;
 {
     titleLabel.text = text;
     titleLabel.font = [titleLabel.font fontWithSize:27];
+    titleLabel.adjustsFontSizeToFitWidth = YES;
     [self.navigationItem.titleView sizeToFit];
 }
 


### PR DESCRIPTION
Tested on iPhone 5S and manually set the title to be a really large balance e.g. "$50,333,456.00" and verified that it renders correctly.