### PR TITLE
fix(Alerts): fix issue where alerts are sometimes not presented.

### DIFF
--- a/Blockchain/Alerts/AlertViewPresenter.swift
+++ b/Blockchain/Alerts/AlertViewPresenter.swift
@@ -138,7 +138,7 @@ import Foundation
         DispatchQueue.main.async {
             let window = UIApplication.shared.keyWindow
             let rootController = window?.rootViewController
-            let presentingViewController = viewController ?? rootController ?? rootController?.topMostViewController
+            let presentingViewController = viewController ?? rootController?.topMostViewController ?? rootController
             presentingViewController?.present(alert, animated: true)
         }
     }


### PR DESCRIPTION
Issue was because an alert was trying to be presented from ECSlidingViewController which was not the top most view controller (there was another view controller presented on top of it).

With this change, I tested that alerts were being presented when tapping on "Import Addresses" from the addresses view. Also tested a bunch of other scenarios in that app where an alert should be presented and verified that it did.