### PR TITLE
 fix(Send): show missing fields on confirmation screen

### DIFF
--- a/Blockchain/BCAddressSelectionView.m
+++ b/Blockchain/BCAddressSelectionView.m
@@ -133,7 +133,7 @@ typedef enum {
             
             if (assetType == LegacyAssetTypeEther || (selectMode == SelectModeExchangeAccountFrom && [WalletManager.sharedInstance.wallet hasEthAccount])) {
                 [ethAccounts addObject:[NSNumber numberWithInt:0]];
-                [ethAccountLabels addObject:BC_STRING_MY_ETHER_WALLET];
+                [ethAccountLabels addObject:[LocalizationConstantsObjcBridge myEtherWallet]];
             }
 
             addressBookSectionNumber = -1;
@@ -180,7 +180,7 @@ typedef enum {
 
             if ([self.delegate getAssetType] == LegacyAssetTypeEther || (selectMode == SelectModeExchangeAccountTo && [WalletManager.sharedInstance.wallet hasEthAccount])) {
                 [ethAccounts addObject:[NSNumber numberWithInt:0]];
-                [ethAccountLabels addObject:BC_STRING_MY_ETHER_WALLET];
+                [ethAccountLabels addObject:[LocalizationConstantsObjcBridge myEtherWallet]];
             }
 
             btcAccountsSectionNumber = btcAccounts.count > 0 ? 0 : -1;
@@ -466,7 +466,7 @@ typedef enum {
             cell.addressLabel.text = nil;
         }
         else if (section == ethAccountsSectionNumber) {
-            label = BC_STRING_MY_ETHER_WALLET;
+            label = [LocalizationConstantsObjcBridge myEtherWallet];
             cell.addressLabel.text = nil;
         }
         else if (section == bchAccountsSectionNumber) {

--- a/Blockchain/BCConfirmPaymentView.m
+++ b/Blockchain/BCConfirmPaymentView.m
@@ -35,7 +35,7 @@
         
         BCTotalAmountView *totalAmountView = [[BCTotalAmountView alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, TOTAL_AMOUNT_VIEW_HEIGHT) color:COLOR_BLOCKCHAIN_RED amount:0];
         
-        totalAmountView.btcAmountLabel.text = self.viewModel.btcTotalAmountText;
+        totalAmountView.btcAmountLabel.text = self.viewModel.totalAmountText;
         totalAmountView.fiatAmountLabel.text = self.viewModel.fiatTotalAmountText;
         
         [self addSubview:totalAmountView];
@@ -109,8 +109,8 @@
     if (self.viewModel.from) [self.rows addObject:@[BC_STRING_FROM, self.viewModel.from]];
     if (self.viewModel.to) [self.rows addObject:@[BC_STRING_TO, self.viewModel.to]];
     if (self.viewModel.showDescription) [self.rows addObject:@[BC_STRING_DESCRIPTION, self.viewModel.noteText ? : @""]];
-    if (self.viewModel.btcWithFiatAmountText) [self.rows addObject:@[BC_STRING_AMOUNT, self.viewModel.btcWithFiatAmountText]];
-    if (self.viewModel.btcWithFiatFeeText) [self.rows addObject:@[BC_STRING_FEE, self.viewModel.btcWithFiatFeeText]];
+    if (self.viewModel.cryptoWithFiatAmountText) [self.rows addObject:@[BC_STRING_AMOUNT, self.viewModel.cryptoWithFiatAmountText]];
+    if (self.viewModel.amountWithFiatFeeText) [self.rows addObject:@[BC_STRING_FEE, self.viewModel.amountWithFiatFeeText]];
 }
 
 - (void)reallyDoPaymentButtonClicked
@@ -169,14 +169,13 @@
     if (self.isEditingDescription) {
         cell = [self configureDescriptionTextViewForCell:cell];
     } else {
-        
         NSString *textLabel = [self.rows[indexPath.row] firstObject];
         NSString *detailTextLabel = [self.rows[indexPath.row] lastObject];
 
         cell.textLabel.text = textLabel;
         cell.detailTextLabel.text = detailTextLabel;
         
-        cell.detailTextLabel.adjustsFontSizeToFitWidth = [textLabel isEqualToString:BC_STRING_FROM] || [textLabel isEqualToString:BC_STRING_TO];
+        cell.detailTextLabel.adjustsFontSizeToFitWidth = [textLabel isEqualToString:BC_STRING_FROM] || [textLabel isEqualToString:BC_STRING_TO] || [textLabel isEqualToString:BC_STRING_AMOUNT];
         
         if ([textLabel isEqualToString:BC_STRING_FEE]) {
             UILabel *testLabel = [[UILabel alloc] initWithFrame:CGRectZero];

--- a/Blockchain/BCConfirmPaymentViewModel.h
+++ b/Blockchain/BCConfirmPaymentViewModel.h
@@ -34,10 +34,10 @@
 
 @property (nonatomic) NSString *from;
 @property (nonatomic) NSString *to;
+@property (nonatomic) NSString *totalAmountText;
 @property (nonatomic) NSString *fiatTotalAmountText;
-@property (nonatomic) NSString *btcTotalAmountText;
-@property (nonatomic) NSString *btcWithFiatAmountText;
-@property (nonatomic) NSString *btcWithFiatFeeText;
+@property (nonatomic) NSString *cryptoWithFiatAmountText;
+@property (nonatomic) NSString *amountWithFiatFeeText;
 @property (nonatomic) NSString *noteText;
 @property (nonatomic) NSString *buttonTitle;
 @property (nonatomic) BOOL showDescription;

--- a/Blockchain/BCConfirmPaymentViewModel.m
+++ b/Blockchain/BCConfirmPaymentViewModel.m
@@ -29,9 +29,9 @@
         self.surgeIsOccurring = surgePresent;
         self.buttonTitle = BC_STRING_SEND;
         self.fiatTotalAmountText = [NSNumberFormatter formatMoney:total localCurrency:YES];
-        self.btcTotalAmountText = [NSNumberFormatter formatBTC:total];
-        self.btcWithFiatAmountText = [self formatAmountInBTCAndFiat:amount];
-        self.btcWithFiatFeeText = [self formatAmountInBTCAndFiat:fee];
+        self.totalAmountText = [NSNumberFormatter formatBTC:total];
+        self.cryptoWithFiatAmountText = [self formatAmountInBTCAndFiat:amount];
+        self.amountWithFiatFeeText = [self formatAmountInBTCAndFiat:fee];
         self.showDescription = YES;
     }
     return self;
@@ -46,10 +46,12 @@
        fiatTotal:(NSString *)fiatTotal
 {
     if (self == [super init]) {
+        self.from = BC_STRING_MY_ETHER_WALLET;
         self.to = to;
         self.fiatTotalAmountText = fiatTotal;
-        self.btcTotalAmountText = ethTotal;
-        self.btcWithFiatFeeText = [NSString stringWithFormat:@"%@ (%@)", ethFee, fiatFee];
+        self.totalAmountText = ethTotal;
+        self.cryptoWithFiatAmountText = [NSString stringWithFormat:@"%@ (%@)", ethAmount, fiatAmount];
+        self.amountWithFiatFeeText = [NSString stringWithFormat:@"%@ (%@)", ethFee, fiatFee];
         self.showDescription = YES;
     }
     return self;
@@ -70,10 +72,10 @@
         self.surgeIsOccurring = surgePresent;
         
         self.fiatTotalAmountText = [NSNumberFormatter formatBchWithSymbol:total localCurrency:YES];
-        self.btcTotalAmountText = [NSNumberFormatter formatBCH:total];
-        self.btcWithFiatAmountText = [self formatAmountInBCHAndFiat:amount];
-        self.btcWithFiatFeeText = [self formatAmountInBCHAndFiat:fee];
-        self.showDescription = NO;
+        self.totalAmountText = [NSNumberFormatter formatBCH:total];
+        self.cryptoWithFiatAmountText = [self formatAmountInBCHAndFiat:amount];
+        self.amountWithFiatFeeText = [self formatAmountInBCHAndFiat:fee];
+        self.showDescription = YES;
         
         if ([WalletManager.sharedInstance.wallet isValidAddress:self.to assetType:LegacyAssetTypeBitcoin]) {
             CGFloat fontSize = FONT_SIZE_EXTRA_SMALL;

--- a/Blockchain/BCConfirmPaymentViewModel.m
+++ b/Blockchain/BCConfirmPaymentViewModel.m
@@ -46,7 +46,7 @@
        fiatTotal:(NSString *)fiatTotal
 {
     if (self == [super init]) {
-        self.from = BC_STRING_MY_ETHER_WALLET;
+        self.from = [LocalizationConstantsObjcBridge myEtherWallet];
         self.to = to;
         self.fiatTotalAmountText = fiatTotal;
         self.totalAmountText = ethTotal;

--- a/Blockchain/LocalizationConstants.h
+++ b/Blockchain/LocalizationConstants.h
@@ -600,8 +600,6 @@
 #define BC_STRING_NOW_SUPPORTING_ETHER_DESCRIPTION NSLocalizedString(@"You asked, we listened. We’re excited to announce that your Blockchain wallet will now allow you to seamlessly send and receive ether!", nil)
 #define BC_STRING_GET_STARTED_WITH_ETHER NSLocalizedString(@"Get Started with Ether", nil)
 
-#define BC_STRING_MY_ETHER_WALLET NSLocalizedString(@"My Ether Wallet", nil)
-
 #define BC_STRING_EXCHANGE NSLocalizedString(@"Exchange", nil)
 #define BC_STRING_NEW_EXCHANGE NSLocalizedString(@"New Exchange", nil)
 #define BC_STRING_USE_MINIMUM NSLocalizedString(@"Use minimum", nil)

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -42,6 +42,10 @@ struct LocalizationConstants {
         "Don't show again",
         comment: "Text displayed to the user when an action has the option to not be asked again."
     )
+    static let myEtherWallet = NSLocalizedString(
+        "My Ether Wallet",
+        comment: "The default name of the ether wallet."
+    )
 
     struct Errors {
         static let error = NSLocalizedString("Error", comment: "")
@@ -415,4 +419,6 @@ struct LocalizationConstants {
     @objc class func pinsDoNotMatch() -> String { return LocalizationConstants.Pin.pinsDoNotMatch }
 
     @objc class func dontShowAgain() -> String { return LocalizationConstants.dontShowAgain }
+
+    @objc class func myEtherWallet() -> String { return LocalizationConstants.myEtherWallet }
 }

--- a/Blockchain/SendEtherViewController.m
+++ b/Blockchain/SendEtherViewController.m
@@ -363,7 +363,7 @@
                                                               ethAmount:[NSNumberFormatter formatEth:self.ethAmount]
                                                               ethFee:[NSNumberFormatter formatEth:self.ethFee]
                                                               ethTotal:[NSNumberFormatter formatEth:[NSNumberFormatter truncatedEthAmount:totalDecimalNumber locale:nil]]
-                                                              fiatAmount:[NSNumberFormatter appendStringToFiatSymbol:self.amountInputView.fiatField.text]
+                                                              fiatAmount:[NSNumberFormatter formatEthToFiatWithSymbol:[self.ethAmount stringValue] exchangeRate:self.latestExchangeRate]
                                                               fiatFee:[NSNumberFormatter formatEthToFiatWithSymbol:[self.ethFee stringValue] exchangeRate:self.latestExchangeRate]
                                                               fiatTotal:[NSNumberFormatter formatEthToFiatWithSymbol:[NSString stringWithFormat:@"%@", totalDecimalNumber] exchangeRate:self.latestExchangeRate]];
         

--- a/Blockchain/SendEtherViewController.m
+++ b/Blockchain/SendEtherViewController.m
@@ -68,7 +68,7 @@
     UILabel *fromPlaceholderLabel = [[UILabel alloc] initWithFrame:CGRectMake(fromPlaceholderLabelOriginX, 8, self.view.frame.size.width - fromPlaceholderLabelOriginX, 30)];
     fromPlaceholderLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_LIGHT size:FONT_SIZE_SMALL];
     fromPlaceholderLabel.textColor = COLOR_TEXT_DARK_GRAY;
-    fromPlaceholderLabel.text = BC_STRING_MY_ETHER_WALLET;
+    fromPlaceholderLabel.text = [LocalizationConstantsObjcBridge myEtherWallet];
     [self.view addSubview:fromPlaceholderLabel];
     
     BCLine *lineAboveToField = [self offsetLineWithYPosition:ROW_HEIGHT_SEND_SMALL];


### PR DESCRIPTION
Highlights in this PR:
- Shows the missing fields on the ethereum payment confirmation screen.

Tested with different local currency symbols to ensure it works.