### PR TITLE
fix(Dashboard): fix bg color of non-spendable label.

### DIFF
--- a/Blockchain/Views/WatchOnlyBalanceView.swift
+++ b/Blockchain/Views/WatchOnlyBalanceView.swift
@@ -24,7 +24,7 @@ import Foundation
         self.balanceLabel.layer.cornerRadius = 5
         self.balanceLabel.layer.borderWidth = 1
         self.balanceLabel.textColor = .gray5
-        self.balanceLabel.backgroundColor = .gray6
+        self.balanceLabel.backgroundColor = .gray1
         self.balanceLabel.layer.borderColor = UIColor.gray2.cgColor
         self.balanceLabel.clipsToBounds = true
         self.balanceLabel.customEdgeInsets = UIEdgeInsets(top: 3.5, left: 11, bottom: 3.5, right: 11)


### PR DESCRIPTION
Fixing bg color of the non-spendable label on the dashboard. Looks like the gray6 color before was different from the new gray6 color. I went ahead and searched for all other gray6 references and verified that this is the only one that was affected.

**Before:**
![simulator screen shot - iphone x - 2018-07-24 at 16 11 46](https://user-images.githubusercontent.com/38220701/43171076-4f793530-8f5d-11e8-9d0d-21bdf42141d7.png)

**After:**
![simulator screen shot - iphone x - 2018-07-24 at 16 13 55](https://user-images.githubusercontent.com/38220701/43171077-51da35f4-8f5d-11e8-8380-3731cd5fff0e.png)
