### PR TITLE
fix(Upgrade): handle wallet upgrade for v2 wallets with a 2nd password.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -295,6 +295,8 @@
 		AA94965E20CB5FA600A9C2DD /* AssetAddressFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA94965D20CB5FA600A9C2DD /* AssetAddressFactory.swift */; };
 		AA94965F20CB5FA600A9C2DD /* AssetAddressFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA94965D20CB5FA600A9C2DD /* AssetAddressFactory.swift */; };
 		AA94966420CB613100A9C2DD /* AssetAddressFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA94966220CB613100A9C2DD /* AssetAddressFactoryTests.swift */; };
+		AA9B30D120F6D85000A7F809 /* WalletUpgradeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B30D020F6D85000A7F809 /* WalletUpgradeDelegate.swift */; };
+		AA9B30D220F6D85000A7F809 /* WalletUpgradeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B30D020F6D85000A7F809 /* WalletUpgradeDelegate.swift */; };
 		AAA3314E20893CE100BBD292 /* PairingInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */; };
 		AAA3316120895A9C00BBD292 /* LoadingViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */; };
 		AAA3316B2089650B00BBD292 /* AlertViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */; };
@@ -1623,6 +1625,7 @@
 		AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressRepository.swift; sourceTree = "<group>"; };
 		AA94965D20CB5FA600A9C2DD /* AssetAddressFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressFactory.swift; sourceTree = "<group>"; };
 		AA94966220CB613100A9C2DD /* AssetAddressFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressFactoryTests.swift; sourceTree = "<group>"; };
+		AA9B30D020F6D85000A7F809 /* WalletUpgradeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletUpgradeDelegate.swift; sourceTree = "<group>"; };
 		AAA3314D20893CE100BBD292 /* PairingInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingInstructionsView.swift; sourceTree = "<group>"; };
 		AAA3316020895A9C00BBD292 /* LoadingViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewPresenter.swift; sourceTree = "<group>"; };
 		AAA3316A2089650B00BBD292 /* AlertViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewPresenter.swift; sourceTree = "<group>"; };
@@ -2789,7 +2792,6 @@
 		AABDED6A208EC320002D8BAC /* Wallet */ = {
 			isa = PBXGroup;
 			children = (
-				C77C19B720C580E5005CB600 /* WalletSecondPasswordDelegate.swift */,
 				C74FEA222093B38A007CAB5D /* JSContextWithDOM.swift */,
 				C77217CE20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift */,
 				AAE9113420A520D40093A431 /* WalletAccountInfoDelegate.swift */,
@@ -2806,12 +2808,14 @@
 				AABDED6B208EC330002D8BAC /* WalletManager.swift */,
 				AA1E52302097CC1F0099BD10 /* WalletPinEntryDelegate.swift */,
 				C77217EC20AFCF940087836A /* WalletRecoveryDelegate.swift */,
+				C77C19B720C580E5005CB600 /* WalletSecondPasswordDelegate.swift */,
 				C78893ED20A4D690003C0A8F /* WalletSendBitcoinDelegate.swift */,
 				C79B27B020A6215B0061D0F2 /* WalletSendEtherDelegate.swift */,
 				C78893D920A34DF4003C0A8F /* WalletSettingsDelegate.swift */,
 				AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */,
 				AAC9FCED20AE456400E28B7A /* WalletTransactionDelegate.swift */,
 				C76D731620B24B5300040B57 /* WalletTransferAllDelegate.swift */,
+				AA9B30D020F6D85000A7F809 /* WalletUpgradeDelegate.swift */,
 				C79DD06D20B3B74A00DF3684 /* WalletWatchOnlyDelegate.swift */,
 			);
 			path = Wallet;
@@ -3829,6 +3833,7 @@
 				AA722C1520B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */,
 				AA1E52352097CC2E0099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */,
 				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
+				AA9B30D220F6D85000A7F809 /* WalletUpgradeDelegate.swift in Sources */,
 				C7BEE13C20C828B20096003B /* BuySellCoordinator.swift in Sources */,
 				AAE94F3220C64B49005A3595 /* PinInteractor.swift in Sources */,
 				511356E1209CA4BA00056D65 /* BlockchainAPI+PayloadTests.swift in Sources */,
@@ -3971,6 +3976,7 @@
 				AA63F87A20A3A198002B719B /* AppFeatureConfigurator.swift in Sources */,
 				C780A446202228A400E49274 /* BCPriceChartView.m in Sources */,
 				FA6323391A433B1C00EB3974 /* Foundation-Utility.m in Sources */,
+				AA9B30D120F6D85000A7F809 /* WalletUpgradeDelegate.swift in Sources */,
 				239CD5681C122BDE00997DF5 /* SettingsTwoStepViewController.m in Sources */,
 				23BF73391C454B8C00204503 /* AccountsAndAddressesNavigationController.m in Sources */,
 				51A862D520921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */,

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -67,8 +67,6 @@ import RxSwift
             return
         }
 
-        AppCoordinator.shared.showHdUpgradeViewIfNeeded()
-
         // Show security reminder modal if needed
         if let dateOfLastSecurityReminder = BlockchainSettings.App.shared.reminderModalDate {
 

--- a/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/Models/AuthenticationCoordinator+Pin.swift
@@ -175,8 +175,6 @@ extension AuthenticationCoordinator: WalletPinEntryDelegate {
         if walletManager.wallet.isInitialized() && !inSettings {
             AlertViewPresenter.shared.showMobileNoticeIfNeeded()
         }
-
-        AppCoordinator.shared.showHdUpgradeViewIfNeeded()
     }
 
     private func askIfUserWantsToResetPIN() {

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -92,7 +92,7 @@ import Foundation
     }
 
     /// Shows an upgrade to HD wallet prompt if the user has a legacy wallet
-    func showHdUpgradeViewIfNeeded() {
+    @objc func showHdUpgradeViewIfNeeded() {
         guard !walletManager.wallet.didUpgradeToHd() else { return }
         showHdUpgradeView()
     }

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -93,6 +93,7 @@ import Foundation
 
     /// Shows an upgrade to HD wallet prompt if the user has a legacy wallet
     @objc func showHdUpgradeViewIfNeeded() {
+        guard walletManager.wallet.isInitialized() else { return }
         guard !walletManager.wallet.didUpgradeToHd() else { return }
         showHdUpgradeView()
     }

--- a/Blockchain/TabControllerManager.m
+++ b/Blockchain/TabControllerManager.m
@@ -38,6 +38,12 @@
     walletManager.fiatAtTimeDelegate = self;
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [AppCoordinator.sharedInstance showHdUpgradeViewIfNeeded];
+}
+
 - (void)didSetAssetType:(LegacyAssetType)assetType
 {
     self.assetType = assetType;

--- a/Blockchain/UpgradeViewController.m
+++ b/Blockchain/UpgradeViewController.m
@@ -221,12 +221,12 @@
 - (void)onWalletUpgraded
 {
     __weak UpgradeViewController *weakSelf = self;
-    [AlertViewPresenter.sharedInstance standardErrorWithMessage:LocalizationConstantsObjcBridge.upgradeSuccess
-                                                          title:LocalizationConstantsObjcBridge.upgradeSuccessTitle
-                                                             in:self
-                                                        handler:^(UIAlertAction * _Nonnull action) {
-                                                            [weakSelf dismissViewControllerAnimated:YES completion:nil];
-                                                        }];
+    [AlertViewPresenter.sharedInstance standardNotifyWithMessage:LocalizationConstantsObjcBridge.upgradeSuccess
+                                                           title:LocalizationConstantsObjcBridge.upgradeSuccessTitle
+                                                              in:self
+                                                         handler:^(UIAlertAction * _Nonnull action) {
+                                                             [weakSelf dismissViewControllerAnimated:YES completion:nil];
+                                                         }];
 }
 
 @end

--- a/Blockchain/UpgradeViewController.m
+++ b/Blockchain/UpgradeViewController.m
@@ -11,7 +11,7 @@
 #import "UILabel+MultiLineAutoSize.h"
 #import "Blockchain-Swift.h"
 
-@interface UpgradeViewController ()
+@interface UpgradeViewController () <WalletUpgradeDelegate>
 @property (weak, nonatomic) IBOutlet UIPageControl *pageControl;
 @property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
 @property (weak, nonatomic) IBOutlet UILabel *captionLabel;
@@ -37,15 +37,10 @@
         [AlertViewPresenter.sharedInstance showNoInternetConnectionAlert];
         return;
     }
-    
-    [WalletManager.sharedInstance.wallet loading_start_upgrade_to_hd];
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * ANIMATION_DURATION * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [[AppCoordinator sharedInstance] closeSideMenu];
-        [WalletManager.sharedInstance.wallet performSelector:@selector(upgradeToV3Wallet) withObject:nil afterDelay:0.1f];
-    });
-    
-    [self dismissViewControllerAnimated:YES completion:nil];
+
+    [LoadingViewPresenter.sharedInstance showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_V3_WALLET];
+
+    [WalletManager.sharedInstance.wallet upgradeToV3Wallet];
 }
 
 - (NSArray *)imageNamesArray
@@ -153,6 +148,8 @@
     [self setTextForCaptionLabel];
     
     [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault animated:YES];
+
+    WalletManager.sharedInstance.upgradeWalletDelegate = self;
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -217,6 +214,19 @@
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
     [self setTextForCaptionLabel];
+}
+
+#pragma mark - WalletUpgradeDelegate
+
+- (void)onWalletUpgraded
+{
+    __weak UpgradeViewController *weakSelf = self;
+    [AlertViewPresenter.sharedInstance standardErrorWithMessage:LocalizationConstantsObjcBridge.upgradeSuccess
+                                                          title:LocalizationConstantsObjcBridge.upgradeSuccessTitle
+                                                             in:self
+                                                        handler:^(UIAlertAction * _Nonnull action) {
+                                                            [weakSelf dismissViewControllerAnimated:YES completion:nil];
+                                                        }];
 }
 
 @end

--- a/Blockchain/Wallet.h
+++ b/Blockchain/Wallet.h
@@ -143,6 +143,7 @@
 - (void)walletDidGetAccountInfoAndExchangeRates:(Wallet *)wallet;
 - (void)getSecondPasswordWithSuccess:(id<WalletSuccessCallback>)success;
 - (void)getPrivateKeyPasswordWithSuccess:(id<WalletSuccessCallback>)success;
+- (void)walletUpgraded:(Wallet *)wallet;
 @end
 
 @interface Wallet : NSObject <UIWebViewDelegate, SRWebSocketDelegate, ExchangeAccountDelegate> {
@@ -328,7 +329,6 @@
 - (void)setPbkdf2Iterations:(int)iterations;
 
 - (void)loading_start_get_history;
-- (void)loading_start_upgrade_to_hd;
 - (void)loading_start_recover_wallet;
 - (void)loading_stop;
 - (void)upgrade_success;

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -2941,13 +2941,6 @@
     });
 }
 
-- (void)loading_start_upgrade_to_hd
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:BC_STRING_LOADING_CREATING_V3_WALLET];
-    });
-}
-
 - (void)loading_start_create_account
 {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -3000,10 +2993,9 @@
 
 - (void)upgrade_success
 {
-    [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:[LocalizationConstantsObjcBridge upgradeSuccess]
-                                                             title:[LocalizationConstantsObjcBridge upgradeSuccessTitle]
-                                                                in: nil
-                                                           handler: nil];
+    if ([delegate respondsToSelector:@selector(walletUpgraded:)]) {
+        [delegate walletUpgraded:self];
+    }
 }
 
 #pragma mark - Callbacks from JS to Obj-C

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -46,6 +46,7 @@ class WalletManager: NSObject {
     @objc weak var transactionDelegate: WalletTransactionDelegate?
     @objc weak var transferAllDelegate: WalletTransferAllDelegate?
     @objc weak var watchOnlyDelegate: WalletWatchOnlyDelegate?
+    @objc weak var upgradeWalletDelegate: WalletUpgradeDelegate?
     weak var swipeAddressDelegate: WalletSwipeAddressDelegate?
     weak var keyImportDelegate: WalletKeyImportDelegate?
     weak var secondPasswordDelegate: WalletSecondPasswordDelegate?
@@ -624,5 +625,13 @@ extension WalletManager: WalletDelegate {
 
     @objc func getPrivateKeyPassword(withSuccess success: WalletSuccessCallback) {
         secondPasswordDelegate?.getPrivateKeyPassword(success: success)
+    }
+
+    // MARK: - Upgrade
+
+    func walletUpgraded(_ wallet: Wallet!) {
+        DispatchQueue.main.async {
+            self.upgradeWalletDelegate?.onWalletUpgraded()
+        }
     }
 }

--- a/Blockchain/Wallet/WalletUpgradeDelegate.swift
+++ b/Blockchain/Wallet/WalletUpgradeDelegate.swift
@@ -1,0 +1,16 @@
+//
+//  WalletUpgradeDelegate.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 7/11/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol definition for a delegate for Bitcoin and Bitcoin Cash related wallet callbacks
+@objc protocol WalletUpgradeDelegate: class {
+    
+    /// Method invoked when the user's wallet has been upgrade from V2 to V3
+    func onWalletUpgraded()
+}


### PR DESCRIPTION
Fix the issue wherein v2 wallets aren't forced to be upgraded if they have a 2nd password set.

### Summary
This fix includes the following changes:
* The logic to present `UpgradeViewController` was moved to `TabControllerManager` (we had that in multiple places previously but now it's just in one place)
* Created `WalletUpgradeDelegate` so that upgrade success notification can be propagated up from the `Wallet`
* Not dismissing `UpgradeViewController` when the user taps on "Continue". This is necessary since previously the 2nd password view was being presented from `UpgradeViewController` which didn't show since that view controller was being dismissed

...with this change the "Upgrade" side menu item is not even necessary since this will always force the user to upgrade.

### Testing
Tested this change on both V2 wallets w/ and w/o 2nd password set.