### PR TITLE
fix(App Review): show prompt on third completed transaction regardless of how often the application has become active

### DIFF
--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -40,6 +40,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         Fabric.with([Crashlytics.self])
 
+        BlockchainSettings.App.shared.appBecameActiveCount += 1
+
         // MARK: - Global Appearance
 
         //: Status Bar
@@ -153,7 +155,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillEnterForeground(_ application: UIApplication) {
         print("applicationWillEnterForeground")
 
-        BlockchainSettings.App.shared.appOpenedCount += 1
+        BlockchainSettings.App.shared.appBecameActiveCount += 1
 
         BuySellCoordinator.shared.start()
 

--- a/Blockchain/AppReviewPrompt/AppReviewPrompt.swift
+++ b/Blockchain/AppReviewPrompt/AppReviewPrompt.swift
@@ -31,19 +31,20 @@ final class AppReviewPrompt: NSObject {
     }
 
     /// Ask to show the prompt, else handle failure silently
-    @objc func askToShow() {
-        if WalletManager.shared.wallet.getAllTransactionsCount() < numberOfTransactionsBeforePrompt {
+    @objc func showIfNeeded() {
+        let transactionsCount = WalletManager.shared.wallet.getAllTransactionsCount()
+        if transactionsCount < numberOfTransactionsBeforePrompt {
             #if DEBUG
             print("App review prompt will not show because the user needs at least \(numberOfTransactionsBeforePrompt) transactions.")
             #endif
             return
         }
-
-        // TODO: support overriding appOpenedCount for debugging
-        let count = BlockchainSettings.App.shared.appOpenedCount
+        // TODO: support overriding appBecameActiveCount for debugging
+        let count = BlockchainSettings.App.shared.appBecameActiveCount
         switch count {
-        case 10, 50: requestReview()
-        case _ where (count >= 100) && (count % 100 == 0): requestReview()
+        case 10, 50,
+             _ where (count >= 100) && (count % 100 == 0),
+             _ where transactionsCount == numberOfTransactionsBeforePrompt: requestReview()
         default:
             #if DEBUG
             print("App review prompt will not show because the application open count is too low (\(count)).")

--- a/Blockchain/Extensions/UserDefaults.swift
+++ b/Blockchain/Extensions/UserDefaults.swift
@@ -20,7 +20,7 @@ extension UserDefaults {
     }
 
     enum Keys: String {
-        case appOpenedCount = "appOpenedCount"
+        case appBecameActiveCount = "appBecameActiveCount"
         case assetType = "assetType"
         case didFailBiometrySetup = "didFailBiometrySetup"
         case encryptedPinPassword = "encryptedPINPassword"

--- a/Blockchain/SendBitcoinViewController.m
+++ b/Blockchain/SendBitcoinViewController.m
@@ -513,7 +513,7 @@ BOOL displayingLocalSymbolSend;
              DLog(@"SendViewController: on_success");
              UIAlertController *paymentSentAlert = [UIAlertController alertControllerWithTitle:[LocalizationConstantsObjcBridge success] message:BC_STRING_PAYMENT_SENT preferredStyle:UIAlertControllerStyleAlert];
              [paymentSentAlert addAction:[UIAlertAction actionWithTitle:BC_STRING_OK style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-                 [[AppReviewPrompt sharedInstance] askToShow];
+                 [[AppReviewPrompt sharedInstance] showIfNeeded];
              }]];
              
              [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:paymentSentAlert animated:YES completion:nil];

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -42,12 +42,12 @@ final class BlockchainSettings: NSObject {
 
         // MARK: - Properties
 
-        @objc var appOpenedCount: Int {
+        @objc var appBecameActiveCount: Int {
             get {
-                return defaults.integer(forKey: UserDefaults.Keys.appOpenedCount.rawValue)
+                return defaults.integer(forKey: UserDefaults.Keys.appBecameActiveCount.rawValue)
             }
             set {
-                defaults.set(newValue, forKey: UserDefaults.Keys.appOpenedCount.rawValue)
+                defaults.set(newValue, forKey: UserDefaults.Keys.appBecameActiveCount.rawValue)
             }
         }
 


### PR DESCRIPTION
Highlights in this PR:
- Fixes an issue where the app review prompt would not show during the user's first session if the user has not had at least 3 transactions in total. The prompt will now show after the third total payment has been sent, regardless of how many times the application has been opened.