### PR TITLE
fix(Accounts+Addresses): show navigation item title in edit views

### DIFF
--- a/Blockchain/AccountsAndAddressesDetailViewController.m
+++ b/Blockchain/AccountsAndAddressesDetailViewController.m
@@ -219,53 +219,52 @@ typedef enum {
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
 {
-    if ([segue.identifier isEqualToString:SEGUE_IDENTIFIER_ACCOUNTS_AND_ADDRESSES_DETAIL_EDIT]) {
+    if (![segue.identifier isEqualToString:SEGUE_IDENTIFIER_ACCOUNTS_AND_ADDRESSES_DETAIL_EDIT]) {
+        return;
+    }
 
-        int detailType = [sender intValue];
+    int detailType = [sender intValue];
 
-        if (detailType == DetailTypeEditAddressLabel) {
+    if (detailType == DetailTypeEditAddressLabel) {
 
-            BCEditAddressView *editAddressView = [[BCEditAddressView alloc] initWithAddress:self.address];
-            editAddressView.labelTextField.text = [WalletManager.sharedInstance.wallet labelForLegacyAddress:self.address assetType:self.assetType];
+        BCEditAddressView *editAddressView = [[BCEditAddressView alloc] initWithAddress:self.address];
+        editAddressView.labelTextField.text = [WalletManager.sharedInstance.wallet labelForLegacyAddress:self.address assetType:self.assetType];
 
-            [self setupModalView:editAddressView inViewController:segue.destinationViewController];
+        [self setupModalView:editAddressView inViewController:segue.destinationViewController];
 
-            [editAddressView.labelTextField becomeFirstResponder];
-            // [self updateHeaderText:BC_STRING_LABEL_ADDRESS];
+        [editAddressView.labelTextField becomeFirstResponder];
+        [segue.destinationViewController.navigationItem setTitle:BC_STRING_LABEL_ADDRESS];
+    } else if (detailType == DetailTypeEditAccountLabel) {
 
-        } else if (detailType == DetailTypeEditAccountLabel) {
+        BCEditAccountView *editAccountView = [[BCEditAccountView alloc] initWithAssetType:self.assetType];
+        editAccountView.labelTextField.text = [WalletManager.sharedInstance.wallet getLabelForAccount:self.account assetType:self.assetType];
+        editAccountView.accountIdx = self.account;
 
-            BCEditAccountView *editAccountView = [[BCEditAccountView alloc] initWithAssetType:self.assetType];
-            editAccountView.labelTextField.text = [WalletManager.sharedInstance.wallet getLabelForAccount:self.account assetType:self.assetType];
-            editAccountView.accountIdx = self.account;
+        [self setupModalView:editAccountView inViewController:segue.destinationViewController];
 
-            [self setupModalView:editAccountView inViewController:segue.destinationViewController];
+        [editAccountView.labelTextField becomeFirstResponder];
+        [segue.destinationViewController.navigationItem setTitle:BC_STRING_NAME];
+    } else if (detailType == DetailTypeShowExtendedPublicKey) {
 
-            [editAccountView.labelTextField becomeFirstResponder];
-            // [self updateHeaderText:BC_STRING_NAME];
+        BCQRCodeView *qrCodeView = [[BCQRCodeView alloc] initWithFrame:self.view.frame qrHeaderText:BC_STRING_EXTENDED_PUBLIC_KEY_DETAIL_HEADER_TITLE addAddressPrefix:YES];
+        qrCodeView.address = [WalletManager.sharedInstance.wallet getXpubForAccount:self.account assetType:self.assetType];
+        qrCodeView.doneButton.hidden = YES;
 
-        } else if (detailType == DetailTypeShowExtendedPublicKey) {
+        [self setupModalView:qrCodeView inViewController:segue.destinationViewController];
 
-            BCQRCodeView *qrCodeView = [[BCQRCodeView alloc] initWithFrame:self.view.frame qrHeaderText:BC_STRING_EXTENDED_PUBLIC_KEY_DETAIL_HEADER_TITLE addAddressPrefix:YES];
-            qrCodeView.address = [WalletManager.sharedInstance.wallet getXpubForAccount:self.account assetType:self.assetType];
-            qrCodeView.doneButton.hidden = YES;
+        qrCodeView.qrCodeFooterLabel.text = BC_STRING_COPY_XPUB;
+        [segue.destinationViewController.navigationItem setTitle:BC_STRING_EXTENDED_PUBLIC_KEY];
 
-            [self setupModalView:qrCodeView inViewController:segue.destinationViewController];
+    } else if (detailType == DetailTypeShowAddress) {
 
-            qrCodeView.qrCodeFooterLabel.text = BC_STRING_COPY_XPUB;
-            // [self updateHeaderText:BC_STRING_EXTENDED_PUBLIC_KEY];
+        BCQRCodeView *qrCodeView = [[BCQRCodeView alloc] initWithFrame:self.view.frame];
+        qrCodeView.address = self.address;
+        qrCodeView.doneButton.hidden = YES;
 
-        } else if (detailType == DetailTypeShowAddress) {
+        [self setupModalView:qrCodeView inViewController:segue.destinationViewController];
 
-            BCQRCodeView *qrCodeView = [[BCQRCodeView alloc] initWithFrame:self.view.frame];
-            qrCodeView.address = self.address;
-            qrCodeView.doneButton.hidden = YES;
-
-            [self setupModalView:qrCodeView inViewController:segue.destinationViewController];
-
-            qrCodeView.qrCodeFooterLabel.text = BC_STRING_COPY_ADDRESS;
-            // [self updateHeaderText:BC_STRING_ADDRESS];
-        }
+        qrCodeView.qrCodeFooterLabel.text = BC_STRING_COPY_ADDRESS;
+        [segue.destinationViewController.navigationItem setTitle:BC_STRING_ADDRESS];
     }
 }
 

--- a/Blockchain/AccountsAndAddressesDetailViewController.m
+++ b/Blockchain/AccountsAndAddressesDetailViewController.m
@@ -273,7 +273,7 @@ typedef enum {
     [viewController.view addSubview:modalView];
 
     CGRect frame = modalView.frame;
-    frame.origin.y = viewController.view.frame.origin.y + DEFAULT_HEADER_HEIGHT;
+    frame.origin.y = viewController.view.frame.origin.y;
     modalView.frame = frame;
 }
 

--- a/Blockchain/Base.lproj/AccountsAndAddresses.storyboard
+++ b/Blockchain/Base.lproj/AccountsAndAddresses.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="rBZ-dM-VjN">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rBZ-dM-VjN">
+    <device id="retina5_9" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Accounts And Addresses Navigation Controller-->
@@ -10,7 +14,7 @@
             <objects>
                 <navigationController storyboardIdentifier="AccountsAndAddressesNavigationController" id="rBZ-dM-VjN" customClass="AccountsAndAddressesNavigationController" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="fLg-pU-lZW">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -30,9 +34,9 @@
                         <viewControllerLayoutGuide type="bottom" id="KPV-iG-9mu"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="tSL-c0-Xii">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <navigationItem key="navigationItem" id="nGf-MK-yxQ"/>
                     <connections>
@@ -41,7 +45,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="97n-UC-z3C" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="333" y="415"/>
+            <point key="canvasLocation" x="439" y="415"/>
         </scene>
         <!--Accounts And Addresses Detail View Controller-->
         <scene sceneID="Gkz-0l-bLq">
@@ -52,9 +56,9 @@
                         <viewControllerLayoutGuide type="bottom" id="ct4-R7-AyU"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="r5u-fP-21C">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <connections>
                         <segue destination="EUT-Xh-PGc" kind="show" identifier="accountsAndAddressesDetailEdit" id="MC5-VY-wLc"/>
@@ -62,7 +66,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LZh-Gh-g95" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="966" y="415"/>
+            <point key="canvasLocation" x="1228" y="415"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="2dy-IR-uhl">
@@ -73,14 +77,14 @@
                         <viewControllerLayoutGuide type="bottom" id="mnY-yq-VrJ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="EWb-XI-KMx">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="env-zu-BzB" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1640" y="415"/>
+            <point key="canvasLocation" x="2023" y="415"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
Highlights in this PR:
- Shows the missing titles in the edit views of the Accounts and Addresses screen.