### PR TITLE
fix(Wallet): check for BCH wallet object before returning balance

### DIFF
--- a/Blockchain/BCAddressSelectionView.m
+++ b/Blockchain/BCAddressSelectionView.m
@@ -541,7 +541,7 @@ typedef enum {
                         if (bchAccounts.count == row - 1) {
                             bchBalance = [WalletManager.sharedInstance.wallet getTotalBalanceForActiveLegacyAddresses:LegacyAssetTypeBitcoinCash];
                         } else if (row == 0) {
-                            bchBalance = [WalletManager.sharedInstance.wallet bitcoinCashTotalBalance];
+                            bchBalance = [WalletManager.sharedInstance.wallet getBchBalance];
                         } else {
                             bchBalance = [[WalletManager.sharedInstance.wallet getBalanceForAccount:[WalletManager.sharedInstance.wallet getIndexOfActiveAccount:[[bchAccounts objectAtIndex:indexPath.row - 1] intValue] assetType:LegacyAssetTypeBitcoinCash] assetType:LegacyAssetTypeBitcoinCash] longLongValue];
                         }

--- a/Blockchain/DashboardViewController.m
+++ b/Blockchain/DashboardViewController.m
@@ -159,7 +159,7 @@
         // Balances
         [self.balancesChartView updateBitcoinBalance:[NSNumberFormatter formatAmount:[WalletManager.sharedInstance.wallet getTotalActiveBalance] localCurrency:NO]];
         [self.balancesChartView updateEtherBalance:[WalletManager.sharedInstance.wallet getEthBalanceTruncated]];
-        [self.balancesChartView updateBitcoinCashBalance:[NSNumberFormatter formatAmount:[WalletManager.sharedInstance.wallet bitcoinCashTotalBalance] localCurrency:NO]];
+        [self.balancesChartView updateBitcoinCashBalance:[NSNumberFormatter formatAmount:[WalletManager.sharedInstance.wallet getBchBalance] localCurrency:NO]];
 
         // Watch only balances
         CGFloat previewViewSpacing = PRICE_PREVIEW_SPACING;
@@ -402,7 +402,7 @@
 
 - (double)getBchBalance
 {
-    return [self doubleFromString:[NSNumberFormatter formatBch:[WalletManager.sharedInstance.wallet bitcoinCashTotalBalance] localCurrency:YES]];
+    return [self doubleFromString:[NSNumberFormatter formatBch:[WalletManager.sharedInstance.wallet getBchBalance] localCurrency:YES]];
 }
 
 - (double)getBtcWatchOnlyBalance

--- a/Blockchain/Wallet.h
+++ b/Blockchain/Wallet.h
@@ -439,7 +439,6 @@
 - (uint64_t)getBchBalance;
 - (NSString *)bitcoinCashExchangeRate;
 - (uint64_t)getBitcoinCashConversion;
-- (uint64_t)bitcoinCashTotalBalance;
 - (NSArray *)getBitcoinCashTransactions:(NSInteger)filterType;
 - (NSString *_Nullable)getLabelForDefaultBchAccount;
 

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -2805,15 +2805,6 @@
     return 0;
 }
 
-- (uint64_t)bitcoinCashTotalBalance
-{
-    if ([self isInitialized]) {
-        return [[[self.context evaluateScript:@"MyWalletPhone.bch.totalBalance()"] toNumber] longLongValue];
-    }
-
-    return 0;
-}
-
 - (BOOL)hasBchAccount
 {
     if ([self isInitialized]) {

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -2966,10 +2966,6 @@ MyWalletPhone.bch = {
         account.archived = !account.archived;
     },
     
-    totalBalance : function() {
-        return MyWallet.wallet.bch.balance;
-    },
-    
     balanceActiveLegacy : function() {
         return MyWallet.wallet.bch.importedAddresses.balance;
     },


### PR DESCRIPTION
Issue: when logging in with a v2 wallet, the balance in the dashboard pie chart is displaying a large negative number due to an unset double (reference https://github.com/blockchain/My-Wallet-V3-iOS/pull/327#pullrequestreview-136744354).

Fix: Removed redundant function `bitcoinCashTotalBalance` and replaced with existing function `getBchBalance` which checks for a BCH account before attempting to return the balance.