### PR TITLE
fix(Exchange): show continue button when selecting 'use minimum/maximum'

### DIFF
--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -264,7 +264,9 @@
     [continueButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
     continueButton.titleLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:17.0];
     [continueButton setTitle:BC_STRING_CONTINUE forState:UIControlStateNormal];
-    continueButton.center = CGPointMake(self.view.center.x, self.view.frame.size.height - 24 - BUTTON_HEIGHT/2);
+    CGFloat safeAreaInsetTop = UIView.rootViewSafeAreaInsets.top;
+    CGFloat continueButtonCenterY = self.view.frame.size.height - 24 - BUTTON_HEIGHT/2 - safeAreaInsetTop - ConstantsObjcBridge.defaultNavigationBarHeight;
+    continueButton.center = CGPointMake(self.view.center.x, continueButtonCenterY);
     [self.view addSubview:continueButton];
     [continueButton addTarget:self action:@selector(continueButtonClicked) forControlEvents:UIControlEventTouchUpInside];
     self.continueButton = continueButton;
@@ -993,26 +995,11 @@
     
     [self updateAvailableBalance];
 
-    [self showKeyboardOnAutoFillIfNeeded];
+    [self hideKeyboard];
     
     [self disablePaymentButtons];
     
     [self performSelector:@selector(getApproximateQuote) withObject:nil afterDelay:0.5];
-}
-
-/**
- Conditionally displays the keyboard when the fields are autofilled. This is necessary because
- the continue button is only visible while the keyboard is shown.
- */
-- (void)showKeyboardOnAutoFillIfNeeded
-{
-    if (self.topLeftField.isFirstResponder ||
-        self.topRightField.isFirstResponder ||
-        self.bottomLeftField.isFirstResponder ||
-        self.bottomRightField.isFirstResponder) {
-        return;
-    }
-    [self.topLeftField becomeFirstResponder];
 }
 
 - (void)showErrorText:(NSString *)errorText

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -992,12 +992,27 @@
     self.bottomLeftField.text = fiatResult;
     
     [self updateAvailableBalance];
-    
-    [self hideKeyboard];
+
+    [self showKeyboardOnAutoFillIfNeeded];
     
     [self disablePaymentButtons];
     
     [self performSelector:@selector(getApproximateQuote) withObject:nil afterDelay:0.5];
+}
+
+/**
+ Conditionally displays the keyboard when the fields are autofilled. This is necessary because
+ the continue button is only visible while the keyboard is shown.
+ */
+- (void)showKeyboardOnAutoFillIfNeeded
+{
+    if (self.topLeftField.isFirstResponder ||
+        self.topRightField.isFirstResponder ||
+        self.bottomLeftField.isFirstResponder ||
+        self.bottomRightField.isFirstResponder) {
+        return;
+    }
+    [self.topLeftField becomeFirstResponder];
 }
 
 - (void)showErrorText:(NSString *)errorText


### PR DESCRIPTION
Fixes the issue wherein tapping on 'Use minimum' or 'Use maximum' does not allow the user to continue until they tap on a UITextField.

With this change, if the user taps on those buttons and the keyboard isn't presented, the topLeftField will become the first responder so that the keyboard is presented.