### PR TITLE
refactor(NetworkManager): returning Single instead of Observable for requestJsonOrString

### DIFF
--- a/Blockchain/Network/API/WalletService.swift
+++ b/Blockchain/Network/API/WalletService.swift
@@ -28,7 +28,7 @@ import RxSwift
         return networkManager.requestJsonOrString(
             BlockchainAPI.shared.walletOptionsUrl,
             method: .get
-        ).asSingle().map {
+        ).map {
             guard $0.statusCode == 200 else {
                 throw WalletServiceError.generic(message: nil)
             }
@@ -74,6 +74,6 @@ import RxSwift
             BlockchainAPI.shared.pinStore,
             method: .post,
             parameters: parameters
-        ).asSingle()
+        )
     }
 }

--- a/BlockchainTests/Mock/MockNetworkManager.swift
+++ b/BlockchainTests/Mock/MockNetworkManager.swift
@@ -35,12 +35,12 @@ class MockNetworkManager: NetworkManager {
         _ url: String,
         method: HttpMethod,
         parameters: URLParameters? = nil
-    ) -> Observable<(HTTPURLResponse, Any)> {
+    ) -> Single<(HTTPURLResponse, Any)> {
         guard let mockResponse = mockResponse else {
             print("No mock response set, performing actual network call")
             return super.requestJsonOrString(url, method: method, parameters: parameters)
         }
-        return Observable.just(mockResponse)
+        return Single.just(mockResponse)
     }
 
 }


### PR DESCRIPTION
Returning a Single instead of an Observable in `NetworkManager#requestJsonOrString` since only one item is emitted.

Tested this by running the app and making sure that pin validation still works and also verifying that unit tests still all pass.