### PR TITLE
 fix(Onboarding Cards): guarantee that onboarding cards are shown when creating a new wallet

### DIFF
--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -127,10 +127,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             WalletManager.shared.close()
         }
 
-        if appSettings.hasSeenAllCards {
-            appSettings.shouldHideAllCards = true
-        }
-
         if appSettings.didFailBiometrySetup && !appSettings.biometryEnabled {
             appSettings.shouldShowBiometrySetup = true
         }

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -175,13 +175,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UIApplication.shared.applicationIconBadgeNumber = 0
     }
 
-    func applicationWillTerminate(_ application: UIApplication) {
-        let appSettings = BlockchainSettings.App.shared
-        appSettings.shouldHideAllCards = true
-        appSettings.hasSeenAllCards = true
-        appSettings.shouldHideBuySellCard = true
-    }
-
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
 
         let urlString = url.absoluteString

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -148,9 +148,6 @@ import Foundation
             return
         }
 
-        BlockchainSettings.App.shared.hasSeenAllCards = true
-        BlockchainSettings.App.shared.shouldHideAllCards = true
-
         if BlockchainSettings.App.shared.isPinSet {
             showPinEntryView()
             if let config = AppFeatureConfigurator.shared.configuration(for: .biometry),

--- a/Blockchain/BCCreateWalletView.m
+++ b/Blockchain/BCCreateWalletView.m
@@ -212,7 +212,7 @@
     BuySellCoordinator.sharedInstance.buyBitcoinViewController.isNew = YES;
     
     BlockchainSettings.sharedAppInstance.hasSeenAllCards = NO;
-    BlockchainSettings.sharedAppInstance.shouldHideAllCards = NO;
+    
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:USER_DEFAULTS_KEY_LAST_CARD_OFFSET];
 
     BlockchainSettings.sharedAppInstance.hasSeenEmailReminder = NO;

--- a/Blockchain/BCManualPairView.m
+++ b/Blockchain/BCManualPairView.m
@@ -132,7 +132,6 @@
     [passwordTextField resignFirstResponder];
     
     BlockchainSettings.sharedAppInstance.hasSeenAllCards = YES;
-    BlockchainSettings.sharedAppInstance.shouldHideAllCards = YES;
 
     [self.delegate manualPairView:self didContinueWithGuid:guid andPassword:password];
 }

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -510,8 +510,6 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 #define USER_DEFAULTS_KEY_HAS_SEEN_SURVEY_PROMPT @"hasSeenSurveyPrompt"
 //#define USER_DEFAULTS_KEY_REMINDER_MODAL_DATE @"reminderModalDate"
 //#define USER_DEFAUTS_KEY_HAS_ENDED_FIRST_SESSION @"hasEndedFirstSession"
-//#define USER_DEFAULTS_KEY_HAS_SEEN_ALL_CARDS @"hasSeenAllCards"
-//#define USER_DEFAULTS_KEY_SHOULD_HIDE_ALL_CARDS @"shouldHideAllCards"
 #define USER_DEFAULTS_KEY_LAST_CARD_OFFSET @"lastCardOffset"
 //#define USER_DEFAULTS_KEY_SHOULD_HIDE_BUY_SELL_CARD @"shouldHideBuySellNotificationCard"
 #define USER_DEFAULTS_KEY_SHOULD_HIDE_BITCOIN_CASH_CARD @"shouldHideBitcoinCashNotificationCard"

--- a/Blockchain/CardsViewController.m
+++ b/Blockchain/CardsViewController.m
@@ -59,7 +59,7 @@
 
 - (void)reloadCards
 {
-    self.showCards = !BlockchainSettings.sharedAppInstance.shouldHideAllCards;
+    self.showCards = !BlockchainSettings.sharedAppInstance.hasSeenAllCards;
     
     self.announcementCards = [NSMutableArray new];
     if (!self.showCards) {
@@ -418,8 +418,8 @@
     } completion:^(BOOL finished) {
         [self removeCardsView];
     }];
-    
-    BlockchainSettings.sharedAppInstance.shouldHideAllCards = YES;
+
+    BlockchainSettings.sharedAppInstance.hasSeenAllCards = YES;
 }
 
 - (void)removeCardsView

--- a/Blockchain/Extensions/UserDefaults.swift
+++ b/Blockchain/Extensions/UserDefaults.swift
@@ -35,7 +35,6 @@ extension UserDefaults {
         case pin = "pin"
         case pinKey = "pinKey"
         case reminderModalDate = "reminderModalDate"
-        case shouldHideAllCards = "shouldHideAllCards"
         case shouldHideBuySellCard = "shouldHideBuySellNotificationCard"
         case shouldShowBiometrySetup = "shouldShowBiometrySetup"
         case swipeToReceiveEnabled = "swipeToReceive"

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -222,15 +222,6 @@ final class BlockchainSettings: NSObject {
             }
         }
 
-        @objc var shouldHideAllCards: Bool {
-            get {
-                return defaults.bool(forKey: UserDefaults.Keys.shouldHideAllCards.rawValue)
-            }
-            set {
-                defaults.set(newValue, forKey: UserDefaults.Keys.shouldHideAllCards.rawValue)
-            }
-        }
-
         @objc var shouldHideBuySellCard: Bool {
             get {
                 return defaults.bool(forKey: UserDefaults.Keys.shouldHideBuySellCard.rawValue)

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -1578,7 +1578,6 @@
     [self useDebugSettingsIfSet];
 
     BlockchainSettings.sharedAppInstance.hasSeenAllCards = YES;
-    BlockchainSettings.sharedAppInstance.shouldHideAllCards = YES;
 
     [self.context evaluateScript:[NSString stringWithFormat:@"MyWalletPhone.parsePairingCode(\"%@\");", [code escapedForJS]]];
 }


### PR DESCRIPTION
The flag `hasSeenAllCards` was incorrectly being toggled to be set to `true` even though the user hasn't seen those cards upon creating a new wallet. This can happen if either the app is terminated or if the user backgrounds the app, and re-foregrounds it. 

With this PR, the only way to dismiss these cards now is to either view all of them, or by tapping on "Skip All".

**Summary of changes**:
* remove areas in the code wherein `hasSeenAllCards` should not be set to _true_
* remove redundant flag `shouldHideAllCards`

Tested this by creating a new wallet, background/foreground app, and verified that the onboarding cards are still shown.