### PR TITLE
fix(Bitcoin Cash TX): Prevent ':' being prefixed from BCH TX detail screen

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		AA1E525A2098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E52582098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift */; };
 		AA24D4C720D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24D4C620D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift */; };
 		AA24D4C820D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA24D4C620D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift */; };
+		AA2BA64420DC754600F01954 /* BitcoinAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2BA64320DC754600F01954 /* BitcoinAddressTests.swift */; };
 		AA2D000120D96FA300B7BE0E /* SwipeToReceiveAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2D000020D96FA300B7BE0E /* SwipeToReceiveAddressView.swift */; };
 		AA2D000220D96FA300B7BE0E /* SwipeToReceiveAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2D000020D96FA300B7BE0E /* SwipeToReceiveAddressView.swift */; };
 		AA31A7B42098DA4900FE6268 /* AlertViewPresenter+Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */; };
@@ -1322,6 +1323,7 @@
 		AA1E523C2097E6AC0099BD10 /* GetPinResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPinResponse.swift; sourceTree = "<group>"; };
 		AA1E52582098374A0099BD10 /* AuthenticationCoordinator+Biometrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "AuthenticationCoordinator+Biometrics.swift"; path = "Authentication/AuthenticationCoordinator+Biometrics.swift"; sourceTree = "<group>"; };
 		AA24D4C620D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetTypeLegacyHelper.swift; sourceTree = "<group>"; };
+		AA2BA64320DC754600F01954 /* BitcoinAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinAddressTests.swift; sourceTree = "<group>"; };
 		AA2D000020D96FA300B7BE0E /* SwipeToReceiveAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeToReceiveAddressView.swift; sourceTree = "<group>"; };
 		AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AlertViewPresenter+Wallet.swift"; sourceTree = "<group>"; };
 		AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuItem.swift; sourceTree = "<group>"; };
@@ -2400,6 +2402,7 @@
 			isa = PBXGroup;
 			children = (
 				AA94966220CB613100A9C2DD /* AssetAddressFactoryTests.swift */,
+				AA2BA64320DC754600F01954 /* BitcoinAddressTests.swift */,
 			);
 			path = Addresses;
 			sourceTree = "<group>";
@@ -3116,6 +3119,7 @@
 				AACE31D42092A99B00B7B806 /* AppCoordinator.swift in Sources */,
 				51578AEB20B448BF00B0080A /* WalletKeyImportDelegate.swift in Sources */,
 				AACE31D02092A99B00B7B806 /* AuthenticationError.swift in Sources */,
+				AA2BA64420DC754600F01954 /* BitcoinAddressTests.swift in Sources */,
 				51C2ADD420BDD3EA00D66108 /* AddressValidatorTests.swift in Sources */,
 				AA63F87520A39D8D002B719B /* AppFeatureConfiguration.swift in Sources */,
 				C77217EE20AFCF940087836A /* WalletRecoveryDelegate.swift in Sources */,

--- a/Blockchain/Addresses/BitcoinAddress.swift
+++ b/Blockchain/Addresses/BitcoinAddress.swift
@@ -30,3 +30,16 @@ public class BitcoinAddress: NSObject & AssetAddress {
         self.assetType = .bitcoin
     }
 }
+
+extension BitcoinAddress {
+    /// Transforms this BTC address to a `BitcoinCashAddress`
+    ///
+    /// - Parameter wallet: a Wallet instance
+    /// - Returns: the transformed BTC address
+    @objc func toBitcoinCashAddress(wallet: Wallet) -> BitcoinCashAddress? {
+        guard let bchAddress = wallet.toBitcoinCash(address, includePrefix: false) else {
+            return nil
+        }
+        return BitcoinCashAddress(string: bchAddress)
+    }
+}

--- a/Blockchain/TransactionDetailViewController.m
+++ b/Blockchain/TransactionDetailViewController.m
@@ -403,8 +403,10 @@ const CGFloat rowHeightValueReceived = 80;
         labelString = self.transactionModel.toString;
     }
 
-    if (self.transactionModel.assetType == LegacyAssetTypeBitcoinCash && [WalletManager.sharedInstance.wallet isValidAddress:address assetType:LegacyAssetTypeBitcoinCash]) {
-        address = [WalletManager.sharedInstance.wallet toBitcoinCash:address includePrefix:NO];
+    Wallet *wallet = WalletManager.sharedInstance.wallet;
+    if (self.transactionModel.assetType == LegacyAssetTypeBitcoinCash && [wallet isValidAddress:address assetType:LegacyAssetTypeBitcoinCash]) {
+        BitcoinAddress *bitcoinAddress = [[BitcoinAddress alloc] initWithString:address];
+        address = [bitcoinAddress toBitcoinCashAddressWithWallet:wallet].address;
     }
 
     UIAlertController *copyAddressController = [UIAlertController alertControllerWithTitle:labelString message:nil preferredStyle:UIAlertControllerStyleActionSheet];

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -2747,7 +2747,7 @@
     JSValue *result = [self.context evaluateScript:[NSString stringWithFormat:@"MyWalletPhone.bch.toBitcoinCash(\"%@\", %d)", [address escapedForJS], includePrefix]];
     if ([result isUndefined]) return nil;
     NSString *bitcoinCashAddress = [result toString];
-    return includePrefix ? bitcoinCashAddress : [bitcoinCashAddress substringFromIndex:[[ConstantsObjcBridge bitcoinCashUriPrefix] length]];
+    return includePrefix ? bitcoinCashAddress : [bitcoinCashAddress substringFromIndex:[[ConstantsObjcBridge bitcoinCashUriPrefix] length]+1];
 }
 
 - (void)getBitcoinCashHistoryAndRates

--- a/BlockchainTests/Addresses/BitcoinAddressTests.swift
+++ b/BlockchainTests/Addresses/BitcoinAddressTests.swift
@@ -1,0 +1,28 @@
+//
+//  BitcoinAddressTests.swift
+//  BlockchainTests
+//
+//  Created by Chris Arriola on 6/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import XCTest
+@testable import Blockchain
+
+class BitcoinAddressTests: XCTestCase {
+
+    private var wallet: Wallet!
+
+    override func setUp() {
+        super.setUp()
+        wallet = WalletManager.shared.wallet
+        wallet.loadJS()
+    }
+
+    func testBtcToBchTransformationNoBchPrefix() {
+        let btcAddress = BitcoinAddress(string: "1W3hBBAnECvpmpFXcBrWoBXXihJAEkTmA")
+        let bchAddress = btcAddress.toBitcoinCashAddress(wallet: wallet)
+        XCTAssertNotNil(bchAddress)
+        XCTAssertFalse(bchAddress!.address.contains(":"))
+    }
+}


### PR DESCRIPTION
Fixed regression caused by removing ":" from our asset prefix constants.

I added a transformation function in `BitcoinAddress` to transform it to a `BitcoinCashAddress` + a unit test to check that the transformed bch address does not have a ":".