### PR TITLE
fi(Exchange): enforce BCH upper limit from wallet options

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -469,6 +469,8 @@
 		C77217E920AFCC3C0087836A /* WalletBackupDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77217E720AFCC3C0087836A /* WalletBackupDelegate.swift */; };
 		C77217ED20AFCF940087836A /* WalletRecoveryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77217EC20AFCF940087836A /* WalletRecoveryDelegate.swift */; };
 		C77217EE20AFCF940087836A /* WalletRecoveryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77217EC20AFCF940087836A /* WalletRecoveryDelegate.swift */; };
+		C774A1262102B87300DCCC17 /* ExchangeRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C774A1252102B87300DCCC17 /* ExchangeRate.swift */; };
+		C774A1272102B87300DCCC17 /* ExchangeRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C774A1252102B87300DCCC17 /* ExchangeRate.swift */; };
 		C77C19B820C580E5005CB600 /* WalletSecondPasswordDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77C19B720C580E5005CB600 /* WalletSecondPasswordDelegate.swift */; };
 		C77C19B920C580E5005CB600 /* WalletSecondPasswordDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77C19B720C580E5005CB600 /* WalletSecondPasswordDelegate.swift */; };
 		C780A446202228A400E49274 /* BCPriceChartView.m in Sources */ = {isa = PBXBuildFile; fileRef = C780A445202228A400E49274 /* BCPriceChartView.m */; };
@@ -1755,6 +1757,7 @@
 		C77217CE20AE44B20087836A /* WalletAccountInfoAndExchangeRatesDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAccountInfoAndExchangeRatesDelegate.swift; sourceTree = "<group>"; };
 		C77217E720AFCC3C0087836A /* WalletBackupDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletBackupDelegate.swift; sourceTree = "<group>"; };
 		C77217EC20AFCF940087836A /* WalletRecoveryDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletRecoveryDelegate.swift; sourceTree = "<group>"; };
+		C774A1252102B87300DCCC17 /* ExchangeRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeRate.swift; sourceTree = "<group>"; };
 		C77C19B720C580E5005CB600 /* WalletSecondPasswordDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSecondPasswordDelegate.swift; sourceTree = "<group>"; };
 		C780A444202228A400E49274 /* BCPriceChartView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BCPriceChartView.h; sourceTree = "<group>"; };
 		C780A445202228A400E49274 /* BCPriceChartView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BCPriceChartView.m; sourceTree = "<group>"; };
@@ -2405,6 +2408,7 @@
 				6780DB971A40BDF40048EED2 /* AccountInOut.m */,
 				9F2D934814C05DD00053F0FF /* Address.h */,
 				9F2D934914C05DD00053F0FF /* Address.m */,
+				C774A1252102B87300DCCC17 /* ExchangeRate.swift */,
 				6780DB901A40BDA70048EED2 /* AddressInOut.h */,
 				6780DB911A40BDA70048EED2 /* AddressInOut.m */,
 				C7CE34B51F4DB8C100032806 /* Assets.h */,
@@ -3834,6 +3838,7 @@
 				AA1E52352097CC2E0099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */,
 				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
 				AA9B30D220F6D85000A7F809 /* WalletUpgradeDelegate.swift in Sources */,
+				C774A1272102B87300DCCC17 /* ExchangeRate.swift in Sources */,
 				C7BEE13C20C828B20096003B /* BuySellCoordinator.swift in Sources */,
 				AAE94F3220C64B49005A3595 /* PinInteractor.swift in Sources */,
 				511356E1209CA4BA00056D65 /* BlockchainAPI+PayloadTests.swift in Sources */,
@@ -3939,6 +3944,7 @@
 				AA63F86720A27AC6002B719B /* PostAuthenticationRoute.swift in Sources */,
 				AA2D000120D96FA300B7BE0E /* SwipeToReceiveAddressView.swift in Sources */,
 				C7EEB8451EA95505002F28B9 /* UIView+ChangeFrameAttribute.m in Sources */,
+				C774A1262102B87300DCCC17 /* ExchangeRate.swift in Sources */,
 				5114EA2320CD8B900098E26E /* UINavigationBar+TitleAttributes.swift in Sources */,
 				C74E21C12024BA1C00A9FBB1 /* BCBalanceChartLegendKeyView.m in Sources */,
 				516546F5208FCF710019EE63 /* NetworkManager+UserAgent.swift in Sources */,

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -475,9 +475,8 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 #define DICTIONARY_KEY_PAIR @"pair"
 #define DICTIONARY_KEY_RATE @"rate"
 #define DICTIONARY_KEY_MINER_FEE @"minerFee"
-#define DICTIONARY_KEY_BTC_HARD_LIMIT @"btcHardLimit"
-#define DICTIONARY_KEY_ETH_HARD_LIMIT @"ethHardLimit"
-#define DICTIONARY_KEY_ETH_HARD_LIMIT_RATE @"ethHardLimitRate"
+#define DICTIONARY_KEY_HARD_LIMIT @"hardLimit"
+#define DICTIONARY_KEY_HARD_LIMIT_RATE @"hardLimitRate"
 
 #define DICTIONARY_KEY_BITCOIN @"bitcoin"
 #define DICTIONARY_KEY_BITCOIN_CASH @"bitcoinCash"

--- a/Blockchain/Blockchain-Prefix.pch
+++ b/Blockchain/Blockchain-Prefix.pch
@@ -469,14 +469,9 @@ green:((float)((rgbValue & 0xFF00) >> 8))/255.0 blue:((float)(rgbValue & 0xFF))/
 #define DICTIONARY_KEY_MULTIADDRESS_SYMBOL_LOCAL @"symbol_local"
 #define DICTIONARY_KEY_MULTIADDRESS_SYMBOL_BTC @"symbol_btc"
 
-#define DICTIONARY_KEY_LIMIT @"limit"
-#define DICTIONARY_KEY_MINIMUM @"minimum"
-#define DICTIONARY_KEY_MAX_LIMIT @"maxLimit"
 #define DICTIONARY_KEY_PAIR @"pair"
 #define DICTIONARY_KEY_RATE @"rate"
 #define DICTIONARY_KEY_MINER_FEE @"minerFee"
-#define DICTIONARY_KEY_HARD_LIMIT @"hardLimit"
-#define DICTIONARY_KEY_HARD_LIMIT_RATE @"hardLimitRate"
 
 #define DICTIONARY_KEY_BITCOIN @"bitcoin"
 #define DICTIONARY_KEY_BITCOIN_CASH @"bitcoinCash"

--- a/Blockchain/ExchangeCreateViewController.h
+++ b/Blockchain/ExchangeCreateViewController.h
@@ -7,9 +7,9 @@
 //
 
 #import <UIKit/UIKit.h>
-
+@class ExchangeRate;
 @interface ExchangeCreateViewController : UIViewController
-- (void)didGetExchangeRate:(NSDictionary *)result;
+- (void)didGetExchangeRate:(ExchangeRate *)result;
 - (void)didGetAvailableEthBalance:(NSDictionary *)result;
 - (void)didGetAvailableBtcBalance:(NSDictionary *)result;
 - (void)didBuildExchangeTrade:(NSDictionary *)tradeInfo;

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -274,17 +274,17 @@
 
 #pragma mark - JS Callbacks
 
-- (void)didGetExchangeRate:(NSDictionary *)result
+- (void)didGetExchangeRate:(ExchangeRate *)exchangeRate
 {
     [self enableAssetToggleButton];
     [self.spinner stopAnimating];
     
     if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_BTC] || [self.fromSymbol isEqualToString:CURRENCY_SYMBOL_BCH]) {
-        NSString *minNumberString = [result objectForKey:DICTIONARY_KEY_TRADE_MINIMUM];
+        NSString *minNumberString = exchangeRate.minimum;
         self.minimum = [NSNumber numberWithLongLong:[NSNumberFormatter parseBtcValueFromString:minNumberString]];
-        NSString *maxNumberString = [result objectForKey:DICTIONARY_KEY_TRADE_MAX_LIMIT];
+        NSString *maxNumberString = exchangeRate.maxLimit;
         self.maximum = [NSNumber numberWithLongLong:[NSNumberFormatter parseBtcValueFromString:maxNumberString]];
-        NSString *hardLimitString = [result objectForKey:DICTIONARY_KEY_HARD_LIMIT];
+        NSString *hardLimitString = exchangeRate.hardLimit;
         self.maximumHardLimit = [NSNumber numberWithLongLong:[NSNumberFormatter parseBtcValueFromString:hardLimitString]];
         if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_BTC]) {
             [WalletManager.sharedInstance.wallet getAvailableBtcBalanceForAccount:self.btcAccount];
@@ -294,9 +294,9 @@
             self.availableBalanceFromSymbol = self.fromSymbol;
         }
     } else if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_ETH]) {
-        self.minimum = [NSDecimalNumber decimalNumberWithString:[result objectForKey:DICTIONARY_KEY_TRADE_MINIMUM]];
-        self.maximum = [NSDecimalNumber decimalNumberWithString:[result objectForKey:DICTIONARY_KEY_TRADE_MAX_LIMIT]];
-        self.maximumHardLimit = [NSDecimalNumber decimalNumberWithString:[result objectForKey:DICTIONARY_KEY_HARD_LIMIT]];
+        self.minimum = [NSDecimalNumber decimalNumberWithString:exchangeRate.minimum];
+        self.maximum = [NSDecimalNumber decimalNumberWithString:exchangeRate.maxLimit];
+        self.maximumHardLimit = [NSDecimalNumber decimalNumberWithString:exchangeRate.hardLimit];
         [WalletManager.sharedInstance.wallet getAvailableEthBalance];
     }
 }

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -284,7 +284,7 @@
         self.minimum = [NSNumber numberWithLongLong:[NSNumberFormatter parseBtcValueFromString:minNumberString]];
         NSString *maxNumberString = [result objectForKey:DICTIONARY_KEY_TRADE_MAX_LIMIT];
         self.maximum = [NSNumber numberWithLongLong:[NSNumberFormatter parseBtcValueFromString:maxNumberString]];
-        NSString *hardLimitString = [result objectForKey:DICTIONARY_KEY_BTC_HARD_LIMIT];
+        NSString *hardLimitString = [result objectForKey:DICTIONARY_KEY_HARD_LIMIT];
         self.maximumHardLimit = [NSNumber numberWithLongLong:[NSNumberFormatter parseBtcValueFromString:hardLimitString]];
         if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_BTC]) {
             [WalletManager.sharedInstance.wallet getAvailableBtcBalanceForAccount:self.btcAccount];
@@ -296,7 +296,7 @@
     } else if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_ETH]) {
         self.minimum = [NSDecimalNumber decimalNumberWithString:[result objectForKey:DICTIONARY_KEY_TRADE_MINIMUM]];
         self.maximum = [NSDecimalNumber decimalNumberWithString:[result objectForKey:DICTIONARY_KEY_TRADE_MAX_LIMIT]];
-        self.maximumHardLimit = [NSDecimalNumber decimalNumberWithString:[result objectForKey:DICTIONARY_KEY_ETH_HARD_LIMIT]];
+        self.maximumHardLimit = [NSDecimalNumber decimalNumberWithString:[result objectForKey:DICTIONARY_KEY_HARD_LIMIT]];
         [WalletManager.sharedInstance.wallet getAvailableEthBalance];
     }
 }

--- a/Blockchain/ExchangeCreateViewController.m
+++ b/Blockchain/ExchangeCreateViewController.m
@@ -280,11 +280,11 @@
     [self.spinner stopAnimating];
     
     if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_BTC] || [self.fromSymbol isEqualToString:CURRENCY_SYMBOL_BCH]) {
-        NSString *minNumberString = exchangeRate.minimum;
+        NSString *minNumberString = exchangeRate.minimum.stringValue;
         self.minimum = [NSNumber numberWithLongLong:[NSNumberFormatter parseBtcValueFromString:minNumberString]];
-        NSString *maxNumberString = exchangeRate.maxLimit;
+        NSString *maxNumberString = exchangeRate.maxLimit.stringValue;
         self.maximum = [NSNumber numberWithLongLong:[NSNumberFormatter parseBtcValueFromString:maxNumberString]];
-        NSString *hardLimitString = exchangeRate.hardLimit;
+        NSString *hardLimitString = exchangeRate.hardLimit.stringValue;
         self.maximumHardLimit = [NSNumber numberWithLongLong:[NSNumberFormatter parseBtcValueFromString:hardLimitString]];
         if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_BTC]) {
             [WalletManager.sharedInstance.wallet getAvailableBtcBalanceForAccount:self.btcAccount];
@@ -294,9 +294,9 @@
             self.availableBalanceFromSymbol = self.fromSymbol;
         }
     } else if ([self.fromSymbol isEqualToString:CURRENCY_SYMBOL_ETH]) {
-        self.minimum = [NSDecimalNumber decimalNumberWithString:exchangeRate.minimum];
-        self.maximum = [NSDecimalNumber decimalNumberWithString:exchangeRate.maxLimit];
-        self.maximumHardLimit = [NSDecimalNumber decimalNumberWithString:exchangeRate.hardLimit];
+        self.minimum = exchangeRate.minimum;
+        self.maximum = exchangeRate.maxLimit;
+        self.maximumHardLimit = exchangeRate.hardLimit;
         [WalletManager.sharedInstance.wallet getAvailableEthBalance];
     }
 }

--- a/Blockchain/ExchangeOverviewViewController.m
+++ b/Blockchain/ExchangeOverviewViewController.m
@@ -208,7 +208,7 @@
     }
 }
 
-- (void)didGetExchangeRateWithRate:(NSDictionary * _Nonnull)rate
+- (void)didGetExchangeRateWithRate:(ExchangeRate * _Nonnull)rate
 {
     [self.createViewController didGetExchangeRate:rate];
 }

--- a/Blockchain/ExchangeRate.swift
+++ b/Blockchain/ExchangeRate.swift
@@ -1,0 +1,70 @@
+//
+//  ExchangeRate.swift
+//  Blockchain
+//
+//  Created by kevinwu on 7/20/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Used to return exchange information from the ShapeShift API and wallet-options to the ExchangeCreateViewController.
+@objc class ExchangeRate: NSObject {
+
+    private struct Keys {
+        static let limit = "limit"
+        static let minimum = "minimum"
+        static let minerFee = "minerFee"
+        static let maxLimit = "maxLimit"
+        static let rate = "rate"
+        static let hardLimit = "hardLimit"
+        static let hardLimitRate = "hardLimitRate"
+    }
+
+    @objc let limit: String? // Not currently used on web, so not used for iOS, but added for documentation
+    @objc let minimum: String? // Minimum amount required to exchange
+    @objc let minerFee: String? // Fee for exchange
+    @objc let maxLimit: String? // Maximum amount allowed to exchange, defined by ShapeShift
+    @objc let rate: String? // Exchange rate between the 'from' and 'to' asset types
+    @objc let hardLimit: String? // Maximum amount allowed to exchange, defined by wallet-options
+    @objc let hardLimitRate: String? // Fiat value for the current 'from' asset type
+
+    private init(
+        limit: String?,
+        minimum: String?,
+        minerFee: String?,
+        maxLimit: String?,
+        rate: String?,
+        hardLimit: String?,
+        hardLimitRate: String?) {
+        self.limit = limit
+        self.minimum = minimum
+        self.minerFee = minerFee
+        self.maxLimit = maxLimit
+        self.rate = rate
+        self.hardLimit = hardLimit
+        self.hardLimitRate = hardLimitRate
+    }
+}
+
+@objc extension ExchangeRate {
+    convenience init(json: JSON) {
+        self.init(limit: json[Keys.limit] as? String,
+                  minimum: json[Keys.minimum] as? String,
+                  minerFee: json[Keys.minerFee] as? String,
+                  maxLimit: json[Keys.maxLimit] as? String,
+                  rate: json[Keys.rate] as? String,
+                  hardLimit: json[Keys.hardLimit] as? String,
+                  hardLimitRate: json[Keys.hardLimitRate] as? String)
+    }
+}
+
+@objc extension ExchangeRate {
+    class func limitKey() -> String { return Keys.limit }
+    class func minimumKey() -> String { return Keys.minimum }
+    class func minerFeeKey() -> String { return Keys.minerFee }
+    class func maxLimitKey() -> String { return Keys.maxLimit }
+    class func rateKey() -> String { return Keys.rate }
+    class func hardLimitKey() -> String { return Keys.hardLimit }
+    class func hardLimitRateKey() -> String { return Keys.hardLimitRate }
+}

--- a/Blockchain/ExchangeRate.swift
+++ b/Blockchain/ExchangeRate.swift
@@ -22,22 +22,22 @@ import JavaScriptCore
         static let hardLimitRate = "hardLimitRate"
     }
 
-    @objc let limit: String? // Not currently used on web, so not used for iOS, but added for documentation
-    @objc let minimum: String? // Minimum amount required to exchange
-    @objc let minerFee: String? // Fee for exchange
-    @objc let maxLimit: String? // Maximum amount allowed to exchange, defined by ShapeShift
-    @objc let rate: String? // Exchange rate between the 'from' and 'to' asset types
-    @objc let hardLimit: String? // Maximum amount allowed to exchange, defined by wallet-options
-    @objc let hardLimitRate: String? // Fiat value for the current 'from' asset type
+    @objc let limit: NSDecimalNumber? // Not currently used on web, so not used for iOS, but added for documentation
+    @objc let minimum: NSDecimalNumber? // Minimum amount required to exchange
+    @objc let minerFee: NSDecimalNumber? // Fee for exchange
+    @objc let maxLimit: NSDecimalNumber? // Maximum amount allowed to exchange, defined by ShapeShift
+    @objc let rate: NSDecimalNumber? // Exchange rate between the 'from' and 'to' asset types
+    @objc let hardLimit: NSDecimalNumber? // Maximum amount allowed to exchange, defined by wallet-options
+    @objc let hardLimitRate: NSDecimalNumber? // Fiat value for the current 'from' asset type
 
     @objc init(
-        limit: String?,
-        minimum: String?,
-        minerFee: String?,
-        maxLimit: String?,
-        rate: String?,
-        hardLimit: String?,
-        hardLimitRate: String?) {
+        limit: NSDecimalNumber?,
+        minimum: NSDecimalNumber?,
+        minerFee: NSDecimalNumber?,
+        maxLimit: NSDecimalNumber?,
+        rate: NSDecimalNumber?,
+        hardLimit: NSDecimalNumber?,
+        hardLimitRate: NSDecimalNumber?) {
         self.limit = limit
         self.minimum = minimum
         self.minerFee = minerFee
@@ -55,33 +55,20 @@ import JavaScriptCore
             return nil
         }
 
-        /*
-         Numeric values inside a JSValue converted to [AnyHashable: Any]! with toDictionary()
-         cannot be casted to a string - the following error will print:
-
-         Could not cast value of type '__NSCFNumber' to 'NSString'.
-
-         The documentation for JSValue's toDictionary() says "All enumerable properties of the object
-         are copied to the dictionary, with JSValues converted to equivalent Objective-C objects
-         as specified."
-
-         Ideally we would specify that the JSValues would be converted to strings to completely eliminate
-         any possibility of precision errors.
-        */
-        let stringFromNumericDictValue = { (_ value: Any?) -> String? in
+        let convertToDecimalNumber = { (value: Any?) -> NSDecimalNumber? in
             guard let number = value as? NSNumber else {
-                print("Could not convert dictionary value to NSNumber!")
+                print("Could not create NSNumber from dictionary value")
                 return nil
             }
-            return NumberFormatter.assetFormatterWithUSLocale.string(from: number)
+            return NSDecimalNumber(decimal: number.decimalValue)
         }
 
-        self.init(limit: stringFromNumericDictValue(dictionary[Keys.limit]),
-                  minimum: stringFromNumericDictValue(dictionary[Keys.minimum]),
-                  minerFee: stringFromNumericDictValue(dictionary[Keys.minerFee]),
-                  maxLimit: stringFromNumericDictValue(dictionary[Keys.maxLimit]),
-                  rate: stringFromNumericDictValue(dictionary[Keys.rate]),
-                  hardLimit: stringFromNumericDictValue(dictionary[Keys.hardLimit]),
-                  hardLimitRate: stringFromNumericDictValue(dictionary[Keys.hardLimitRate]))
+        self.init(limit: convertToDecimalNumber(dictionary[Keys.limit]),
+                  minimum: convertToDecimalNumber(dictionary[Keys.minimum]),
+                  minerFee: convertToDecimalNumber(dictionary[Keys.minerFee]),
+                  maxLimit: convertToDecimalNumber(dictionary[Keys.maxLimit]),
+                  rate: convertToDecimalNumber(dictionary[Keys.rate]),
+                  hardLimit: convertToDecimalNumber(dictionary[Keys.hardLimit]),
+                  hardLimitRate: convertToDecimalNumber(dictionary[Keys.hardLimitRate]))
     }
 }

--- a/Blockchain/ExchangeRate.swift
+++ b/Blockchain/ExchangeRate.swift
@@ -55,6 +55,19 @@ import JavaScriptCore
             return nil
         }
 
+        /*
+         Numeric values inside a JSValue converted to [AnyHashable: Any]! with toDictionary()
+         cannot be casted to a string - the following error will print:
+
+         Could not cast value of type '__NSCFNumber' to 'NSString'.
+
+         The documentation for JSValue's toDictionary() says "All enumerable properties of the object
+         are copied to the dictionary, with JSValues converted to equivalent Objective-C objects
+         as specified."
+
+         Ideally we would specify that the JSValues would be converted to strings to completely eliminate
+         any possibility of precision errors.
+        */
         let stringFromNumericDictValue = { (_ value: Any?) -> String? in
             guard let number = value as? NSNumber else {
                 print("Could not convert dictionary value to NSNumber!")

--- a/Blockchain/ExchangeRate.swift
+++ b/Blockchain/ExchangeRate.swift
@@ -55,7 +55,7 @@ import JavaScriptCore
             return nil
         }
 
-        let stringFromDictValue = { (_ value: Any?) -> String? in
+        let stringFromNumericDictValue = { (_ value: Any?) -> String? in
             guard let number = value as? NSNumber else {
                 print("Could not convert dictionary value to NSNumber!")
                 return nil
@@ -63,12 +63,12 @@ import JavaScriptCore
             return NumberFormatter.assetFormatterWithUSLocale.string(from: number)
         }
 
-        self.init(limit: stringFromDictValue(dictionary[Keys.limit]),
-                  minimum: stringFromDictValue(dictionary[Keys.minimum]),
-                  minerFee: stringFromDictValue(dictionary[Keys.minerFee]),
-                  maxLimit: stringFromDictValue(dictionary[Keys.maxLimit]),
-                  rate: stringFromDictValue(dictionary[Keys.rate]),
-                  hardLimit: stringFromDictValue(dictionary[Keys.hardLimit]),
-                  hardLimitRate: stringFromDictValue(dictionary[Keys.hardLimitRate]))
+        self.init(limit: stringFromNumericDictValue(dictionary[Keys.limit]),
+                  minimum: stringFromNumericDictValue(dictionary[Keys.minimum]),
+                  minerFee: stringFromNumericDictValue(dictionary[Keys.minerFee]),
+                  maxLimit: stringFromNumericDictValue(dictionary[Keys.maxLimit]),
+                  rate: stringFromNumericDictValue(dictionary[Keys.rate]),
+                  hardLimit: stringFromNumericDictValue(dictionary[Keys.hardLimit]),
+                  hardLimitRate: stringFromNumericDictValue(dictionary[Keys.hardLimitRate]))
     }
 }

--- a/Blockchain/NumberFormatter+Assets.swift
+++ b/Blockchain/NumberFormatter+Assets.swift
@@ -67,6 +67,7 @@ extension NumberFormatter {
     }()
 
     // Used to create QR code string from amount
+    // Used to convert values from returned from APIs
     static let assetFormatterWithUSLocale: NumberFormatter = {
         let formatter = decimalStyleFormatter(withMinfractionDigits: 0,
                                               maxfractionDigits: assetFractionDigits,

--- a/Blockchain/Wallet.h
+++ b/Blockchain/Wallet.h
@@ -41,7 +41,7 @@
 @property(nonatomic, assign) int tag;
 @end
 
-@class Wallet, Transaction, JSValue, JSContext;
+@class Wallet, Transaction, JSValue, JSContext, ExchangeRate;
 
 @protocol WalletSuccessCallback;
 
@@ -128,7 +128,7 @@
 - (void)didErrorDuringEtherSend:(NSString *)error;
 - (void)didGetEtherAddressWithSecondPassword;
 - (void)didGetExchangeTrades:(NSArray *)trades;
-- (void)didGetExchangeRate:(NSDictionary *)result;
+- (void)didGetExchangeRate:(ExchangeRate *)result;
 - (void)didGetAvailableEthBalance:(NSDictionary *)result;
 - (void)didGetAvailableBtcBalance:(NSDictionary *)result;
 - (void)didBuildExchangeTrade:(NSDictionary *)tradeInfo;

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -4068,7 +4068,7 @@
 
 - (void)on_get_exchange_rate_success:(ExchangeRate *)exchangeRate
 {
-    NSDecimalNumber *hardLimitRate = [NSDecimalNumber decimalNumberWithString:exchangeRate.hardLimitRate];
+    NSDecimalNumber *hardLimitRate = exchangeRate.hardLimitRate;
 
     NSDecimalNumber *fiatHardLimit = [NSDecimalNumber decimalNumberWithString:[[self.context evaluateScript:@"MyWalletPhone.fiatExchangeHardLimit()"] toString]];
 
@@ -4081,7 +4081,7 @@
                                                                     minerFee: exchangeRate.minerFee
                                                                     maxLimit: exchangeRate.maxLimit
                                                                     rate: exchangeRate.rate
-                                                                    hardLimit: hardLimit
+                                                                    hardLimit: [NSDecimalNumber decimalNumberWithString:hardLimit]
                                                                     hardLimitRate: nil];
 
     if ([self.delegate respondsToSelector:@selector(didGetExchangeRate:)]) {

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -819,13 +819,8 @@
         [weakSelf on_get_exchange_trades_success:trades];
     };
 
-    self.context[@"objc_on_get_exchange_rate_success"] = ^(JSValue *limit, JSValue *minimum, JSValue *minerFee, JSValue *maxLimit, JSValue *pair, JSValue *rate, JSValue *hardLimitRate) {
-        ExchangeRate *exchangeRate = [[ExchangeRate alloc] initWithJson:@{[ExchangeRate limitKey] : [limit toString],
-                                                                          [ExchangeRate minimumKey] : [minimum toString],
-                                                                          [ExchangeRate minerFeeKey] : [minerFee toString],
-                                                                          [ExchangeRate maxLimitKey] : [maxLimit toString],
-                                                                          [ExchangeRate rateKey] : [rate toString],
-                                                                          [ExchangeRate hardLimitRateKey] : [hardLimitRate toString]}];
+    self.context[@"objc_on_get_exchange_rate_success"] = ^(JSValue *rate) {
+        ExchangeRate *exchangeRate = [[ExchangeRate alloc] initWithJavaScriptValue:rate];
         [weakSelf on_get_exchange_rate_success:exchangeRate];
     };
 
@@ -4081,12 +4076,13 @@
 
     NSString *hardLimit = [numberFormatter stringFromNumber:[fiatHardLimit decimalNumberByDividingBy:hardLimitRate]];
 
-    ExchangeRate *exchangeRateWithHardLimit = [[ExchangeRate alloc] initWithJson:@{[ExchangeRate limitKey] : exchangeRate.limit,
-                                                                                   [ExchangeRate minimumKey] : exchangeRate.minimum,
-                                                                                   [ExchangeRate minerFeeKey] : exchangeRate.minerFee,
-                                                                                   [ExchangeRate maxLimitKey] : exchangeRate.maxLimit,
-                                                                                   [ExchangeRate rateKey] : exchangeRate.rate,
-                                                                                   [ExchangeRate hardLimitKey] : hardLimit}];
+    ExchangeRate *exchangeRateWithHardLimit = [[ExchangeRate alloc] initWithLimit: exchangeRate.limit
+                                                                    minimum: exchangeRate.minimum
+                                                                    minerFee: exchangeRate.minerFee
+                                                                    maxLimit: exchangeRate.maxLimit
+                                                                    rate: exchangeRate.rate
+                                                                    hardLimit: hardLimit
+                                                                    hardLimitRate: nil];
 
     if ([self.delegate respondsToSelector:@selector(didGetExchangeRate:)]) {
         [self.delegate didGetExchangeRate:exchangeRateWithHardLimit];

--- a/Blockchain/Wallet.m
+++ b/Blockchain/Wallet.m
@@ -4071,10 +4071,7 @@
 
     NSDecimalNumber *fiatHardLimit = [NSDecimalNumber decimalNumberWithString:[[self.context evaluateScript:@"MyWalletPhone.fiatExchangeHardLimit()"] toString]];
 
-    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
-    [numberFormatter setMaximumFractionDigits:8];
-    [numberFormatter setNumberStyle:NSNumberFormatterDecimalStyle];
-    [numberFormatter setLocale:[NSLocale localeWithLocaleIdentifier:LOCALE_IDENTIFIER_EN_US]];
+    NSNumberFormatter *numberFormatter = [NSNumberFormatter assetFormatterWithUSLocale];
 
     NSString *hardLimit = [numberFormatter stringFromNumber:[fiatHardLimit decimalNumberByDividingBy:hardLimitRate]];
 

--- a/Blockchain/Wallet/WalletExchangeDelegate.swift
+++ b/Blockchain/Wallet/WalletExchangeDelegate.swift
@@ -14,7 +14,7 @@ import Foundation
     func didGetExchangeTrades(trades: NSArray)
 
     /// Method invoked when rate has been fetched
-    func didGetExchangeRate(rate: NSDictionary)
+    func didGetExchangeRate(rate: ExchangeRate)
 
     /// Method invoked when the BTC balance has been fetched
     func didGetAvailableBtcBalance(result: NSDictionary?)

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -458,9 +458,9 @@ extension WalletManager: WalletDelegate {
         }
     }
 
-    func didGetExchangeRate(_ result: [AnyHashable: Any]!) {
+    func didGet(_ rate: ExchangeRate!) {
         DispatchQueue.main.async { [unowned self] in
-            self.exchangeDelegate?.didGetExchangeRate(rate: result as NSDictionary)
+            self.exchangeDelegate?.didGetExchangeRate(rate: rate)
         }
     }
 

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -2581,9 +2581,9 @@ MyWalletPhone.getExchangeTrades = function() {
 MyWalletPhone.getRate = function(coinPair) {
 
     var success = function(result) {
-        var from = coinPair.split('_')[0];
+        const from = coinPair.split('_')[0];
 
-        var fetchRateSuccess = function(hardLimit) {
+        const fetchRateSuccess = function(hardLimit) {
             var currencyCode = MyWalletPhone.currencyCodeForHardLimit();
             objc_on_get_exchange_rate_success(result.limit, result.minimum, result.minerFee, result.maxLimit, result.pair, result.rate, hardLimit[currencyCode].last);
         };

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -2585,7 +2585,8 @@ MyWalletPhone.getRate = function(coinPair) {
 
         const fetchRateSuccess = function(hardLimit) {
             var currencyCode = MyWalletPhone.currencyCodeForHardLimit();
-            objc_on_get_exchange_rate_success(result.limit, result.minimum, result.minerFee, result.maxLimit, result.pair, result.rate, hardLimit[currencyCode].last);
+            result.hardLimitRate = hardLimit[currencyCode].last;
+            objc_on_get_exchange_rate_success(result);
         };
 
         MyWalletPhone.getExchangeRateForHardLimit(from).then(fetchRateSuccess);

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -2581,10 +2581,25 @@ MyWalletPhone.getExchangeTrades = function() {
 MyWalletPhone.getRate = function(coinPair) {
 
     var success = function(result) {
-        MyWalletPhone.getEthExchangeRateForHardLimit().then(function(hardLimit) {
-             var currencyCode = MyWalletPhone.currencyCodeForHardLimit();
-             objc_on_get_exchange_rate_success(result.limit, result.minimum, result.minerFee, result.maxLimit, result.pair, result.rate, hardLimit[currencyCode].last);
-        });
+        var btcTicker = 'BTC';
+        var ethTicker = 'ETH';
+        var bchTicker = 'BCH';
+
+        var coins = coinPair.split('_');
+        var from = coins[0];
+
+        var fetchRateSuccess = function(hardLimit) {
+            var currencyCode = MyWalletPhone.currencyCodeForHardLimit();
+            objc_on_get_exchange_rate_success(result.limit, result.minimum, result.minerFee, result.maxLimit, result.pair, result.rate, hardLimit[currencyCode].last);
+        };
+
+        if (from.indexOf(btcTicker) !== -1) {
+            MyWalletPhone.getExchangeRateForHardLimit(btcTicker).then(fetchRateSuccess);
+        } else if (from.indexOf(ethTicker) !== -1) {
+            MyWalletPhone.getExchangeRateForHardLimit(ethTicker).then(fetchRateSuccess);
+        } else if (from.indexOf(bchTicker) !== -1) {
+            MyWalletPhone.getExchangeRateForHardLimit(bchTicker).then(fetchRateSuccess);
+        }
     }
 
     var error = function(e) {
@@ -2828,9 +2843,9 @@ MyWalletPhone.isWithdrawalTransaction = function(txHash) {
     return MyWallet.wallet.shapeshift.isWithdrawalTx(txHash);
 }
 
-MyWalletPhone.getEthExchangeRateForHardLimit = function() {
+MyWalletPhone.getExchangeRateForHardLimit = function(assetType) {
     var currencyCode = MyWalletPhone.currencyCodeForHardLimit();
-    return BlockchainAPI.getExchangeRate(currencyCode, 'ETH');
+    return BlockchainAPI.getExchangeRate(currencyCode, assetType);
 }
 
 MyWalletPhone.currencyCodeForHardLimit = function() {

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -2581,10 +2581,6 @@ MyWalletPhone.getExchangeTrades = function() {
 MyWalletPhone.getRate = function(coinPair) {
 
     var success = function(result) {
-        var btcTicker = 'BTC';
-        var ethTicker = 'ETH';
-        var bchTicker = 'BCH';
-
         var coins = coinPair.split('_');
         var from = coins[0];
 
@@ -2593,13 +2589,7 @@ MyWalletPhone.getRate = function(coinPair) {
             objc_on_get_exchange_rate_success(result.limit, result.minimum, result.minerFee, result.maxLimit, result.pair, result.rate, hardLimit[currencyCode].last);
         };
 
-        if (from.indexOf(btcTicker) !== -1) {
-            MyWalletPhone.getExchangeRateForHardLimit(btcTicker).then(fetchRateSuccess);
-        } else if (from.indexOf(ethTicker) !== -1) {
-            MyWalletPhone.getExchangeRateForHardLimit(ethTicker).then(fetchRateSuccess);
-        } else if (from.indexOf(bchTicker) !== -1) {
-            MyWalletPhone.getExchangeRateForHardLimit(bchTicker).then(fetchRateSuccess);
-        }
+        MyWalletPhone.getExchangeRateForHardLimit(from).then(fetchRateSuccess);
     }
 
     var error = function(e) {

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -2581,8 +2581,7 @@ MyWalletPhone.getExchangeTrades = function() {
 MyWalletPhone.getRate = function(coinPair) {
 
     var success = function(result) {
-        var coins = coinPair.split('_');
-        var from = coins[0];
+        var from = coinPair.split('_')[0];
 
         var fetchRateSuccess = function(hardLimit) {
             var currencyCode = MyWalletPhone.currencyCodeForHardLimit();

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -2849,7 +2849,7 @@ MyWalletPhone.getExchangeRateForHardLimit = function(assetType) {
 }
 
 MyWalletPhone.currencyCodeForHardLimit = function() {
-    return MyWalletPhone.isCountryGuessWhitelistedForShapeshift() == 'US' ? 'USD' : 'EUR';
+    return MyWallet.wallet.accountInfo.countryCodeGuess == 'US' ? 'USD' : 'EUR';
 }
 
 MyWalletPhone.fiatExchangeHardLimit = function() {


### PR DESCRIPTION
Goal is to merge this today into `release` for a build.

**Requirement:**
If the user is in the US, enforce the upper limit from wallet options for the `from` asset type in USD. Otherwise, enforce it in EUR.

**Issue:**
BCH upper limit from wallet options was not being fetched and returned when the `from` asset type was BCH. As a result, an incorrect conversion rate was used for this limit.

The current implementation for enforcing these limits were quite messy and nonsensical:
- Regardless of the `from` asset type, both BTC and ETH hard limits were being returned to the `ExchangeCreateViewController`
- The country code check for using USD or EUR was implemented incorrectly.
- For BTC, it was getting the last fetched rate, and for ETH it was fetching the latest rate.

**Fixes**
- Fetch and return the rate for only the `from` asset type
- Return the country code instead of a boolean

**Feedback Requests**
- https://github.com/blockchain/My-Wallet-V3-iOS/blob/kevin/IOS-1095/fix_bch_limit/Blockchain/js/wallet-ios.js#L2596-L2602 as I'm sure it can rewritten better. 
- What level of refactoring are we comfortable when making these kinds of fixes to put in a build quickly? We should use `Constants.swift` instead of the `Blockchain-Prefix.pch`. To take it even further we should create an object instead of using all of these dictionary keys here https://github.com/blockchain/My-Wallet-V3-iOS/blob/kevin/IOS-1095/fix_bch_limit/Blockchain/Wallet.m#L823