### PR TITLE
fix(Exchange): prevent app crash when exchange is created

### DIFF
--- a/Blockchain/ExchangeOverviewViewController.m
+++ b/Blockchain/ExchangeOverviewViewController.m
@@ -218,7 +218,7 @@
     [self.createViewController didGetAvailableEthBalance:result];
 }
 
-- (void)didGetAvailableBtcBalanceWithResult:(NSDictionary * _Nonnull)result
+- (void)didGetAvailableBtcBalanceWithResult:(NSDictionary * _Nullable)result
 {
     [self.createViewController didGetAvailableBtcBalance:result];
 }

--- a/Blockchain/Wallet/WalletExchangeDelegate.swift
+++ b/Blockchain/Wallet/WalletExchangeDelegate.swift
@@ -17,7 +17,7 @@ import Foundation
     func didGetExchangeRate(rate: NSDictionary)
 
     /// Method invoked when the BTC balance has been fetched
-    func didGetAvailableBtcBalance(result: NSDictionary)
+    func didGetAvailableBtcBalance(result: NSDictionary?)
 
     /// Method invoked when the ETH balance has been fetched
     func didGetAvailableEthBalance(result: NSDictionary)

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -475,6 +475,7 @@ extension WalletManager: WalletDelegate {
     }
 
     // MARK: - Exchange
+
     func didGetExchangeTrades(_ trades: [Any]!) {
         DispatchQueue.main.async { [unowned self] in
             self.exchangeDelegate?.didGetExchangeTrades(trades: trades as NSArray)
@@ -487,9 +488,9 @@ extension WalletManager: WalletDelegate {
         }
     }
 
-    func didGetAvailableBtcBalance(_ result: [AnyHashable: Any]!) {
+    func didGetAvailableBtcBalance(_ result: [AnyHashable: Any]?) {
         DispatchQueue.main.async { [unowned self] in
-            self.exchangeDelegate?.didGetAvailableBtcBalance(result: result as NSDictionary)
+            self.exchangeDelegate?.didGetAvailableBtcBalance(result: result as NSDictionary?)
         }
     }
 


### PR DESCRIPTION
Highlights in this PR:
- Fixes a crash where the user creates a new exchange with no free outputs to spend.