### PR TITLE
fix(Dashboard): automatically adjust balance label font size

### DIFF
--- a/Blockchain/BCBalanceChartLegendKeyView.m
+++ b/Blockchain/BCBalanceChartLegendKeyView.m
@@ -44,6 +44,7 @@
         UILabel *balanceLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, fiatBalanceLabel.frame.origin.y + fiatBalanceLabel.frame.size.height, frame.size.width, labelHeight)];
         balanceLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_LIGHT size:fontSize];
         balanceLabel.textColor = labelTextColor;
+        balanceLabel.adjustsFontSizeToFitWidth = YES;
         [self addSubview:balanceLabel];
         self.balanceLabel = balanceLabel;
     }


### PR DESCRIPTION
Highlights in this PR:
- Dashboard: the font size of the balance label will now automatically shrink if the label's content exceed its own width.