### PR TITLE
fix(Payment Received): fix payment received alert not shown on pin screen

### DIFF
--- a/Blockchain/TabControllerManager.m
+++ b/Blockchain/TabControllerManager.m
@@ -74,7 +74,7 @@
 
 - (void)onPaymentReceivedWithAmount:(NSString * _Nonnull)amount assetType:(enum AssetType)assetType
 {
-    [AlertViewPresenter.sharedInstance standardNotifyWithMessage:amount title:BC_STRING_PAYMENT_RECEIVED in:self handler:nil];
+    [AlertViewPresenter.sharedInstance standardNotifyWithMessage:amount title:BC_STRING_PAYMENT_RECEIVED in:nil handler:nil];
 
     LegacyAssetType legacyType = [AssetTypeLegacyHelper convertToLegacy: assetType];
     


### PR DESCRIPTION
Looks like it wasn't being presented because of the change wherein the alert was trying to be presented from `TabControllerManager` which is not in the foreground. Setting the "in:" parameter to `nil` will use the `topMostViewController` so that the alert is presented correctly.

These are the sort of side-effects that having a single delegate on the `Wallet` create. Once we get to refactoring websockets out of the `Wallet`, we'll have a more robust solution.