### PR TITLE
fix(AuthenticationCoordinator): reset send BTC/BCH screens and reques…

### DIFF
--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -57,6 +57,13 @@ import RxSwift
 
         ModalPresenter.shared.closeAllModals()
 
+        let tabControllerManager = AppCoordinator.shared.tabControllerManager
+        tabControllerManager.sendBitcoinViewController?.reload()
+        tabControllerManager.sendBitcoinCashViewController?.reload()
+                
+        /// Prompt the user for push notification permission
+        PushNotificationManager.shared.requestAuthorization()
+
         // Make user set up a pin if none is set. They can also optionally enable touch ID and link their email.
         guard BlockchainSettings.App.shared.isPinSet else {
             if strongSelf.walletManager.wallet.isNew {
@@ -84,15 +91,8 @@ import RxSwift
             ReminderPresenter.shared.checkIfSettingsLoadedAndShowEmailReminder()
         }
 
-        let tabControllerManager = AppCoordinator.shared.tabControllerManager
-        tabControllerManager.sendBitcoinViewController?.reload()
-        tabControllerManager.sendBitcoinCashViewController?.reload()
-
         // Enabling touch ID and immediately backgrounding the app hides the status bar
         UIApplication.shared.setStatusBarHidden(false, with: .slide)
-
-        /// Prompt the user for push notification permission
-        PushNotificationManager.shared.requestAuthorization()
 
         // Handle post authentication route, if any
         if let route = strongSelf.postAuthenticationRoute {


### PR DESCRIPTION
…t authorization for push notifications when authenticating without PIN

- Send BTC/BCH screens aren't being reset because execution terminates at the return here https://github.com/blockchain/My-Wallet-V3-iOS/blob/9a093d94eb0efb62c41d8564915bbf67d9c19856/Blockchain/Authentication/AuthenticationCoordinator.swift#L68-L75 when the PIN isn't set. So after logging out or forgetting a wallet, a user will see the same text in the `from` label on the Send screens as before when they pair with a wallet again (since the PIN isn't set).
- For the same reason, push notifications were not being requested if the user starts the app without a paired wallet then creates/pairs a wallet, but I'm not sure how the prompt will present along with this alert since we'd need a TestFlight build to confirm that both will be presented sequentially. Requesting feedback for this potentially simultaneous alert presentation. https://github.com/blockchain/My-Wallet-V3-iOS/blob/9a093d94eb0efb62c41d8564915bbf67d9c19856/Blockchain/Authentication/AuthenticationCoordinator.swift#L382-L388