### PR TITLE
fix(Swipe to Receive): make sure swipe to receive BCH funds goes to default address

### DIFF
--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -3094,9 +3094,10 @@ MyWalletPhone.bch = {
 
         var xpub = MyWallet.wallet.bch.defaultAccount.xpub
         var receiveIndex = MyWallet.wallet.bch.getAccountIndexes(xpub).receive;
+        const accountIndex = MyWallet.wallet.bch.defaultAccountIdx;
 
         for (var i = 0; i < numberOfAddresses; i++) {
-            var address = Helpers.toBitcoinCash(Blockchain.MyWallet.wallet.hdwallet.accounts[0].receiveAddressAtIndex(receiveIndex + i));
+            var address = Helpers.toBitcoinCash(Blockchain.MyWallet.wallet.hdwallet.accounts[accountIndex].receiveAddressAtIndex(receiveIndex + i));
             addresses.push(address);
         }
 


### PR DESCRIPTION
Fixes the issue where received funds always goes to the 1st BCH address. 

Tested that this works and verified that funds were always received to the correct address (the default address).