### PR TITLE
fix(Send-WatchOnly): use correct error handling method when sending f…

### DIFF
--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -227,7 +227,7 @@ struct LocalizationConstants {
         static let importedKeyButForIncorrectAddress = NSLocalizedString("You've successfully imported a private key.", comment: "")
         static let importedKeyDoesNotCorrespondToAddress = NSLocalizedString("NOTE: The scanned private key does not correspond to this watch-only address. If you want to spend from this address, make sure that you scan the correct private key.", comment: "")
         static let importedKeySuccess = NSLocalizedString("You can now spend from this address.", comment: "")
-        static let incorrectPrivateKey = NSLocalizedString("", comment: "Incorrect private key")
+        static let incorrectPrivateKey = NSLocalizedString("Incorrect private key", comment: "Incorrect private key")
         static let keyAlreadyImported = NSLocalizedString("Key already imported", comment: "")
         static let keyNeedsBip38Password = NSLocalizedString("Needs BIP38 Password", comment: "")
         static let incorrectBip38Password = NSLocalizedString("Wrong BIP38 Password", comment: "")

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -3351,7 +3351,7 @@
 - (void)on_error_import_key_for_sending_from_watch_only:(NSString *)error
 {
     // TODO: remove bridging function call
-    [[KeyImportCoordinator sharedInstance] on_error_adding_private_key_watch_onlyWithError:error];
+    [[KeyImportCoordinator sharedInstance] on_error_import_key_for_sending_from_watch_onlyWithError:error];
 }
 
 /* End Key Importer */


### PR DESCRIPTION
…rom watch-only and scanning incorrect private key

**Issue:** Incorrect error handler was being called for scanning a watch-only private key, leading to a crash (Unexpectedly found nil while unwrapping an Optional value at https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/Blockchain/Coordinators/KeyImportCoordinator.swift#L216)

**Fix:** Call correct error handler and add back localized string.