### PR TITLE
Fix assignment of dust property and fee amount

### DIFF
--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -1734,7 +1734,7 @@ BOOL displayingLocalSymbolSend;
     
     CGFloat warningLabelYPosition = [self defaultYPositionForWarningLabel];
     
-    if (availableAmount <= 0 || availableAmount < fee) {
+    if (availableAmount <= 0) {
         [lineBelowFeeField changeYPositionAnimated:warningLabelYPosition + 30 completion:^(BOOL finished) {
             if (self.feeType == FeeTypeCustom) {
                 [self setupFeeWarningLabelFrameSmall];

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -1378,17 +1378,6 @@ BOOL displayingLocalSymbolSend;
     }
 }
 
-
-- (uint64_t)dust
-{
-    if (self.assetType == LegacyAssetTypeBitcoin) {
-        return [WalletManager.sharedInstance.wallet dust];
-    } else if (self.assetType == LegacyAssetTypeBitcoinCash) {
-        
-    }
-    return 0;
-}
-
 - (void)checkIfOverspending
 {
     if (self.assetType == LegacyAssetTypeBitcoin) {
@@ -2088,7 +2077,6 @@ BOOL displayingLocalSymbolSend;
 
 - (IBAction)sendPaymentClicked:(id)sender
 {
-    // TODO: investigate if dust should be used
     if ([self.toAddress length] == 0) {
         self.toAddress = toField.text;
         DLog(@"toAddress: %@", self.toAddress);


### PR DESCRIPTION
Assignment of dust property:
- A property named `dust` is used to locally store the dust value for the frontend to use.
- The dust threshold `[app.wallet dust]` was called for when a contact transaction (deprecated feature) was to be created.
- When adding BCH, a method `-(uint64_t)dust` was added to replace `[app.wallet dust]` so that it could branch cleanly with an if statement depending on whether BTC or BCH was used.
- This change inadvertently started returning the dust threshold when `self.dust` was read. As a result, incorrect dust amounts were displayed.
- This issue could have been avoided if I had better named `Wallet.h`'s `dust` as `dustThreshold`.

Fee amount calculation:
- Origin: https://github.com/blockchain/My-Wallet-V3-iOS/commit/732ed311060d315d9ef89b77e428a5b8dcc501d5#diff-728b7b9d142662f5aea5ff7f0f50ebdeR1485
- Fees are incorrectly displayed on the confirm payment screen - they are different in the explorer/tx details.
- Unsure of why I added  `|| availableAmount < fee` - I deleted it here because the `fee` is factored into the `sweepAmount` returned from My-Wallet-V3, so as long as the `sweepAmount` is > 0, it is assumed that the fee can be afforded.