### PR TITLE
fix(Send Screen): make confirm button visible on iPhone X

### DIFF
--- a/Blockchain/BCConfirmPaymentView.h
+++ b/Blockchain/BCConfirmPaymentView.h
@@ -16,7 +16,7 @@
 @end
 @interface BCConfirmPaymentView : BCDescriptionView
 
-- (id)initWithWindow:(UIView *)window viewModel:(BCConfirmPaymentViewModel *)viewModel sendButtonFrame:(CGRect)sendButtonFrame;
+- (id)initWithFrame:(CGRect)frame viewModel:(BCConfirmPaymentViewModel *)viewModel sendButtonFrame:(CGRect)sendButtonFrame;
 
 @property (nonatomic) UIButton *reallyDoPaymentButton;
 @property (nonatomic) UIButton *feeInformationButton;

--- a/Blockchain/BCConfirmPaymentView.m
+++ b/Blockchain/BCConfirmPaymentView.m
@@ -23,12 +23,14 @@
 @end
 @implementation BCConfirmPaymentView
 
-- (id)initWithWindow:(UIView *)window viewModel:(BCConfirmPaymentViewModel *)viewModel sendButtonFrame:(CGRect)sendButtonFrame
+- (id)initWithFrame:(CGRect)frame viewModel:(BCConfirmPaymentViewModel *)viewModel sendButtonFrame:(CGRect)sendButtonFrame
 {
-    self = [super initWithFrame:CGRectMake(0, DEFAULT_HEADER_HEIGHT, window.frame.size.width, window.frame.size.height - DEFAULT_HEADER_HEIGHT)];
-    
+    self = [super initWithFrame:frame];
+
     if (self) {
         
+        self.frame = frame;
+
         self.viewModel = viewModel;
         
         BCTotalAmountView *totalAmountView = [[BCTotalAmountView alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, TOTAL_AMOUNT_VIEW_HEIGHT) color:COLOR_BLOCKCHAIN_RED amount:0];
@@ -45,7 +47,7 @@
         
         self.backgroundColor = [UIColor whiteColor];
         
-        UITableView *summaryTableView = [[UITableView alloc] initWithFrame:CGRectMake(0, totalAmountView.frame.origin.y + totalAmountView.frame.size.height, window.frame.size.width, tableViewHeight)];
+        UITableView *summaryTableView = [[UITableView alloc] initWithFrame:CGRectMake(0, totalAmountView.frame.origin.y + totalAmountView.frame.size.height, frame.size.width, tableViewHeight)];
         summaryTableView.scrollEnabled = NO;
         summaryTableView.delegate = self;
         summaryTableView.dataSource = self;
@@ -73,7 +75,7 @@
         
         self.reallyDoPaymentButton = [[UIButton alloc] initWithFrame:sendButtonFrame];
         self.reallyDoPaymentButton.layer.cornerRadius = CORNER_RADIUS_BUTTON;
-        [self.reallyDoPaymentButton changeYPosition:self.bounds.size.height - 12 - sendButtonFrame.size.height];
+        [self.reallyDoPaymentButton changeYPosition:self.frame.size.height - 20 + 49];
         
         [self.reallyDoPaymentButton setTitle:buttonTitle forState:UIControlStateNormal];
         self.reallyDoPaymentButton.backgroundColor = COLOR_BLOCKCHAIN_LIGHT_BLUE;
@@ -82,7 +84,7 @@
         [self.reallyDoPaymentButton addTarget:self action:@selector(reallyDoPaymentButtonClicked) forControlEvents:UIControlEventTouchUpInside];
         
         [self addSubview:self.reallyDoPaymentButton];
-        
+
         if (viewModel.warningText) {
             UITextView *warning = [[UITextView alloc] initWithFrame:self.reallyDoPaymentButton.frame];
             warning.textContainerInset = UIEdgeInsetsMake(8, 8, 8, 8);

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -399,19 +399,6 @@ BOOL displayingLocalSymbolSend;
     }
 }
 
-- (void)showContactLabelWithName:(NSString *)name reason:(NSString *)reason
-{
-    CGFloat originX = toField.frame.origin.x;
-    CGFloat originY = lineBelowFromField.frame.origin.y + 4;
-    contactLabel.frame = CGRectMake(originX, originY, addressBookButton.frame.origin.x - originX, lineBelowToField.frame.origin.y - originY - 4);
-    contactLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_LIGHT size:FONT_SIZE_SMALL];
-    contactLabel.textColor = COLOR_TEXT_DARK_GRAY;
-    
-    contactLabel.hidden = NO;
-    contactLabel.text = IS_USING_SCREEN_SIZE_4S ? [NSString stringWithFormat:@"%@ - %@", name, reason] : [NSString stringWithFormat:@"%@\n%@", name, reason];
-    contactLabel.alpha = 0.5;
-}
-
 - (void)reloadFromAndToFields
 {
     [self reloadFromField];
@@ -474,13 +461,10 @@ BOOL displayingLocalSymbolSend;
 - (IBAction)reallyDoPayment:(id)sender
 {
     if (self.sendFromAddress && [WalletManager.sharedInstance.wallet isWatchOnlyLegacyAddress:self.fromAddress]) {
-        
         [self alertUserForSpendingFromWatchOnlyAddress];
-    
         return;
-    } else {
-        [self sendPaymentWithListener];
     }
+    [self sendPaymentWithListener];
 }
 
 - (void)getInfoForTransferAllFundsToDefaultAccount
@@ -844,7 +828,9 @@ BOOL displayingLocalSymbolSend;
                                                                                 surge:surgePresent];
         }
         
-        self.confirmPaymentView = [[BCConfirmPaymentView alloc] initWithWindow:[UIApplication sharedApplication].keyWindow viewModel:confirmPaymentViewModel sendButtonFrame:continuePaymentButton.frame];
+        self.confirmPaymentView = [[BCConfirmPaymentView alloc] initWithFrame:self.view.frame
+                                                                     viewModel:confirmPaymentViewModel
+                                                               sendButtonFrame:continuePaymentButton.frame];
         
         self.confirmPaymentView.confirmDelegate = self;
         

--- a/Blockchain/SendEtherViewController.m
+++ b/Blockchain/SendEtherViewController.m
@@ -377,7 +377,7 @@
                                                               fiatFee:[NSNumberFormatter formatEthToFiatWithSymbol:[self.ethFee stringValue] exchangeRate:self.latestExchangeRate]
                                                               fiatTotal:[NSNumberFormatter formatEthToFiatWithSymbol:[NSString stringWithFormat:@"%@", totalDecimalNumber] exchangeRate:self.latestExchangeRate]];
         
-        self.confirmPaymentView = [[BCConfirmPaymentView alloc] initWithWindow:self.view.window viewModel:confirmPaymentViewModel sendButtonFrame:self.continuePaymentButton.frame];
+        self.confirmPaymentView = [[BCConfirmPaymentView alloc] initWithFrame:self.view.frame viewModel:confirmPaymentViewModel sendButtonFrame:self.continuePaymentButton.frame];
         self.confirmPaymentView.confirmDelegate = self;
         
         [self.confirmPaymentView.reallyDoPaymentButton addTarget:self action:@selector(reallyDoPayment) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
Highlights in this PR:
- Fixes the out of view confirm button on the send confirmation screen.
- Removes old contacts-related method.