### PR TITLE
fix(Pin): Make sure pin input is properly reseted when an alert is presented

### DIFF
--- a/PinEntry/Classes/PEPinEntryController.m
+++ b/PinEntry/Classes/PEPinEntryController.m
@@ -133,7 +133,10 @@ static PEViewController *VerifyController()
 
 - (void)reset
 {
-    [pinController resetPin];
+    UIViewController * viewController = self.viewControllers.firstObject;
+    if ([viewController isKindOfClass:[PEViewController class]]) {
+        [((PEViewController *) viewController) resetPin];
+    }
 }
 
 - (void)setupQRCode
@@ -366,10 +369,6 @@ static PEViewController *VerifyController()
                                                              in:self
                                                         handler:^(UIAlertAction * _Nonnull action) {
                                                             [weakSelf reset];
-                                                            UIViewController * viewController = weakSelf.viewControllers.firstObject;
-                                                            if ([viewController isKindOfClass:[PEViewController class]]) {
-                                                                [((PEViewController *) viewController) resetPin];
-                                                            }
                                                         }];
 }
 


### PR DESCRIPTION
Fixes the issue wherein the circles in the pin entry view sometimes don't get cleared when an alert is presented.