### PR TITLE
fix(Pin): fix aspect ratio of pin entry keyboard to 19:16.

### DIFF
--- a/PinEntry/Classes/PEViewController.m
+++ b/PinEntry/Classes/PEViewController.m
@@ -80,7 +80,7 @@
             pin3.frame = CGRectOffset(pin3.frame, 0, offsetY);
             promptLabel.frame = CGRectOffset(promptLabel.frame, 0, offsetY);
         }
-        containerViewHeight = [[UIScreen mainScreen] bounds].size.height/HEIGHT_IPHONE_5S * 380;
+        containerViewHeight = UIScreen.mainScreen.bounds.size.width * 1.1875; // PIN entry view must be 19:16 aspect ratio
     }
     
     promptLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_LARGE];


### PR DESCRIPTION
Fixes the issue wherein the keyboard view was stretched on the iPhone X.

Screenshots:

**iPhone X:**
![iphone x](https://user-images.githubusercontent.com/38220701/42005559-0db095aa-7a2a-11e8-8d91-e93e2a6ccdb3.png)

**iPhone 6S:**
![iphone 6s](https://user-images.githubusercontent.com/38220701/42005565-11e04422-7a2a-11e8-9462-5f02cad0b468.png)

**iPhone 5S:**
![iphone 5s](https://user-images.githubusercontent.com/38220701/42005568-1598a104-7a2a-11e8-9c2d-e2c128ffa0d2.png)
