### PR TITLE
fix(Send, PrivateKeyReader): remove reload and show import error alerts

### DIFF
--- a/Blockchain/AccountsAndAddressesViewController.m
+++ b/Blockchain/AccountsAndAddressesViewController.m
@@ -235,20 +235,6 @@
     [WalletManager.sharedInstance.wallet addKey:privateKey];
 }
 
-- (void)didFinishScanningWithError:(PrivateKeyReaderError)error {
-    switch (error) {
-        case PrivateKeyReaderErrorBadMetadataObject:
-            [[AlertViewPresenter sharedInstance] standardErrorWithMessage:[LocalizationConstantsObjcBridge error] title:[LocalizationConstantsObjcBridge error] in:self handler:nil];
-            break;
-        case PrivateKeyReaderErrorUnknownKeyFormat:
-            [[AlertViewPresenter sharedInstance] standardErrorWithMessage:[LocalizationConstantsObjcBridge unknownKeyFormat] title:[LocalizationConstantsObjcBridge error] in:self handler:nil];
-            break;
-        case PrivateKeyReaderErrorUnsupportedPrivateKey:
-            [[AlertViewPresenter sharedInstance] standardErrorWithMessage:[LocalizationConstantsObjcBridge unsupportedPrivateKey] title:[LocalizationConstantsObjcBridge error] in:self handler:nil];
-            break;
-    }
-}
-
 - (void)promptForLabelAfterScan
 {
     //: Newest address is the last object in activeKeys

--- a/Blockchain/Coordinators/KeyImportCoordinator.swift
+++ b/Blockchain/Coordinators/KeyImportCoordinator.swift
@@ -131,7 +131,7 @@ extension KeyImportCoordinator: WalletKeyImportDelegate {
         let importedKeyButForIncorrectAddress = LocalizationConstants.AddressAndKeyImport.importedKeyButForIncorrectAddress
         let importedKeyDoesNotCorrespondToAddress = LocalizationConstants.AddressAndKeyImport.importedKeyDoesNotCorrespondToAddress
         let message = String(format: "%@\n\n%@", importedKeyButForIncorrectAddress, importedKeyDoesNotCorrespondToAddress)
-        AlertViewPresenter.shared.standardNotify(message: message, title: LocalizationConstants.okString, handler: nil)
+        AlertViewPresenter.shared.standardNotify(message: message, title: LocalizationConstants.success, handler: nil)
     }
 
     @objc func alertUserOfImportedKey() {

--- a/Blockchain/Coordinators/KeyImportCoordinator.swift
+++ b/Blockchain/Coordinators/KeyImportCoordinator.swift
@@ -265,8 +265,4 @@ extension KeyImportCoordinator: PrivateKeyReaderDelegate {
     func didFinishScanning(_ privateKey: String, for address: AssetAddress?) {
         walletManager.wallet.addKey(privateKey, toWatchOnlyAddress: address?.address)
     }
-
-    func didFinishScanningWithError(_ error: PrivateKeyReaderError) {
-        // No custom implementation - error presentation handled by PrivateKeyReader
-    }
 }

--- a/Blockchain/Coordinators/KeyImportCoordinator.swift
+++ b/Blockchain/Coordinators/KeyImportCoordinator.swift
@@ -267,13 +267,6 @@ extension KeyImportCoordinator: PrivateKeyReaderDelegate {
     }
 
     func didFinishScanningWithError(_ error: PrivateKeyReaderError) {
-        switch error {
-        case .badMetadataObject:
-            AlertViewPresenter.shared.standardError(message: LocalizationConstants.Errors.error)
-        case .unknownKeyFormat:
-            AlertViewPresenter.shared.standardError(message: LocalizationConstants.AddressAndKeyImport.unknownKeyFormat)
-        case .unsupportedPrivateKey:
-            AlertViewPresenter.shared.standardError(message: LocalizationConstants.AddressAndKeyImport.unsupportedPrivateKey)
-        }
+        // No custom implementation - error presentation handled by PrivateKeyReader
     }
 }

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -234,9 +234,9 @@ struct LocalizationConstants {
         static let unknownErrorPrivateKey = NSLocalizedString("There was an error importing this private key.", comment: "")
         static let addressNotPresentInWallet = NSLocalizedString("Your wallet does not contain this address.", comment: "")
         static let addressNotWatchOnly = NSLocalizedString("This address is not watch-only.", comment: "")
-        static let keyBelongsToOtherAddressNotWatchOnly = NSLocalizedString("This private key belongs to another address that is not watch only.", comment: "")
-        static let unknownKeyFormat = NSLocalizedString("Unknown key format.", comment: "")
-        static let unsupportedPrivateKey = NSLocalizedString("Unsupported Private Key Format,", comment: "")
+        static let keyBelongsToOtherAddressNotWatchOnly = NSLocalizedString("This private key belongs to another address that is not watch only", comment: "")
+        static let unknownKeyFormat = NSLocalizedString("Unknown key format", comment: "")
+        static let unsupportedPrivateKey = NSLocalizedString("Unsupported Private Key Format", comment: "")
         static let addWatchOnlyAddressWarning = NSLocalizedString("You are about to import a watch-only address, an address (or public key script) stored in the wallet without the corresponding private key. This means that the funds can be spent ONLY if you have the private key stored elsewhere. If you do not have the private key stored, do NOT instruct anyone to send you bitcoin to the watch-only address.", comment: "")
         static let addWatchOnlyAddressWarningPrompt = NSLocalizedString("These options are recommended for advanced users only. Continue?", comment: "")
     }

--- a/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
+++ b/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-protocol PrivateKeyReaderDelegate: class {
+@objc protocol PrivateKeyReaderDelegate: class {
     func didFinishScanning(_ privateKey: String, for address: AssetAddress?)
-    func didFinishScanningWithError(_ error: PrivateKeyReaderError)
+    @objc optional func didFinishScanningWithError(_ error: PrivateKeyReaderError)
 }
 
 // TODO: remove once AccountsAndAddresses and SendBitcoinViewController are migrated to Swift
@@ -181,7 +181,7 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
             metadataObject.type == .qr,
             let codeObject = metadataObject as? AVMetadataMachineReadableCodeObject,
             let stringValue = codeObject.stringValue else {
-                delegate?.didFinishScanningWithError(.badMetadataObject)
+                delegate?.didFinishScanningWithError?(.badMetadataObject)
                 // TODO: remove once LegacyPrivateKeyDelegate is deprecated
                 legacyDelegate?.didFinishScanningWithError(.badMetadataObject)
                 return
@@ -235,7 +235,7 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
     }
 
     func didFinishScanningWithError(_ error: PrivateKeyReaderError) {
-        self.delegate?.didFinishScanningWithError(error)
+        self.delegate?.didFinishScanningWithError?(error)
         // TODO: remove once LegacyPrivateKeyDelegate is deprecated
         self.legacyDelegate?.didFinishScanningWithError(error)
 

--- a/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
+++ b/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
@@ -16,7 +16,7 @@ import Foundation
 // TODO: remove once AccountsAndAddresses and SendBitcoinViewController are migrated to Swift
 @objc protocol LegacyPrivateKeyDelegate: class {
     func didFinishScanning(_ privateKey: String)
-    func didFinishScanningWithError(_ error: PrivateKeyReaderError)
+    @objc optional func didFinishScanningWithError(_ error: PrivateKeyReaderError)
 }
 
 @objc enum PrivateKeyReaderError: Int {
@@ -183,7 +183,7 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
             let stringValue = codeObject.stringValue else {
                 delegate?.didFinishScanningWithError?(.badMetadataObject)
                 // TODO: remove once LegacyPrivateKeyDelegate is deprecated
-                legacyDelegate?.didFinishScanningWithError(.badMetadataObject)
+                legacyDelegate?.didFinishScanningWithError?(.badMetadataObject)
                 return
         }
 
@@ -237,7 +237,7 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
     func didFinishScanningWithError(_ error: PrivateKeyReaderError) {
         self.delegate?.didFinishScanningWithError?(error)
         // TODO: remove once LegacyPrivateKeyDelegate is deprecated
-        self.legacyDelegate?.didFinishScanningWithError(error)
+        self.legacyDelegate?.didFinishScanningWithError?(error)
 
         switch error {
         case .badMetadataObject:

--- a/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
+++ b/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
@@ -211,28 +211,41 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
                         let address = BitcoinAddress(string: scannedKey)
                         let validator = AddressValidator(context: WalletManager.shared.wallet.context)
                         guard validator.validate(bitcoinAddress: address) else {
-                                self.delegate?.didFinishScanningWithError(.unknownKeyFormat)
-                                // TODO: remove once LegacyPrivateKeyDelegate is deprecated
-                                self.legacyDelegate?.didFinishScanningWithError(.unknownKeyFormat)
-                                return
+                            self.didFinishScanningWithError(.unknownKeyFormat)
+                            return
                         }
                         WalletManager.shared.askUserToAddWatchOnlyAddress(address) {
-                            self.delegate?.didFinishScanning(scannedKey, for: address)
-                            // TODO: remove once LegacyPrivateKeyDelegate is deprecated
-                            self.legacyDelegate?.didFinishScanning(scannedKey)
+                            self.didFinishScanning(scannedKey, for: address)
                         }
                     } else {
-                        self.delegate?.didFinishScanningWithError(.unsupportedPrivateKey)
-                        // TODO: remove once LegacyPrivateKeyDelegate is deprecated
-                        self.legacyDelegate?.didFinishScanningWithError(.unsupportedPrivateKey)
+                        self.didFinishScanningWithError(.unsupportedPrivateKey)
                     }
                     return
                 }
                 //: Pass valid private key back via success handler
-                self.delegate?.didFinishScanning(scannedKey, for: self.assetAddress)
-                // TODO: remove once LegacyPrivateKeyDelegate is deprecated
-                self.legacyDelegate?.didFinishScanning(scannedKey)
+                self.didFinishScanning(scannedKey, for: self.assetAddress)
             }
+        }
+    }
+
+    func didFinishScanning(_ privateKey: String, for address: AssetAddress?) {
+        self.delegate?.didFinishScanning(privateKey, for: address)
+        // TODO: remove once LegacyPrivateKeyDelegate is deprecated
+        self.legacyDelegate?.didFinishScanning(privateKey)
+    }
+
+    func didFinishScanningWithError(_ error: PrivateKeyReaderError) {
+        self.delegate?.didFinishScanningWithError(error)
+        // TODO: remove once LegacyPrivateKeyDelegate is deprecated
+        self.legacyDelegate?.didFinishScanningWithError(error)
+
+        switch error {
+        case .badMetadataObject:
+            AlertViewPresenter.shared.standardError(message: LocalizationConstants.Errors.error)
+        case .unknownKeyFormat:
+            AlertViewPresenter.shared.standardError(message: LocalizationConstants.AddressAndKeyImport.unknownKeyFormat)
+        case .unsupportedPrivateKey:
+            AlertViewPresenter.shared.standardError(message: LocalizationConstants.AddressAndKeyImport.unsupportedPrivateKey)
         }
     }
 }

--- a/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
+++ b/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
@@ -181,9 +181,7 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
             metadataObject.type == .qr,
             let codeObject = metadataObject as? AVMetadataMachineReadableCodeObject,
             let stringValue = codeObject.stringValue else {
-                delegate?.didFinishScanningWithError?(.badMetadataObject)
-                // TODO: remove once LegacyPrivateKeyDelegate is deprecated
-                legacyDelegate?.didFinishScanningWithError?(.badMetadataObject)
+                self.didFinishScanningWithError(.badMetadataObject)
                 return
         }
 

--- a/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
+++ b/Blockchain/PrivateKeyReader/PrivateKeyReader.swift
@@ -228,13 +228,13 @@ final class PrivateKeyReader: UIViewController & AVCaptureMetadataOutputObjectsD
         }
     }
 
-    func didFinishScanning(_ privateKey: String, for address: AssetAddress?) {
+    private func didFinishScanning(_ privateKey: String, for address: AssetAddress?) {
         self.delegate?.didFinishScanning(privateKey, for: address)
         // TODO: remove once LegacyPrivateKeyDelegate is deprecated
         self.legacyDelegate?.didFinishScanning(privateKey)
     }
 
-    func didFinishScanningWithError(_ error: PrivateKeyReaderError) {
+    private func didFinishScanningWithError(_ error: PrivateKeyReaderError) {
         self.delegate?.didFinishScanningWithError?(error)
         // TODO: remove once LegacyPrivateKeyDelegate is deprecated
         self.legacyDelegate?.didFinishScanningWithError?(error)

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -125,8 +125,6 @@ BOOL displayingLocalSymbolSend;
     [super viewDidDisappear:animated];
 
     [[NSNotificationCenter defaultCenter] removeObserver:self name:NOTIFICATION_KEY_LOADING_TEXT object:nil];
-
-    [self reload];
 }
 
 - (void)viewDidLoad


### PR DESCRIPTION
Issue:
unable to send from watch-only address - after scanning a private key, nothing happens, and infinite spinner results.

Stack:
`KeyImportCoordinator` presents view controller to scan private key -> `SendBitcoinViewController`'s `viewDidDisappear` -> `reload` -> `self.fromAddress = @""`

Notes:
This will reopen the bug that the `reload` in `SendBitcoinViewController`'s `viewDidDisappear` was intended to fix, which was clearing the fields when navigating away from them (reminder: do not link the tickets on github).

My suggestion is to avoid trying to clear the fields until further wallet refactoring since it could create mismatching states between the UI and payment object.

Requesting feedback on moving the import error alert presentation to the `PrivateKeyReader` - I feel like it does belong in the `KeyImportCoordinator`, but it would seem a bit much to add another delegate to `PrivateKeyReader`.

Other fixes:
- Fixed strings to match translations
- Changed string used in alert.