### PR TITLE
fix(Swipe to Receive): update swipe to receive addresses when foregrounding app

### DIFF
--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -143,11 +143,6 @@ static PEViewController *VerifyController()
 
     if (self.verifyOnly && BlockchainSettings.sharedAppInstance.swipeToReceiveEnabled) {
         
-        for (NSNumber *key in self.swipeViews) {
-            SwipeToReceiveAddressView *swipeView = [self.swipeViews objectForKey:key];
-            [swipeView removeFromSuperview];
-        }
-        
         pinController.swipeLabel.alpha = 1;
         pinController.swipeLabel.hidden = NO;
         
@@ -159,30 +154,46 @@ static PEViewController *VerifyController()
         [pinController.scrollView setUserInteractionEnabled:YES];
 
         CGFloat windowWidth = self.view.frame.size.width;
-
         NSArray *assets = [self assets];
 
         [pinController.scrollView setContentSize:CGSizeMake(windowWidth * (assets.count + 1), self.view.frame.size.height)];
         [pinController.scrollView setPagingEnabled:YES];
         pinController.scrollView.delegate = self;
-
-        for (int assetIndex = 0; assetIndex < assets.count; assetIndex++) {
-            LegacyAssetType asset = [assets[assetIndex] integerValue];
-            BCSwipeAddressViewModel *viewModel = [[BCSwipeAddressViewModel alloc] initWithAssetType:asset];
-            SwipeToReceiveAddressView *swipeView = [SwipeToReceiveAddressView instanceFromNib];
-            swipeView.onRequestAssetTapped = ^(NSString * _Nonnull address) {
-                [self confirmCopyAddressToClipboard:address];
-            };
-            swipeView.frame = CGRectMake(windowWidth * (assetIndex + 1), 0, windowWidth, pinController.scrollView.frame.size.height);
-            [swipeView layoutIfNeeded];
-            swipeView.viewModel = viewModel;
-            [self addAddressToSwipeToReceiveView:swipeView assetType:asset];
-            [self.swipeViews setObject:swipeView forKey:[NSNumber numberWithInteger:asset]];
-            [pinController.scrollView addSubview:swipeView];
-        }
     } else {
         pinController.swipeLabel.hidden = YES;
         pinController.swipeLabelImageView.hidden = YES;
+    }
+}
+
+- (void)viewWillLayoutSubviews
+{
+    [super viewWillLayoutSubviews];
+    [self updateSwipeToReceiveViews];
+}
+
+- (void)updateSwipeToReceiveViews
+{
+    CGFloat windowWidth = self.view.frame.size.width;
+    NSArray *assets = [self assets];
+
+    for (NSNumber *key in self.swipeViews) {
+        SwipeToReceiveAddressView *swipeView = [self.swipeViews objectForKey:key];
+        [swipeView removeFromSuperview];
+    }
+
+    for (int assetIndex = 0; assetIndex < assets.count; assetIndex++) {
+        LegacyAssetType asset = [assets[assetIndex] integerValue];
+        BCSwipeAddressViewModel *viewModel = [[BCSwipeAddressViewModel alloc] initWithAssetType:asset];
+        SwipeToReceiveAddressView *swipeView = [SwipeToReceiveAddressView instanceFromNib];
+        swipeView.onRequestAssetTapped = ^(NSString * _Nonnull address) {
+            [self confirmCopyAddressToClipboard:address];
+        };
+        swipeView.frame = CGRectMake(windowWidth * (assetIndex + 1), 0, windowWidth, pinController.scrollView.frame.size.height);
+        [swipeView layoutIfNeeded];
+        swipeView.viewModel = viewModel;
+        [self addAddressToSwipeToReceiveView:swipeView assetType:asset];
+        [self.swipeViews setObject:swipeView forKey:[NSNumber numberWithInteger:asset]];
+        [pinController.scrollView addSubview:swipeView];
     }
 }
 


### PR DESCRIPTION
Fixing the issue wherein the swipe to receive addresses do not show upon foregrounding the app right after creating a new wallet or automatically pairing an existing wallet.

Although this fix addresses that issue, note that this isn't the _ideal_ fix. The reason we need to move updating the swipe to receive views in `viewWillLayoutSubviews` (instead of `viewWillAppear`) is that the pin view may also be added "modally" (i.e. it will be added as a subview to the top most view in the view hierarchy). This is really bad and instead should use the standard way of presenting a `UIViewController` (I'm fixing that issue in #238 but is a larger change that I'm still testing).

Tested this and verified that the addresses on the swipe to receive views show up.