### PR TITLE
fix(Send): clear amount fields when view disappears

### DIFF
--- a/Blockchain/Base.lproj/SendCoins.xib
+++ b/Blockchain/Base.lproj/SendCoins.xib
@@ -24,7 +24,6 @@
                 <outlet property="bottomContainerView" destination="UFr-og-Lbi" id="lgK-g1-LV7"/>
                 <outlet property="btcAmountField" destination="52" id="YXL-6B-QU6"/>
                 <outlet property="btcLabel" destination="7ho-GV-ikp" id="e2a-3k-kXk"/>
-                <outlet property="contactLabel" destination="qkl-tN-HpA" id="8W4-Q3-S0p"/>
                 <outlet property="containerView" destination="Gzr-Wy-8Rh" id="DL3-hD-g0C"/>
                 <outlet property="continueButtonTopConstraint" destination="imL-4O-tP2" id="yHH-pp-d9a"/>
                 <outlet property="continuePaymentAccessoryButton" destination="pPu-bJ-k6p" id="ymH-4D-0a6"/>
@@ -221,14 +220,6 @@
                             </subviews>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
-                        <label hidden="YES" opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Contact Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="qkl-tN-HpA">
-                            <rect key="frame" x="63" y="51" width="222" height="39"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            <fontDescription key="fontDescription" name="Montserrat-Light" family="Montserrat" pointSize="13"/>
-                            <color key="textColor" red="0.23137254900000001" green="0.23137254900000001" blue="0.23137254900000001" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4">
                             <rect key="frame" x="20" y="420" width="279" height="40"/>
                             <color key="backgroundColor" red="0.094117647058823528" green="0.61176470588235299" blue="0.8666666666666667" alpha="1" colorSpace="calibratedRGB"/>

--- a/Blockchain/DestinationAddressSource.h
+++ b/Blockchain/DestinationAddressSource.h
@@ -15,7 +15,6 @@ typedef enum {
     DestinationAddressSourcePaste,
     DestinationAddressSourceURI,
     DestinationAddressSourceDropDown,
-    DestinationAddressSourceContact
 } DestinationAddressSource;
 
 #endif /* DestinationAddressSource_h */

--- a/Blockchain/ReceiveBitcoinViewController.m
+++ b/Blockchain/ReceiveBitcoinViewController.m
@@ -115,6 +115,11 @@
     [self updateUI];
 }
 
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [self clearAmounts];
+}
+
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];

--- a/Blockchain/ReceiveBitcoinViewController.m
+++ b/Blockchain/ReceiveBitcoinViewController.m
@@ -117,6 +117,8 @@
 
 - (void)viewDidDisappear:(BOOL)animated
 {
+    [super viewDidDisappear:animated];
+
     [self clearAmounts];
 }
 

--- a/Blockchain/SendBitcoinViewController.h
+++ b/Blockchain/SendBitcoinViewController.h
@@ -37,7 +37,6 @@
     IBOutlet UIButton *selectFromButton;
     IBOutlet UIButton *fundsAvailableButton;
     
-    IBOutlet UILabel *contactLabel;
     IBOutlet UILabel *toLabel;
     IBOutlet UITextField *toField;
     IBOutlet UIButton *addressBookButton;

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -124,10 +124,10 @@ BOOL displayingLocalSymbolSend;
 - (void)viewDidDisappear:(BOOL)animated
 {
     [super viewDidDisappear:animated];
+
     [[NSNotificationCenter defaultCenter] removeObserver:self name:NOTIFICATION_KEY_LOADING_TEXT object:nil];
 
-    TabControllerManager *tabControllerManager = [AppCoordinator sharedInstance].tabControllerManager;
-    if (self.addressSource == DestinationAddressSourceContact && tabControllerManager.tabViewController.selectedIndex != TAB_SEND) [self reload];
+    [self reload];
 }
 
 - (void)viewDidLoad
@@ -769,7 +769,7 @@ BOOL displayingLocalSymbolSend;
     // Timeout so the keyboard is fully dismised - otherwise the second password modal keyboard shows the send screen kebyoard accessory
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         
-        if ([self transferAllMode] || self.addressSource == DestinationAddressSourceContact) {
+        if ([self transferAllMode]) {
             [[ModalPresenter sharedInstance].modalView.backButton addTarget:self action:@selector(reload) forControlEvents:UIControlEventTouchUpInside];
         }
         

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -325,7 +325,6 @@ BOOL displayingLocalSymbolSend;
     
     [self enableAmountViews];
     [self enableToField];
-    [self hideContactLabel];
     
     self.isSending = NO;
     self.isReloading = NO;
@@ -1239,11 +1238,6 @@ BOOL displayingLocalSymbolSend;
 - (CGFloat)defaultYPositionForWarningLabel
 {
     return IS_USING_SCREEN_SIZE_4S ? 76 : 112;
-}
-
-- (void)hideContactLabel
-{
-    contactLabel.hidden = YES;
 }
 
 - (void)disableToField

--- a/Blockchain/SendEtherViewController.m
+++ b/Blockchain/SendEtherViewController.m
@@ -176,6 +176,8 @@
 
 - (void)viewDidDisappear:(BOOL)animated
 {
+    [super viewDidDisappear:animated];
+
     [self reload];
 }
 

--- a/Blockchain/SendEtherViewController.m
+++ b/Blockchain/SendEtherViewController.m
@@ -174,6 +174,11 @@
     [self getHistory];
 }
 
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [self reload];
+}
+
 - (void)keepCurrentPayment
 {
     self.shouldKeepCurrentPayment = YES;

--- a/Blockchain/TabControllerManager.m
+++ b/Blockchain/TabControllerManager.m
@@ -100,8 +100,6 @@
         eventName = WALLET_EVENT_TX_FROM_URI;
     } else if (source == DestinationAddressSourceDropDown) {
         eventName = WALLET_EVENT_TX_FROM_DROPDOWN;
-    } else if (source == DestinationAddressSourceContact) {
-        eventName = WALLET_EVENT_TX_FROM_CONTACTS;
     } else if (source == DestinationAddressSourceNone) {
         DLog(@"Destination address source none");
         return;


### PR DESCRIPTION
Highlights in this PR:
- In the **Send** and **Request** views, amount fields are now cleared when navigating away from them.
- The **Send** view also resets the **To** field and the **Use total available minus fee** label.
- Removed more references to the deprecated **Contacts** feature.