### PR TITLE
fix(Settings): show correct biometric type in settings

### DIFF
--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -131,8 +131,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             appSettings.shouldHideAllCards = true
         }
 
-        if appSettings.didFailTouchIDSetup && !appSettings.touchIDEnabled {
-            appSettings.shouldShowTouchIDSetup = true
+        if appSettings.didFailBiometrySetup && !appSettings.biometryEnabled {
+            appSettings.shouldShowBiometrySetup = true
         }
 
         // UI-related background actions

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -155,9 +155,9 @@ import Foundation
 
         if BlockchainSettings.App.shared.isPinSet {
             showPinEntryView(asModal: true)
-            if let config = AppFeatureConfigurator.shared.configuration(for: .touchId),
+            if let config = AppFeatureConfigurator.shared.configuration(for: .biometry),
                 config.isEnabled,
-                BlockchainSettings.App.shared.touchIDEnabled {
+                BlockchainSettings.App.shared.biometryEnabled {
                 authenticateWithBiometrics()
             }
         } else {
@@ -598,14 +598,14 @@ extension AuthenticationCoordinator: SetupDelegate {
                 let errorMessage = error ?? LocalizationConstants.Biometrics.unableToUseBiometrics
                 AlertViewPresenter.shared.standardError(message: errorMessage)
 
-                BlockchainSettings.App.shared.didFailTouchIDSetup = true
+                BlockchainSettings.App.shared.didFailBiometrySetup = true
 
                 completion(false)
 
                 return
             }
 
-            BlockchainSettings.App.shared.touchIDEnabled = true
+            BlockchainSettings.App.shared.biometryEnabled = true
 
             // Saving the last entered pin will store the pin in the user's keychain
             self.lastEnteredPIN?.saveToKeychain()

--- a/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
@@ -77,7 +77,7 @@ extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
 
         showVerifyingBusyView(withTimeout: 30)
 
-        if let config = AppFeatureConfigurator.shared.configuration(for: .touchId),
+        if let config = AppFeatureConfigurator.shared.configuration(for: .biometry),
             config.isEnabled,
             pinEntryController.verifyOptional {
             pin.saveToKeychain()
@@ -280,10 +280,10 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
         } else if response.code == GetPinResponse.StatusCode.success.rawValue {
 
             // Handle touch ID
-            if let config = AppFeatureConfigurator.shared.configuration(for: .touchId), config.isEnabled,
+            if let config = AppFeatureConfigurator.shared.configuration(for: .biometry), config.isEnabled,
                 pinEntryViewController?.verifyOptional ?? false {
                 LoadingViewPresenter.shared.hideBusyView()
-                BlockchainSettings.App.shared.touchIDEnabled = true
+                BlockchainSettings.App.shared.biometryEnabled = true
                 closePinEntryView(animated: true)
                 AppCoordinator.shared.showSettingsView()
                 return

--- a/Blockchain/Extensions/UserDefaults.swift
+++ b/Blockchain/Extensions/UserDefaults.swift
@@ -21,7 +21,7 @@ extension UserDefaults {
 
     enum Keys: String {
         case assetType = "assetType"
-        case didFailTouchIDSetup = "didFailTouchIDSetup"
+        case didFailBiometrySetup = "didFailBiometrySetup"
         case encryptedPinPassword = "encryptedPINPassword"
         case environment = "environment"
         case firstRun = "firstRun"
@@ -36,10 +36,10 @@ extension UserDefaults {
         case reminderModalDate = "reminderModalDate"
         case shouldHideAllCards = "shouldHideAllCards"
         case shouldHideBuySellCard = "shouldHideBuySellNotificationCard"
-        case shouldShowTouchIDSetup = "shouldShowTouchIDSetup"
+        case shouldShowBiometrySetup = "shouldShowBiometrySetup"
         case swipeToReceiveEnabled = "swipeToReceive"
         case symbolLocal = "symbolLocal"
-        case touchIDEnabled = "touchIDEnabled"
+        case biometryEnabled = "biometryEnabled"
         case hideTransferAllFundsAlert = "hideTransferAllFundsAlert"
         case defaultAccountLabelledAddressesCount = "defaultAccountLabelledAddressesCount"
     }

--- a/Blockchain/Extensions/UserDefaults.swift
+++ b/Blockchain/Extensions/UserDefaults.swift
@@ -1,5 +1,5 @@
 //
-//  Userstandard.swift
+//  UserDefaults.swift
 //  Blockchain
 //
 //  Created by Maurice A. on 4/13/18.

--- a/Blockchain/Extensions/UserDefaults.swift
+++ b/Blockchain/Extensions/UserDefaults.swift
@@ -44,18 +44,15 @@ extension UserDefaults {
         case defaultAccountLabelledAddressesCount = "defaultAccountLabelledAddressesCount"
     }
 
-    static func migrateLegacyKeysIfNeeded() {
-        if let didFailTouchIDSetup = standard.object(forKey: "didFailTouchIDSetup") as? Bool {
-            standard.set(didFailTouchIDSetup, forKey: Keys.didFailBiometrySetup.rawValue)
-            standard.removeObject(forKey: "didFailTouchIDSetup")
-        }
-        if let shouldShowTouchIDSetup = standard.object(forKey: "shouldShowTouchIDSetup") as? Bool {
-            standard.set(shouldShowTouchIDSetup, forKey: Keys.shouldShowBiometrySetup.rawValue)
-            standard.removeObject(forKey: "shouldShowTouchIDSetup")
-        }
-        if let touchIDEnabled = standard.object(forKey: "touchIDEnabled") as? Bool {
-            standard.set(touchIDEnabled, forKey: Keys.biometryEnabled.rawValue)
-            standard.removeObject(forKey: "touchIDEnabled")
-        }
+    func migrateLegacyKeysIfNeeded() {
+        migrateBool(fromKey: "didFailTouchIDSetup", toKey: Keys.didFailBiometrySetup.rawValue)
+        migrateBool(fromKey: "shouldShowTouchIDSetup", toKey: Keys.shouldShowBiometrySetup.rawValue)
+        migrateBool(fromKey: "touchIDEnabled", toKey: Keys.biometryEnabled.rawValue)
+    }
+
+    private func migrateBool(fromKey: String, toKey: String) {
+        guard let value = self.object(forKey: fromKey) as? Bool else { return }
+        self.set(value, forKey: toKey)
+        self.removeObject(forKey: fromKey)
     }
 }

--- a/Blockchain/Extensions/UserDefaults.swift
+++ b/Blockchain/Extensions/UserDefaults.swift
@@ -1,5 +1,5 @@
 //
-//  UserDefaults.swift
+//  Userstandard.swift
 //  Blockchain
 //
 //  Created by Maurice A. on 4/13/18.
@@ -42,5 +42,20 @@ extension UserDefaults {
         case biometryEnabled = "biometryEnabled"
         case hideTransferAllFundsAlert = "hideTransferAllFundsAlert"
         case defaultAccountLabelledAddressesCount = "defaultAccountLabelledAddressesCount"
+    }
+
+    static func migrateLegacyKeysIfNeeded() {
+        if let didFailTouchIDSetup = standard.object(forKey: "didFailTouchIDSetup") as? Bool {
+            standard.set(didFailTouchIDSetup, forKey: Keys.didFailBiometrySetup.rawValue)
+            standard.removeObject(forKey: "didFailTouchIDSetup")
+        }
+        if let shouldShowTouchIDSetup = standard.object(forKey: "shouldShowTouchIDSetup") as? Bool {
+            standard.set(shouldShowTouchIDSetup, forKey: Keys.shouldShowBiometrySetup.rawValue)
+            standard.removeObject(forKey: "shouldShowTouchIDSetup")
+        }
+        if let touchIDEnabled = standard.object(forKey: "touchIDEnabled") as? Bool {
+            standard.set(touchIDEnabled, forKey: Keys.biometryEnabled.rawValue)
+            standard.removeObject(forKey: "touchIDEnabled")
+        }
     }
 }

--- a/Blockchain/Feature Configuration/AppFeature.swift
+++ b/Blockchain/Feature Configuration/AppFeature.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Enumerates app features that can be dynamically configured (e.g. enabled/disabled)
 @objc enum AppFeature: Int {
-    case touchId
+    case biometry
     case swipeToReceive
     case transferFundsFromImportedAddress
 }
@@ -18,6 +18,6 @@ import Foundation
 extension AppFeature {
     // Use CaseIterable once upgraded to Swift 4.2
     static let allFeatures: [AppFeature] = [
-        .touchId, .swipeToReceive, .transferFundsFromImportedAddress
+        .biometry, .swipeToReceive, .transferFundsFromImportedAddress
     ]
 }

--- a/Blockchain/LocalizationConstants.h
+++ b/Blockchain/LocalizationConstants.h
@@ -284,8 +284,6 @@
 #define BC_STRING_SETTINGS_FEES NSLocalizedString(@"Fees", nil)
 #define BC_STRING_SETTINGS_FEE_PER_KB NSLocalizedString(@"Fee per KB", nil)
 #define BC_STRING_SETTINGS_SECURITY NSLocalizedString(@"Security", nil)
-#define BC_STRING_SETTINGS_PIN_USE_FACE_ID_AS_PIN NSLocalizedString(@"Use Face ID as PIN", nil)
-#define BC_STRING_SETTINGS_PIN_USE_TOUCH_ID_AS_PIN NSLocalizedString(@"Use Touch ID as PIN", nil)
 #define BC_STRING_SETTINGS_PIN_SWIPE_TO_RECEIVE NSLocalizedString(@"Swipe to Receive", nil)
 #define BC_STRING_SWIPE_TO_RECEIVE_NO_INTERNET_CONNECTION_WARNING NSLocalizedString(@"We can't check whether this address has been used. Show anyway?", nil)
 #define BC_STRING_SETTINGS_SECURITY_TWO_STEP_VERIFICATION NSLocalizedString(@"2-step Verification", nil)
@@ -401,10 +399,6 @@
 #define BC_STRING_FACE_ID_ERROR_UNKNOWN_ARGUMENT NSLocalizedString(@"Unknown Face ID error. Code: %ld", nil)
 // No longer needed
 #define BC_STRING_TOUCH_ID_ERROR_UNKNOWN_ARGUMENT NSLocalizedString(@"Unknown Touch ID error. Code: %ld", nil)
-// No longer needed
-#define BC_STRING_FACE_ID_WARNING NSLocalizedString(@"Enabling this feature will allow all users with a registered Face ID fingerprint on this device to access to your wallet.", nil)
-// No longer needed
-#define BC_STRING_TOUCH_ID_WARNING NSLocalizedString(@"Enabling this feature will allow all users with a registered Touch ID fingerprint on this device to access to your wallet.", nil)
 
 #define BC_STRING_NO_EMAIL_CONFIGURED NSLocalizedString(@"You do not have an account set up for Mail. Please contact %@", nil)
 #define BC_STRING_PIN NSLocalizedString(@"PIN", nil)
@@ -546,12 +540,6 @@
 #define BC_STRING_WELCOME_MESSAGE_ONE NSLocalizedString (@"Welcome to Blockchain", nil)
 #define BC_STRING_WELCOME_MESSAGE_TWO NSLocalizedString (@"Securely store bitcoin", nil)
 #define BC_STRING_WELCOME_MESSAGE_THREE NSLocalizedString (@"Seamlessly transact with others around the world", nil)
-#define BC_STRING_WELCOME_FACE_ID_INSTRUCTIONS NSLocalizedString (@"Use Face ID instead of PIN to authenticate Blockchain and access your wallet.", nil)
-#define BC_STRING_WELCOME_TOUCH_ID_INSTRUCTIONS NSLocalizedString (@"Use Touch ID fingerprint instead of PIN to authenticate Blockchain and access your wallet.", nil)
-#define BC_STRING_FACE_ID NSLocalizedString(@"Face ID", nil)
-#define BC_STRING_TOUCH_ID NSLocalizedString(@"Touch ID", nil)
-#define BC_STRING_ENABLE_FACE_ID NSLocalizedString(@"Enable Face ID", nil)
-#define BC_STRING_ENABLE_TOUCH_ID NSLocalizedString(@"Enable Touch ID", nil)
 #define BC_STRING_OVERVIEW_MARKET_PRICE_TITLE NSLocalizedString(@"Current Price", nil)
 #define BC_STRING_OVERVIEW_MARKET_PRICE_DESCRIPTION NSLocalizedString (@"We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet.", nil)
 #define BC_STRING_OVERVIEW_REQUEST_FUNDS_TITLE NSLocalizedString(@"Request Funds", nil)

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -105,18 +105,36 @@ struct LocalizationConstants {
     }
 
     struct Biometrics {
-        //: Touch ID specific instructions
-        static let touchIDEnableInstructions = NSLocalizedString("Touch ID is not enabled on this device. To enable Touch ID, go to Settings -> Touch ID & Passcode and add a fingerprint.", comment: "")
-
+        static let touchIDEnableInstructions = NSLocalizedString(
+            "Touch ID is not enabled on this device. To enable Touch ID, go to Settings -> Touch ID & Passcode and add a fingerprint.",
+            comment: "The error description for when the user is not enrolled in biometric authentication."
+        )
         //: Biometry Authentication Errors (only available on iOS 11, possibly including newer versions)
-        static let biometricsLockout = NSLocalizedString("Unable to Authenticate due to failing Authentication too many times.", comment: "")
-        static let biometricsNotSupported = NSLocalizedString("Unable to Authenticate because the device does not support biometric Authentication.", comment: "")
-        static let unableToUseBiometrics = NSLocalizedString("Unable to use biometrics.", comment: "")
-
+        static let biometricsLockout = NSLocalizedString(
+            "Unable to authenticate due to failing authentication too many times.",
+            comment: "The error description for when the user has made too many failed authentication attempts using biometrics."
+        )
+        static let biometricsNotSupported = NSLocalizedString(
+            "Unable to authenticate because the device does not support biometric authentication.",
+            comment: "The error description for when the device does not support biometric authentication."
+        )
+        static let unableToUseBiometrics = NSLocalizedString(
+            "Unable to use biometrics.",
+            comment: "The error message displayed to the user upon failure to authenticate using biometrics."
+        )
         //: Deprecated Authentication Errors (remove once we stop supporting iOS >= 8.0 and iOS <= 11)
-        static let touchIDLockout = NSLocalizedString("Unable to Authenticate because there were too many failed Touch ID attempts. Passcode is required to unlock Touch ID", comment: "")
-        static let biometryWarning = NSLocalizedString("Enabling this feature will allow all users with a registered %@ fingerprint on this device to access to your wallet.", comment: "%@ represents either Face ID or Touch ID to avoid additional translation")
-        static let enableBiometrics = NSLocalizedString("Enable %@", comment: "")
+        static let touchIDLockout = NSLocalizedString(
+            "Unable to Authenticate because there were too many failed Touch ID attempts. Passcode is required to unlock Touch ID",
+            comment: "The error description for when the user has made too many failed authentication attempts using Touch ID."
+        )
+        static let biometryWarning = NSLocalizedString(
+            "Enabling this feature will allow all users with a registered %@ fingerprint on this device to access to your wallet.",
+            comment: "The message displayed in the alert view when the biometry switch is toggled in the settings view."
+        )
+        static let enableX = NSLocalizedString(
+            "Enable %@",
+            comment: "The title of the biometric authentication button in the wallet setup view. The value depends on the type of biometry."
+        )
     }
 
     struct Onboarding {
@@ -325,5 +343,5 @@ struct LocalizationConstants {
 
     @objc class func biometricInstructions() -> String { return LocalizationConstants.Onboarding.biometricInstructions }
 
-    @objc class func enableBiometrics() -> String { return LocalizationConstants.Biometrics.enableBiometrics }
+    @objc class func enableBiometrics() -> String { return LocalizationConstants.Biometrics.enableX }
 }

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -115,6 +115,8 @@ struct LocalizationConstants {
 
         //: Deprecated Authentication Errors (remove once we stop supporting iOS >= 8.0 and iOS <= 11)
         static let touchIDLockout = NSLocalizedString("Unable to Authenticate because there were too many failed Touch ID attempts. Passcode is required to unlock Touch ID", comment: "")
+        static let biometryWarning = NSLocalizedString("Enabling this feature will allow all users with a registered %@ fingerprint on this device to access to your wallet.", comment: "%@ represents either Face ID or Touch ID to avoid additional translation")
+        static let enableBiometrics = NSLocalizedString("Enable %@", comment: "")
     }
 
     struct Onboarding {
@@ -125,6 +127,7 @@ struct LocalizationConstants {
         static let askToUserOldWalletTitle = NSLocalizedString("We’ve detected a previous installation of Blockchain Wallet on your phone.", comment: "")
         static let askToUserOldWalletMessage = NSLocalizedString("Please choose from the options below.", comment: "")
         static let loginExistingWallet = NSLocalizedString("Login existing Wallet", comment: "")
+        static let biometricInstructions = NSLocalizedString("Use %@ instead of PIN to authenticate Blockchain and access your wallet.", comment: "")
     }
 
     struct SideMenu {
@@ -184,6 +187,7 @@ struct LocalizationConstants {
     struct Settings {
         static let cookiePolicy = NSLocalizedString("Cookie Policy", comment: "")
         static let allRightsReserved = NSLocalizedString("All rights reserved.", comment: "")
+        static let useBiometricsAsPin = NSLocalizedString("Use %@ as PIN", comment: "")
     }
 
     struct SwipeToReceive {
@@ -314,4 +318,12 @@ struct LocalizationConstants {
     @objc class func upgradeFeatureTwo() -> String { return LocalizationConstants.LegacyUpgrade.upgradeFeatureTwo }
 
     @objc class func upgradeFeatureThree() -> String { return LocalizationConstants.LegacyUpgrade.upgradeFeatureThree }
+
+    @objc class func useBiometricsAsPin() -> String { return LocalizationConstants.Settings.useBiometricsAsPin }
+
+    @objc class func biometryWarning() -> String { return LocalizationConstants.Biometrics.biometryWarning }
+
+    @objc class func biometricInstructions() -> String { return LocalizationConstants.Onboarding.biometricInstructions }
+
+    @objc class func enableBiometrics() -> String { return LocalizationConstants.Biometrics.enableBiometrics }
 }

--- a/Blockchain/Pin/Pin.swift
+++ b/Blockchain/Pin/Pin.swift
@@ -59,9 +59,9 @@ class Pin {
         WalletManager.shared.wallet.pinServerPutKey(onPinServerServer: key, value: value, pin: self.toString)
 
         // Optionally save PIN in keychain if touch ID is enabled
-        if let config = AppFeatureConfigurator.shared.configuration(for: .touchId),
+        if let config = AppFeatureConfigurator.shared.configuration(for: .biometry),
             config.isEnabled,
-            BlockchainSettings.App.shared.touchIDEnabled {
+            BlockchainSettings.App.shared.biometryEnabled {
             saveToKeychain()
         }
     }

--- a/Blockchain/Reminder/ReminderPresenter.swift
+++ b/Blockchain/Reminder/ReminderPresenter.swift
@@ -70,11 +70,11 @@ import Foundation
         appSettings.hasSeenEmailReminder = true
 
         let setupViewController = WalletSetupViewController(setupDelegate: AuthenticationCoordinator.shared)!
-        setupViewController.emailOnly = !appSettings.shouldShowTouchIDSetup
+        setupViewController.emailOnly = !appSettings.shouldShowBiometrySetup
         setupViewController.modalTransitionStyle = .crossDissolve
 
-        appSettings.shouldShowTouchIDSetup = false
-        appSettings.didFailTouchIDSetup = false
+        appSettings.shouldShowBiometrySetup = false
+        appSettings.didFailBiometrySetup = false
 
         UIApplication.shared.keyWindow?.rootViewController?.topMostViewController?.present(setupViewController, animated: true)
     }

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -309,7 +309,7 @@ final class BlockchainSettings: NSObject {
 
         //: Handles settings migration when keys change
         func handleMigrationIfNeeded() {
-            UserDefaults.migrateLegacyKeysIfNeeded()
+            defaults.migrateLegacyKeysIfNeeded()
         }
     }
 

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -36,12 +36,12 @@ final class BlockchainSettings: NSObject {
 
         // MARK: - Properties
 
-        @objc var didFailTouchIDSetup: Bool {
+        @objc var didFailBiometrySetup: Bool {
             get {
-                return defaults.bool(forKey: UserDefaults.Keys.didFailTouchIDSetup.rawValue)
+                return defaults.bool(forKey: UserDefaults.Keys.didFailBiometrySetup.rawValue)
             }
             set {
-                defaults.set(newValue, forKey: UserDefaults.Keys.didFailTouchIDSetup.rawValue)
+                defaults.set(newValue, forKey: UserDefaults.Keys.didFailBiometrySetup.rawValue)
             }
         }
 
@@ -150,12 +150,12 @@ final class BlockchainSettings: NSObject {
             }
         }
 
-        @objc var touchIDEnabled: Bool {
+        @objc var biometryEnabled: Bool {
             get {
-                return defaults.bool(forKey: UserDefaults.Keys.touchIDEnabled.rawValue)
+                return defaults.bool(forKey: UserDefaults.Keys.biometryEnabled.rawValue)
             }
             set {
-                defaults.set(newValue, forKey: UserDefaults.Keys.touchIDEnabled.rawValue)
+                defaults.set(newValue, forKey: UserDefaults.Keys.biometryEnabled.rawValue)
             }
         }
 
@@ -217,12 +217,12 @@ final class BlockchainSettings: NSObject {
             }
         }
 
-        @objc var shouldShowTouchIDSetup: Bool {
+        @objc var shouldShowBiometrySetup: Bool {
             get {
-                return defaults.bool(forKey: UserDefaults.Keys.shouldShowTouchIDSetup.rawValue)
+                return defaults.bool(forKey: UserDefaults.Keys.shouldShowBiometrySetup.rawValue)
             }
             set {
-                defaults.set(newValue, forKey: UserDefaults.Keys.shouldShowTouchIDSetup.rawValue)
+                defaults.set(newValue, forKey: UserDefaults.Keys.shouldShowBiometrySetup.rawValue)
             }
         }
 

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -279,6 +279,7 @@ final class BlockchainSettings: NSObject {
                 UserDefaults.DebugKeys.enableCertificatePinning.rawValue: true
             ])
             migratePasswordAndPinIfNeeded()
+            handleMigrationIfNeeded()
         }
 
         // MARK: - Public
@@ -304,6 +305,11 @@ final class BlockchainSettings: NSObject {
 
             defaults.removeObject(forKey: UserDefaults.Keys.password.rawValue)
             defaults.removeObject(forKey: UserDefaults.Keys.pin.rawValue)
+        }
+
+        //: Handles settings migration when keys change
+        func handleMigrationIfNeeded() {
+            UserDefaults.migrateLegacyKeysIfNeeded()
         }
     }
 

--- a/Blockchain/SettingsTableViewController.m
+++ b/Blockchain/SettingsTableViewController.m
@@ -15,6 +15,7 @@
 #import "BCVerifyEmailViewController.h"
 #import "BCVerifyMobileNumberViewController.h"
 #import "WebLoginViewController.h"
+#import <LocalAuthentication/LocalAuthentication.h>
 
 const int textFieldTagChangePasswordHint = 8;
 const int textFieldTagVerifyMobileNumber = 7;
@@ -60,34 +61,36 @@ const int aboutCookiePolicy = 3;
 @property (nonatomic) BOOL isEnablingTwoStepSMS;
 @property (nonatomic) BackupNavigationViewController *backupController;
 
-@property (readonly, nonatomic) int PINTouchID;
+@property (readonly, nonatomic) int PINBiometry;
 @property (readonly, nonatomic) int PINSwipeToReceive;
 
 @end
 
 @implementation SettingsTableViewController
 
-- (int)PINTouchID
+// Note: - There should not be a toggle for this setting, instead just assume the user wants to use it during pin setup.
+// SeeAlso: - https://developer.apple.com/design/human-interface-guidelines/ios/user-interaction/authentication
+- (int)PINBiometry
 {
-    AppFeatureConfiguration *touchIDConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureTouchId];
-    AppFeatureConfiguration *swipeToReceiveConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureSwipeToReceive];
-    if (touchIDConfig.isEnabled && swipeToReceiveConfig.isEnabled) {
-        return 4;
-    } else if (touchIDConfig.isEnabled) {
-        return 4;
+    //: Don't show the option to enable biometric authentication if the user is not enrolled
+    if (![self biometryTypeDescription]) {
+        return -1;
     }
-    return -1;
+    //: As long as the user is enrolled in biometric authentication, the row index will be 4
+    return 4;
 }
 
 - (int)PINSwipeToReceive
 {
-    AppFeatureConfiguration *touchIDConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureTouchId];
-    AppFeatureConfiguration *swipeToReceiveConfig = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureSwipeToReceive];
-    if (touchIDConfig.isEnabled && swipeToReceiveConfig.isEnabled) {
-        return 5;
-    } else if (touchIDConfig.isEnabled) {
+    AppFeatureConfiguration *swipeToReceive = [AppFeatureConfigurator.sharedInstance configurationFor:AppFeatureSwipeToReceive];
+    if (!swipeToReceive.isEnabled) {
         return -1;
     }
+    //: If the user is enrolled in biometric authentication, account for the additional row
+    if ([self biometryTypeDescription]) {
+        return 5;
+    }
+    //: Otherwise it will be the forth item
     return 4;
 }
 
@@ -584,42 +587,59 @@ const int aboutCookiePolicy = 3;
     }
 }
 
-#pragma mark - Change Touch ID
+#pragma mark - Biometrics
 
-- (void)switchTouchIDTapped
+/**
+ Gets the biometric type description depending on whether the device supports Face ID or Touch ID.
+ This method may also be used to quickly determine whether or not the user is enrolled in biometric authentication.
+ @return The biometric type description of the authentication method.
+ */
+- (NSString *)biometryTypeDescription
+{
+    LAContext *context = [[LAContext alloc] init];
+    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil]) {
+        if (context.biometryType == LABiometryTypeFaceID) {
+            return [NSString stringWithFormat:[LocalizationConstantsObjcBridge useBiometricsAsPin], @"Face ID"];
+        }
+        return [NSString stringWithFormat:[LocalizationConstantsObjcBridge useBiometricsAsPin], @"Touch ID"];
+    }
+    return nil;
+}
+
+- (void)biometrySwitchTapped
 {
     [AuthenticationManager.sharedInstance canAuthenticateUsingBiometryWithAndReply:^(BOOL success, NSString * _Nullable errorMessage) {
         if (success) {
-            [self toggleTouchID];
+            [self toggleBiometry];
         } else {
-            BlockchainSettings.sharedAppInstance.touchIDEnabled = NO;
-            UIAlertController *alertTouchIDError = [UIAlertController alertControllerWithTitle:BC_STRING_ERROR message:errorMessage preferredStyle:UIAlertControllerStyleAlert];
-            [alertTouchIDError addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-                NSIndexPath *indexPath = [NSIndexPath indexPathForRow:self.PINTouchID inSection:sectionSecurity];
+            BlockchainSettings.sharedAppInstance.biometryEnabled = NO;
+            UIAlertController *alertBiometryError = [UIAlertController alertControllerWithTitle:BC_STRING_ERROR message:errorMessage preferredStyle:UIAlertControllerStyleAlert];
+            [alertBiometryError addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+                NSIndexPath *indexPath = [NSIndexPath indexPathForRow:self.PINBiometry inSection:sectionSecurity];
                 [self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
             }]];
-            [self presentViewController:alertTouchIDError animated:YES completion:nil];
+            [self presentViewController:alertBiometryError animated:YES completion:nil];
         }
     }];
 }
 
-- (void)toggleTouchID
+- (void)toggleBiometry
 {
-    BOOL touchIDEnabled = BlockchainSettings.sharedAppInstance.touchIDEnabled;
-
-    if (!(touchIDEnabled == YES)) {
-        UIAlertController *alertForTogglingTouchID = [UIAlertController alertControllerWithTitle:BC_STRING_SETTINGS_PIN_USE_TOUCH_ID_AS_PIN message:BC_STRING_TOUCH_ID_WARNING preferredStyle:UIAlertControllerStyleAlert];
-        [alertForTogglingTouchID addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:self.PINTouchID inSection:sectionSecurity];
+    BOOL biometryEnabled = BlockchainSettings.sharedAppInstance.biometryEnabled;
+    if (!(biometryEnabled == YES)) {
+        NSString *biometryWarning = [NSString stringWithFormat:[LocalizationConstantsObjcBridge biometryWarning], [self biometryTypeDescription]];
+        UIAlertController *alertForTogglingBiometry = [UIAlertController alertControllerWithTitle:[self biometryTypeDescription] message:biometryWarning preferredStyle:UIAlertControllerStyleAlert];
+        [alertForTogglingBiometry addAction:[UIAlertAction actionWithTitle:BC_STRING_CANCEL style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:self.PINBiometry inSection:sectionSecurity];
             [self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
         }]];
-        [alertForTogglingTouchID addAction:[UIAlertAction actionWithTitle:BC_STRING_CONTINUE style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [alertForTogglingBiometry addAction:[UIAlertAction actionWithTitle:BC_STRING_CONTINUE style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [AuthenticationCoordinator.sharedInstance validatePin];
         }]];
-        [self presentViewController:alertForTogglingTouchID animated:YES completion:nil];
+        [self presentViewController:alertForTogglingBiometry animated:YES completion:nil];
     } else {
         [KeychainItemWrapper removePinFromKeychain];
-        BlockchainSettings.sharedAppInstance.touchIDEnabled = !touchIDEnabled;
+        BlockchainSettings.sharedAppInstance.biometryEnabled = !biometryEnabled;
     }
 }
 
@@ -1125,44 +1145,21 @@ const int aboutCookiePolicy = 3;
         case sectionProfile: return 4;
         case sectionPreferences: return 2;
         case sectionSecurity: {
-            NSInteger numberOfRows = 0;
-
-            if (self.PINTouchID > 0 && self.PINSwipeToReceive > 0) {
-                numberOfRows = 5;
-            } else if (self.PINTouchID > 0 || self.PINSwipeToReceive > 0) {
-                numberOfRows = 4;
-            } else {
-                numberOfRows = 3;
+            NSInteger numberOfRows = 6;
+            if (self.PINBiometry == -1) {
+                numberOfRows--;
             }
-
-            return [WalletManager.sharedInstance.wallet didUpgradeToHd] ? numberOfRows + 1 : numberOfRows;
+            if (self.PINSwipeToReceive == -1) {
+                numberOfRows--;
+            }
+            if (![WalletManager.sharedInstance.wallet didUpgradeToHd]) {
+                numberOfRows--;
+            }
+            return numberOfRows;
         }
         case aboutSection: return 4;
         default: return 0;
     }
-}
-
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 45)];
-    view.backgroundColor = COLOR_TABLE_VIEW_BACKGROUND_LIGHT_GRAY;
-
-    UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(20, 20, self.view.frame.size.width, 14)];
-    label.textColor = COLOR_BLOCKCHAIN_BLUE;
-    label.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_SMALL_MEDIUM];
-
-    [view addSubview:label];
-
-    NSString *labelString = [self titleForHeaderInSection:section];
-
-    label.text = labelString;
-
-    return view;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    return 45.0f;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -1294,17 +1291,17 @@ const int aboutCookiePolicy = 3;
                 cell.textLabel.text = BC_STRING_CHANGE_PIN;
                 cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
                 return cell;
-            } else if (indexPath.row == self.PINTouchID) {
+            } else if (indexPath.row == self.PINBiometry) {
                 cell.textLabel.adjustsFontSizeToFitWidth = YES;
                 cell.detailTextLabel.adjustsFontSizeToFitWidth = YES;
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
                 cell.textLabel.font = [SettingsTableViewController fontForCell];
-                cell.textLabel.text = BC_STRING_SETTINGS_PIN_USE_TOUCH_ID_AS_PIN;
-                UISwitch *switchForTouchID = [[UISwitch alloc] init];
-                BOOL touchIDEnabled = BlockchainSettings.sharedAppInstance.touchIDEnabled;
-                switchForTouchID.on = touchIDEnabled;
-                [switchForTouchID addTarget:self action:@selector(switchTouchIDTapped) forControlEvents:UIControlEventTouchUpInside];
-                cell.accessoryView = switchForTouchID;
+                cell.textLabel.text = [self biometryTypeDescription];
+                UISwitch *biometrySwitch = [[UISwitch alloc] init];
+                BOOL biometryEnabled = BlockchainSettings.sharedAppInstance.biometryEnabled;
+                biometrySwitch.on = biometryEnabled;
+                [biometrySwitch addTarget:self action:@selector(biometrySwitchTapped) forControlEvents:UIControlEventTouchUpInside];
+                cell.accessoryView = biometrySwitch;
                 return cell;
             } else if (indexPath.row == self.PINSwipeToReceive) {
                 cell.textLabel.adjustsFontSizeToFitWidth = YES;
@@ -1340,10 +1337,36 @@ const int aboutCookiePolicy = 3;
                     return cell;
                 }
             }
-        }        default: return nil;
+        }
+        default: return nil;
     }
 
     return cell;
+}
+
+#pragma mark - Table view delegate
+
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+    UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 45)];
+    view.backgroundColor = COLOR_TABLE_VIEW_BACKGROUND_LIGHT_GRAY;
+
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(20, 20, self.view.frame.size.width, 14)];
+    label.textColor = COLOR_BLOCKCHAIN_BLUE;
+    label.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_SMALL_MEDIUM];
+
+    NSString *labelString = [self titleForHeaderInSection:section];
+    label.text = labelString;
+    [label sizeToFit];
+
+    [view addSubview:label];
+
+    return view;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    return 45.0f;
 }
 
 - (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -99,7 +99,7 @@ class WalletManager: NSObject {
 
         AppCoordinator.shared.reload()
 
-        BlockchainSettings.App.shared.touchIDEnabled = false
+        BlockchainSettings.App.shared.biometryEnabled = false
 
         AppCoordinator.shared.tabControllerManager.transition(to: 1)
 


### PR DESCRIPTION
Highlights in this PR:
- Now shows the correct biometric authentication type in the **Settings** view.
- Now shows the correct biometric authentication type in the **Wallet Setup** view.
- Standardizes the naming of objects related to biometric authentication (to be more agnostic).
- Correctly sizes header labels for table view sections.

### IMPORTANT
Two keys in the UserDefaults have been renamed to reflect the object name standardization and thus will **disable** biometric authentication the **first time** the user returns to the app after updating the application.

Some localized constants were also affected and thus translations need to be updated before merging this PR.

As mentioned in the code docs, we should not have a toggle to opt-in to using biometric authentication, but rather prompt the user with the system dialog during the pin creation step. To be discussed further.

Biometric authentication-related configuration should **not** be stored by the application, but rather by the system itself.

For more info, please see:
https://developer.apple.com/design/human-interface-guidelines/ios/user-interaction/authentication