### PR TITLE
fix(Pin): make sure user is prompted to create new pin upon entering password

### DIFF
--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -213,6 +213,8 @@ import RxSwift
     @objc func logout(showPasswordView: Bool) {
         invalidateLoginTimeout()
 
+        pinEntryViewController = nil
+
         BlockchainSettings.App.shared.clearPin()
 
         WalletManager.shared.close()

--- a/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
@@ -119,9 +119,9 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
     func errorDidFailPutPin(errorMessage: String) {
         LoadingViewPresenter.shared.hideBusyView()
 
-        AlertViewPresenter.shared.standardError(message: errorMessage)
-
-        reopenChangePin()
+        AlertViewPresenter.shared.standardError(message: errorMessage) { [unowned self] _ in
+            self.reopenChangePin()
+        }
     }
 
     func putPinSuccess(response: PutPinResponse) {


### PR DESCRIPTION
Fixes the issue wherein when the user is prompted to enter their password after incorrectly entering their pin 4 times, they aren't asked to create a new pin.