### PR TITLE
fix(Receive): prevent BTC payment received amount from showing twice.

### DIFF
--- a/Blockchain/ReceiveBitcoinViewController.h
+++ b/Blockchain/ReceiveBitcoinViewController.h
@@ -46,8 +46,6 @@
 
 @property(nonatomic) UIView *bottomContainerView;
 @property(nonatomic) UILabel *receiveToLabel;
-@property(nonatomic) UIButton *selectFromButton;
-@property(nonatomic) UIButton *whatsThisButton;
 @property(nonatomic) UIView *headerView;
 
 - (IBAction)archiveAddressClicked:(id)sender;

--- a/Blockchain/ReceiveBitcoinViewController.m
+++ b/Blockchain/ReceiveBitcoinViewController.m
@@ -245,21 +245,6 @@
     fromLabel.text = BC_STRING_FROM;
     fromLabel.adjustsFontSizeToFitWidth = YES;
     [self.bottomContainerView addSubview:fromLabel];
-
-    self.selectFromButton = [[UIButton alloc] initWithFrame:CGRectMake(self.view.frame.size.width - 35,  lineBelowToField.frame.origin.y + 10, 35, 30)];
-    self.selectFromButton.adjustsImageWhenHighlighted = NO;
-    [self.selectFromButton setImage:[UIImage imageNamed:@"disclosure"] forState:UIControlStateNormal];
-    [self.selectFromButton addTarget:self action:@selector(selectFromClicked) forControlEvents:UIControlEventTouchUpInside];
-    self.selectFromButton.hidden = YES;
-    [self.bottomContainerView addSubview:self.selectFromButton];
-    
-    CGFloat whatsThisButtonWidth = IS_USING_SCREEN_SIZE_LARGER_THAN_5S ? 120 : 100;
-    self.whatsThisButton = [[UIButton alloc] initWithFrame:CGRectMake(self.view.frame.size.width - whatsThisButtonWidth, lineBelowToField.frame.origin.y + 15, whatsThisButtonWidth, 21)];
-    self.whatsThisButton.titleLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_SMALL];
-    [self.whatsThisButton setTitleColor:COLOR_BLOCKCHAIN_LIGHT_BLUE forState:UIControlStateNormal];
-    [self.whatsThisButton setTitle:BC_STRING_WHATS_THIS forState:UIControlStateNormal];
-    [self.whatsThisButton addTarget:self action:@selector(whatsThisButtonClicked) forControlEvents:UIControlEventTouchUpInside];
-    [self.bottomContainerView addSubview:self.whatsThisButton];
     
     self.descriptionContainerView = [[UIView alloc] initWithFrame:CGRectMake(0, self.lineBelowFromField.frame.origin.y + self.lineBelowFromField.frame.size.height, self.view.frame.size.width, 49)];
     self.descriptionContainerView.backgroundColor = [UIColor whiteColor];
@@ -728,9 +713,6 @@
         [self.bottomContainerView changeYPosition:self.view.frame.size.height - BOTTOM_CONTAINER_HEIGHT_PLUS_BUTTON_SPACE_4S];
     }
 
-    self.selectFromButton.hidden = YES;
-    self.whatsThisButton.hidden = NO;
-
     self.receiveToLabel.text = self.mainLabel;
     self.mainAddressLabel.text = [[self.mainAddress componentsSeparatedByString:@":"] lastObject];
     
@@ -741,7 +723,14 @@
 {
     NSString *btcAmountString = self.assetType == LegacyAssetTypeBitcoin ? [NSNumberFormatter formatMoney:amountReceived localCurrency:NO] : [NSNumberFormatter formatBchWithSymbol:amountReceived localCurrency:NO];
     NSString *localCurrencyAmountString = self.assetType == LegacyAssetTypeBitcoin ? [NSNumberFormatter formatMoney:amountReceived localCurrency:YES] : [NSNumberFormatter formatBchWithSymbol:amountReceived localCurrency:YES];
-    [self alertUserOfPaymentWithMessage:[[NSString alloc] initWithFormat:@"%@\n%@", btcAmountString, localCurrencyAmountString] showBackupReminder:showBackupReminder];
+
+    NSString *paymentMessage;
+    if (![localCurrencyAmountString isEqualToString:btcAmountString]) {
+        paymentMessage = [NSString stringWithFormat:@"%@\n%@", btcAmountString, localCurrencyAmountString];
+    } else {
+        paymentMessage = btcAmountString;
+    }
+    [self alertUserOfPaymentWithMessage:paymentMessage showBackupReminder:showBackupReminder];
 }
 
 - (void)selectDestination


### PR DESCRIPTION
Fixes the issue wherein the alert shown when a payment is received displays duplicate payment amounts in BTC.

Ideally the fiat amount right after the BTC amount should be displayed (which happens most of the time). However, there is a race condition wherein we don't have the user's local currency's conversion value from/to BTC amount. When this happens, we'll just display the BTC amount and leave the fiat amount off. Also weird, when the local currency conversion is not available, the `NSNumberFormatter:formatMoney:localCurrency` method will fallback to _always_ just convert the amount to BTC and completely ignore the `localCurrency` flag. Fixing this method may have some unintended consequences since it's used in a lot of other places so I figured this patch will do for now.

Obviously this isn't ideal but the correct fix should be addressed in our wallet rearch efforts.