### PR TITLE
fix(UpgradeViewController): always present HD upgrade screen when authenticating with a legacy wallet

### DIFF
--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -92,17 +92,17 @@ import Foundation
     }
 
     /// Shows an upgrade to HD wallet prompt if the user has a legacy wallet
-    @objc func showHdUpgradeViewIfNeeded() {
+    func showHdUpgradeViewIfNeeded() {
         guard !walletManager.wallet.didUpgradeToHd() else { return }
         showHdUpgradeView()
     }
 
     /// Shows the HD wallet upgrade view
-    @objc func showHdUpgradeView() {
+    func showHdUpgradeView() {
         let storyboard = UIStoryboard(name: "Upgrade", bundle: nil)
         let upgradeViewController = storyboard.instantiateViewController(withIdentifier: "UpgradeViewController")
         upgradeViewController.modalTransitionStyle = .coverVertical
-        UIApplication.shared.keyWindow?.rootViewController?.topMostViewController?.present(
+        UIApplication.shared.keyWindow?.rootViewController?.present(
             upgradeViewController,
             animated: true
         )


### PR DESCRIPTION
Fixes issue where the upgrade prompt was not being presented open authenticating into a legacy wallet. The reason it wasn't shown was because the UpgradeViewController was being presented from a UIViewController that was not in the view hierarchy (i.e. from the PEViewController). Fix is to always present from the rootViewController.