### PR TITLE
 feat(Logger): IOS-1116 Creating Logger class.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -339,6 +339,14 @@
 		AA31A7BB2098DFCF00FE6268 /* SideMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */; };
 		AA31A7BC2098DFCF00FE6268 /* SideMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */; };
 		AA31A7D12099310B00FE6268 /* WalletBuySellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31A7D02099310B00FE6268 /* WalletBuySellDelegate.swift */; };
+		AA3CA9AF2107F18C00C2AD46 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9AE2107F18C00C2AD46 /* Logger.swift */; };
+		AA3CA9B02107F18D00C2AD46 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9AE2107F18C00C2AD46 /* Logger.swift */; };
+		AA3CA9B22107F2B700C2AD46 /* LogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B12107F2B700C2AD46 /* LogDestination.swift */; };
+		AA3CA9B32107F2B700C2AD46 /* LogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B12107F2B700C2AD46 /* LogDestination.swift */; };
+		AA3CA9B52107F36800C2AD46 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B42107F36700C2AD46 /* LogLevel.swift */; };
+		AA3CA9B62107F36800C2AD46 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B42107F36700C2AD46 /* LogLevel.swift */; };
+		AA3CA9B82107F66E00C2AD46 /* ConsoleLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B72107F66E00C2AD46 /* ConsoleLogDestination.swift */; };
+		AA3CA9B92107F66E00C2AD46 /* ConsoleLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B72107F66E00C2AD46 /* ConsoleLogDestination.swift */; };
 		AA54277C20D88DD900D5FEEE /* SwipeToReceiveAddressView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AA54277B20D88DD900D5FEEE /* SwipeToReceiveAddressView.xib */; };
 		AA56423820DDBDAA0092A022 /* PinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA56421D20DDBDA90092A022 /* PinTests.swift */; };
 		AA56423B20DDBDBB0092A022 /* String+EscapeJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA56423920DDBDBB0092A022 /* String+EscapeJSTests.swift */; };
@@ -1996,6 +2004,10 @@
 		AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AlertViewPresenter+Wallet.swift"; sourceTree = "<group>"; };
 		AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuItem.swift; sourceTree = "<group>"; };
 		AA31A7D02099310B00FE6268 /* WalletBuySellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletBuySellDelegate.swift; sourceTree = "<group>"; };
+		AA3CA9AE2107F18C00C2AD46 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		AA3CA9B12107F2B700C2AD46 /* LogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogDestination.swift; sourceTree = "<group>"; };
+		AA3CA9B42107F36700C2AD46 /* LogLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevel.swift; sourceTree = "<group>"; };
+		AA3CA9B72107F66E00C2AD46 /* ConsoleLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogDestination.swift; sourceTree = "<group>"; };
 		AA54277B20D88DD900D5FEEE /* SwipeToReceiveAddressView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SwipeToReceiveAddressView.xib; sourceTree = "<group>"; };
 		AA56421D20DDBDA90092A022 /* PinTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinTests.swift; sourceTree = "<group>"; };
 		AA56423920DDBDBB0092A022 /* String+EscapeJSTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+EscapeJSTests.swift"; sourceTree = "<group>"; };
@@ -3016,6 +3028,7 @@
 				9F0CBAAB15135DF200CD945D /* JavaScript */,
 				51383536210253A700767B2E /* KYC */,
 				515EF91A210282B4002350B6 /* Localization */,
+				AA3CA9932107F10000C2AD46 /* Logging */,
 				678AD5EC19D4731C00E9A778 /* Modal Content Views */,
 				9F765F3A14BC7C3100048EFB /* Models */,
 				51A7348B20891EB3009727D5 /* Network */,
@@ -3147,6 +3160,17 @@
 				AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */,
 			);
 			path = "Side Menu";
+			sourceTree = "<group>";
+		};
+		AA3CA9932107F10000C2AD46 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				AA3CA9B72107F66E00C2AD46 /* ConsoleLogDestination.swift */,
+				AA3CA9B12107F2B700C2AD46 /* LogDestination.swift */,
+				AA3CA9AE2107F18C00C2AD46 /* Logger.swift */,
+				AA3CA9B42107F36700C2AD46 /* LogLevel.swift */,
+			);
+			path = Logging;
 			sourceTree = "<group>";
 		};
 		AA54277820D88D1D00D5FEEE /* Swipe to Receive */ = {
@@ -4179,6 +4203,7 @@
 				AA31A7BC2098DFCF00FE6268 /* SideMenuItem.swift in Sources */,
 				AA63F85920A134DA002B719B /* BCTextField.swift in Sources */,
 				AACE31D42092A99B00B7B806 /* AppCoordinator.swift in Sources */,
+				AA3CA9B92107F66E00C2AD46 /* ConsoleLogDestination.swift in Sources */,
 				AAE94DCA20C25124005A3595 /* WalletServiceTests.swift in Sources */,
 				AA69118520D0967300DDB541 /* WalletServiceError.swift in Sources */,
 				51578AEB20B448BF00B0080A /* WalletKeyImportDelegate.swift in Sources */,
@@ -4224,6 +4249,7 @@
 				AA6911A120D18B6E00DDB541 /* MockWalletService.swift in Sources */,
 				5113570A209CF6CE00056D65 /* BCSecureTextField.swift in Sources */,
 				C76D731820B24B5400040B57 /* WalletTransferAllDelegate.swift in Sources */,
+				AA3CA9B62107F36800C2AD46 /* LogLevel.swift in Sources */,
 				AACE31D52092A99B00B7B806 /* Coordinator.swift in Sources */,
 				AACE32082097835F00B7B806 /* AuthenticationManagerTests.swift in Sources */,
 				5185E11C208E7F7C00A26B64 /* BlockchainSettings.swift in Sources */,
@@ -4248,6 +4274,7 @@
 				AACE31C82092A99B00B7B806 /* ModalPresenter.swift in Sources */,
 				C76D730520B2052000040B57 /* WalletExchangeDelegate.swift in Sources */,
 				AACE31C32092A99B00B7B806 /* AppDelegate.swift in Sources */,
+				AA3CA9B32107F2B700C2AD46 /* LogDestination.swift in Sources */,
 				AADB027F20C0BACA000FFFEC /* WalletCryptoService.swift in Sources */,
 				AACE31822092858600B7B806 /* Pin.swift in Sources */,
 				AACE31D72092A99B00B7B806 /* Enum+Enumeratable.swift in Sources */,
@@ -4329,6 +4356,7 @@
 				C74E865A20B31DE300F7263D /* WalletExchangeIntermediateDelegate.swift in Sources */,
 				C7E1A2902108FDFC0072DDA0 /* Colors.swift in Sources */,
 				5114EA2420CD8B900098E26E /* UINavigationBar+TitleAttributes.swift in Sources */,
+				AA3CA9B02107F18D00C2AD46 /* Logger.swift in Sources */,
 				C764372A20ED199500CA7CA4 /* BalanceChartModel.swift in Sources */,
 				AADB023A20C0A871000FFFEC /* HttpMethod.swift in Sources */,
 				519435AC208E6279001EF882 /* CertificatePinnerTests.swift in Sources */,
@@ -4372,6 +4400,7 @@
 				670595A41AB0F59D00D2D6D9 /* KeychainItemWrapper.m in Sources */,
 				51C9EBB620DBE4A700AB521D /* UIView+SafeAreaFrame.swift in Sources */,
 				C790E1211E5345160063D141 /* BCVerifyEmailViewController.m in Sources */,
+				AA3CA9B22107F2B700C2AD46 /* LogDestination.swift in Sources */,
 				C71859571F4B695700745A87 /* TabControllerManager.m in Sources */,
 				51135701209CEEB900056D65 /* PushNotificationAuthPayload.swift in Sources */,
 				C7A9E7A61FAB5FF600027F22 /* UILabel+CGRectForSubstring.m in Sources */,
@@ -4386,6 +4415,7 @@
 				C9BE917D1945D8F600FD516D /* PEViewController.m in Sources */,
 				674709EC19D1D14300757D46 /* BCWelcomeView.m in Sources */,
 				67D95A281B3DDC900012EBB1 /* Constants.swift in Sources */,
+				AA3CA9B82107F66E00C2AD46 /* ConsoleLogDestination.swift in Sources */,
 				9F765F3214BC622E00048EFB /* TransactionsBitcoinViewController.m in Sources */,
 				2322DCC21D771831000E5AC1 /* SRURLUtilities.m in Sources */,
 				C7A0E9261FA89FE9004F4267 /* ExchangeModalView.m in Sources */,
@@ -4444,6 +4474,7 @@
 				239CD5681C122BDE00997DF5 /* SettingsTwoStepViewController.m in Sources */,
 				23BF73391C454B8C00204503 /* AccountsAndAddressesNavigationController.m in Sources */,
 				51383559210253A800767B2E /* KYCVerifyAccountController.swift in Sources */,
+				AA3CA9B52107F36800C2AD46 /* LogLevel.swift in Sources */,
 				51A862D520921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */,
 				2378271A1B7E472D00E9EE03 /* BCSecureTextField.swift in Sources */,
 				9F2D934A14C05DD00053F0FF /* Address.m in Sources */,
@@ -4485,6 +4516,7 @@
 				9FCA4D1B151494BF00ECDFBE /* SendBitcoinViewController.m in Sources */,
 				511646E2208523E300C43522 /* UIDevice.swift in Sources */,
 				C7CE34BE1F4E128900032806 /* BCAmountInputView.m in Sources */,
+				AA3CA9AF2107F18C00C2AD46 /* Logger.swift in Sources */,
 				AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */,
 				67D95A261B3DD86B0012EBB1 /* BCTextField.swift in Sources */,
 				2322DCC01D771831000E5AC1 /* SRRandom.m in Sources */,

--- a/Blockchain/AV/SoundManager.swift
+++ b/Blockchain/AV/SoundManager.swift
@@ -37,7 +37,7 @@ import Foundation
 
     private func play(systemSoundID: SystemSoundID?) {
         guard let systemSoundID = systemSoundID else {
-            print("Cannot play sound with nil SystemSoundID")
+            Logger.shared.warning("Cannot play sound with nil SystemSoundID")
             return
         }
         AudioServicesPlaySystemSound(systemSoundID)
@@ -45,7 +45,7 @@ import Foundation
 
     private func systemSoundID(forSoundFileName name: String) -> SystemSoundID? {
         guard let soundPath = Bundle.main.path(forResource: name, ofType: "wav") else {
-            print("Could not retrieve file URL path for the sound '\(name).wav'")
+            Logger.shared.warning("Could not retrieve file URL path for the sound '\(name).wav'")
             return nil
         }
         var soundID: SystemSoundID = 0

--- a/Blockchain/Addresses/AssetAddressRepository.swift
+++ b/Blockchain/Addresses/AssetAddressRepository.swift
@@ -32,19 +32,19 @@ import Foundation
         // Perform guard checks
         let appSettings = BlockchainSettings.App.shared
         guard appSettings.swipeToReceiveEnabled else {
-            print("Swipe to receive is disabled.")
+            Logger.shared.info("Swipe to receive is disabled.")
             return
         }
 
         let wallet = walletManager.wallet
 
         guard wallet.isInitialized() else {
-            print("Wallet is not yet initialized.")
+            Logger.shared.warning("Wallet is not yet initialized.")
             return
         }
 
         guard wallet.didUpgradeToHd() else {
-            print("Wallet has not yet been upgraded to HD.")
+            Logger.shared.warning("Wallet has not yet been upgraded to HD.")
             return
         }
 
@@ -124,7 +124,7 @@ extension AssetAddressRepository {
         errorHandler: @escaping (() -> Void)
     ) {
         guard assetType != .ethereum else {
-            print("Ethereum addresses not supported for checking if it is unused.")
+            Logger.shared.info("Ethereum addresses not supported for checking if it is unused.")
             return
         }
 
@@ -135,7 +135,7 @@ extension AssetAddressRepository {
         }
 
         guard let urlString = BlockchainAPI.shared.assetInfoURL(for: assetAddress), let url = URL(string: urlString) else {
-            print("Cannot construct URL to check if the address '\(address)' is unused.")
+            Logger.shared.warning("Cannot construct URL to check if the address '\(address)' is unused.")
             return
         }
 

--- a/Blockchain/Alerts/AlertViewPresenter+Wallet.swift
+++ b/Blockchain/Alerts/AlertViewPresenter+Wallet.swift
@@ -16,7 +16,7 @@ extension AlertViewPresenter {
     /// - Parameter walletOptions: the WalletOptions
     func showMaintenanceError(from walletOptions: WalletOptions) {
         guard walletOptions.downForMaintenance else {
-            print("Not showing site maintenance alert. WalletOptions `downForMaintenance` flag is not set.")
+            Logger.shared.info("Not showing site maintenance alert. WalletOptions `downForMaintenance` flag is not set.")
             return
         }
         let message = walletOptions.mobileInfo?.message ?? LocalizationConstants.Errors.siteMaintenanceError

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -39,6 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         Fabric.with([Crashlytics.self])
+
         BlockchainSettings.App.shared.appBecameActiveCount += 1
         // MARK: - Global Appearance
         //: Status Bar

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -87,7 +87,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-        print("applicationWillResignActive")
+        Logger.shared.debug("applicationWillResignActive")
         if !AuthenticationCoordinator.shared.isPromptingForBiometricAuthentication {
             showPrivacyScreen()
         }
@@ -97,7 +97,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
-        print("applicationDidEnterBackground")
+        Logger.shared.debug("applicationDidEnterBackground")
 
         // Wallet-related background actions
 
@@ -142,12 +142,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         NetworkManager.shared.session.reset {
-            print("URLSession reset completed.")
+            Logger.shared.debug("URLSession reset completed.")
         }
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
-        print("applicationWillEnterForeground")
+        Logger.shared.debug("applicationWillEnterForeground")
 
         BlockchainSettings.App.shared.appBecameActiveCount += 1
 
@@ -163,7 +163,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
-        print("applicationDidBecomeActive")
+        Logger.shared.debug("applicationDidBecomeActive")
         hidePrivacyScreen()
         UIApplication.shared.applicationIconBadgeNumber = 0
     }
@@ -236,7 +236,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         guard !onboardingSettings.firstRun else {
-            print("This is not the 1st time the user is running the app.")
+            Logger.shared.info("This is not the 1st time the user is running the app.")
             return
         }
 

--- a/Blockchain/AppReviewPrompt/AppReviewPrompt.swift
+++ b/Blockchain/AppReviewPrompt/AppReviewPrompt.swift
@@ -34,9 +34,7 @@ final class AppReviewPrompt: NSObject {
     @objc func showIfNeeded() {
         let transactionsCount = WalletManager.shared.wallet.getAllTransactionsCount()
         if transactionsCount < numberOfTransactionsBeforePrompt {
-            #if DEBUG
-            print("App review prompt will not show because the user needs at least \(numberOfTransactionsBeforePrompt) transactions.")
-            #endif
+            Logger.shared.info("App review prompt will not show because the user needs at least \(numberOfTransactionsBeforePrompt) transactions.")
             return
         }
         // TODO: support overriding appBecameActiveCount for debugging
@@ -46,9 +44,7 @@ final class AppReviewPrompt: NSObject {
              _ where (count >= 100) && (count % 100 == 0),
              _ where transactionsCount == numberOfTransactionsBeforePrompt: requestReview()
         default:
-            #if DEBUG
-            print("App review prompt will not show because the application open count is too low (\(count)).")
-            #endif
+            Logger.shared.info("App review prompt will not show because the application open count is too low (\(count)).")
             return
         }
     }
@@ -60,9 +56,7 @@ final class AppReviewPrompt: NSObject {
         }
         let settings = BlockchainSettings.App.shared
         if settings.dontAskUserToShowAppReviewPrompt {
-            #if DEBUG
-            print("App review prompt will not show because the user does not want to be asked.")
-            #endif
+            Logger.shared.info("App review prompt will not show because the user does not want to be asked.")
             return
         }
         let affirmativeAction = UIAlertAction(

--- a/Blockchain/Authentication/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator+Pin.swift
@@ -38,7 +38,7 @@ extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
     }
 
     func pinEntryControllerDidCancel(_ pinEntryController: PEPinEntryController!) {
-        print("Pin change cancelled!")
+        Logger.shared.info("Pin change cancelled!")
         closePinEntryView(animated: true)
     }
 

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -246,7 +246,7 @@ import RxSwift
         alert.addAction(UIAlertAction(title: LocalizationConstants.cancel, style: .cancel))
         alert.addAction(
             UIAlertAction(title: LocalizationConstants.Authentication.forgetWallet, style: .default) { [unowned self] _ in
-                print("Forgetting wallet")
+                Logger.shared.info("Forgetting wallet")
                 ModalPresenter.shared.closeModal(withTransition: kCATransitionFade)
                 self.walletManager.forgetWallet()
                 OnboardingCoordinator.shared.start()
@@ -570,7 +570,7 @@ extension AuthenticationCoordinator: ManualPairViewDelegate {
         case .sms:
             view.verifyTwoFactorSMS()
         default:
-            print("Unhandled 2FA type: \(twoFactorAuthType)")
+            Logger.shared.error("Unhandled 2FA type: \(twoFactorAuthType)")
         }
     }
 }

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -222,7 +222,7 @@ import Foundation
 extension AppCoordinator: SideMenuViewControllerDelegate {
     func onSideMenuItemTapped(_ identifier: String!) {
         guard let sideMenuItem = SideMenuItem(rawValue: identifier) else {
-            print("Unrecognized SideMenuItem with identifier: \(String(describing: identifier))")
+            Logger.shared.warning("Unrecognized SideMenuItem with identifier: \(String(describing: identifier))")
             return
         }
 

--- a/Blockchain/Coordinators/BuySellCoordinator.swift
+++ b/Blockchain/Coordinators/BuySellCoordinator.swift
@@ -41,12 +41,12 @@ import RxSwift
             .observeOn(MainScheduler.instance)
             .subscribe(onSuccess: { walletOptions in
                 guard let rootURL = walletOptions.mobile?.walletRoot else {
-                    print("Error with wallet options response when starting buy sell webview")
+                    Logger.shared.warning("Error with wallet options response when starting buy sell webview")
                     return
                 }
                 self.initializeWebView(rootURL: rootURL)
             }, onError: { _ in
-                print("Error getting wallet options to start buy sell webview")
+                Logger.shared.error("Error getting wallet options to start buy sell webview")
             })
     }
 
@@ -56,7 +56,7 @@ import RxSwift
 
     @objc func showBuyBitcoinView() {
         guard let buyBitcoinViewController = buyBitcoinViewController else {
-            print("buyBitcoinViewController not yet initialized")
+            Logger.shared.warning("buyBitcoinViewController not yet initialized")
             return
         }
 
@@ -64,22 +64,22 @@ import RxSwift
         guard let loginDataDict = walletManager.wallet.executeJSSynchronous(
             "MyWalletPhone.getWebViewLoginData()"
             ).toDictionary() else {
-                print("loginData from wallet is empty")
+                Logger.shared.warning("loginData from wallet is empty")
                 return
         }
 
         guard let walletJson = loginDataDict["walletJson"] as? String else {
-            print("walletJson is nil")
+            Logger.shared.warning("walletJson is nil")
             return
         }
 
         guard let externalJson = loginDataDict["externalJson"] is NSNull ? "" : loginDataDict["externalJson"] as? String else {
-            print("externalJson is nil")
+            Logger.shared.warning("externalJson is nil")
             return
         }
 
         guard let magicHash = loginDataDict["magicHash"] is NSNull ? "" : loginDataDict["magicHash"] as? String else {
-            print("magicHash is nil")
+            Logger.shared.warning("magicHash is nil")
             return
         }
 

--- a/Blockchain/Extensions/Reachability.swift
+++ b/Blockchain/Extensions/Reachability.swift
@@ -14,7 +14,7 @@ extension Reachability {
     @objc static func hasInternetConnection() -> Bool {
         let reachability = Reachability.forInternetConnection()
         guard reachability?.currentReachabilityStatus() != NotReachable else {
-            print("No internet connection.")
+            Logger.shared.info("No internet connection.")
             return false
         }
         return true

--- a/Blockchain/LoadingViewPresenter.swift
+++ b/Blockchain/LoadingViewPresenter.swift
@@ -35,7 +35,7 @@ import Foundation
     @objc func hideBusyView() {
 
         guard self.isLoadingShown else {
-            print("[LoadingViewPresenter]: Cannot hide busy view, already not shown.")
+            Logger.shared.info("Cannot hide busy view, already not shown.")
             return
         }
 
@@ -50,14 +50,14 @@ import Foundation
     @objc func showBusyView(withLoadingText text: String) {
 
         if AppCoordinator.shared.tabControllerManager.isSending() && ModalPresenter.shared.modalView != nil {
-            print("Send progress modal is presented - will not show busy view")
+            Logger.shared.info("Send progress modal is presented - will not show busy view")
             return
         }
 
         self.busyView.labelBusy.text = text
 
         guard !self.isLoadingShown else {
-            print("[LoadingViewPresenter]: cannot show busy view already shown.")
+            Logger.shared.info("Cannot show busy view already shown.")
             return
         }
 
@@ -75,7 +75,7 @@ import Foundation
         }
 
         guard self.isLoadingShown else {
-            print("[LoadingViewPresenter]: Cannot update busy view with text: '\(text)', busy view should be shown.")
+            Logger.shared.info("Cannot update busy view with text: '\(text)', busy view should be shown.")
             return
         }
 
@@ -84,7 +84,7 @@ import Foundation
 
     private func attachToMainWindow() {
         guard !isLoadingShown else {
-            print("Loading view already attached.")
+            Logger.shared.info("Loading view already attached.")
             return
         }
 

--- a/Blockchain/Logging/ConsoleLogDestination.swift
+++ b/Blockchain/Logging/ConsoleLogDestination.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// A destination wherein log statements are outputted to standard output (i.e. XCode's console)
 class ConsoleLogDestination: LogDestination {
     func log(statement: String) {
         print(statement)

--- a/Blockchain/Logging/ConsoleLogDestination.swift
+++ b/Blockchain/Logging/ConsoleLogDestination.swift
@@ -1,0 +1,15 @@
+//
+//  ConsoleLogDestination.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 7/24/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+class ConsoleLogDestination: LogDestination {
+    func log(statement: String) {
+        print(statement)
+    }
+}

--- a/Blockchain/Logging/LogDestination.swift
+++ b/Blockchain/Logging/LogDestination.swift
@@ -1,0 +1,19 @@
+//
+//  LogDestination.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 7/24/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol description for a log statement destination (e.g. console, file, remote, etc.)
+protocol LogDestination {
+
+    /// Logs a statement to this destination.
+    ///
+    /// - Parameters:
+    ///   - statement: the statement to log
+    func log(statement: String)
+}

--- a/Blockchain/Logging/LogLevel.swift
+++ b/Blockchain/Logging/LogLevel.swift
@@ -1,0 +1,24 @@
+//
+//  LogLevel.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 7/24/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+enum LogLevel {
+    case debug, info, warning, error
+}
+
+extension LogLevel {
+    var emoji: String {
+        switch self {
+        case .debug: return "🏗"
+        case .info: return "ℹ️"
+        case .warning: return "⚠️"
+        case .error: return "🛑"
+        }
+    }
+}

--- a/Blockchain/Logging/LogLevel.swift
+++ b/Blockchain/Logging/LogLevel.swift
@@ -8,11 +8,13 @@
 
 import Foundation
 
+/// Enumerates the level/severity of a log statement
 enum LogLevel {
     case debug, info, warning, error
 }
 
 extension LogLevel {
+
     var emoji: String {
         switch self {
         case .debug: return "🏗"

--- a/Blockchain/Logging/Logger.swift
+++ b/Blockchain/Logging/Logger.swift
@@ -1,0 +1,98 @@
+//
+//  Logger.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 7/24/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Class in charge of logging debug/info/warning/error messages to a `LogDestination`.
+@objc class Logger: NSObject {
+
+    private var destinations = [LogDestination]()
+
+    static let shared: Logger = {
+        let logger = Logger()
+        #if DEBUG
+        logger.destinations.append(ConsoleLogDestination())
+        #endif
+        return logger
+    }()
+
+    @objc class func sharedInstance() -> Logger { return shared }
+
+    func debug(
+        _ message: String,
+        file: String = #file,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        log(message, level: .debug, file: file, function: function, line: line)
+    }
+
+    func info(
+        _ message: String,
+        file: String = #file,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        log(message, level: .info, file: file, function: function, line: line)
+    }
+
+    func warning(
+        _ message: String,
+        file: String = #file,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        log(message, level: .warning, file: file, function: function, line: line)
+    }
+
+    func error(
+        _ message: String,
+        file: String = #file,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        log(message, level: .error, file: file, function: function, line: line)
+    }
+
+    func log (
+        _ message: String,
+        level: LogLevel,
+        file: String = #file,
+        function: String = #function,
+        line: Int = #line
+    ) {
+        destinations.forEach {
+            let statement = formatMessage(
+                message,
+                level: level,
+                file: file,
+                function: function,
+                line: line
+            )
+            $0.log(statement: statement)
+        }
+    }
+
+    private func formatMessage(
+        _ message: String,
+        level: LogLevel,
+        file: String = #file,
+        function: String = #function,
+        line: Int = #line
+    ) -> String {
+        let logLevelTitle = "\(level)".uppercased()
+        return "\(level.emoji) \(logLevelTitle) \(filename(from: file)).\(function):\(line) - \(message)"
+    }
+
+    private func filename(from file: String) -> String {
+        if let lastComponent = file.components(separatedBy: "/").last {
+            return lastComponent.components(separatedBy: ".").first ?? lastComponent
+        }
+        return file
+    }
+}

--- a/Blockchain/Logging/Logger.swift
+++ b/Blockchain/Logging/Logger.swift
@@ -13,6 +13,12 @@ import Foundation
 
     private var destinations = [LogDestination]()
 
+    private lazy var timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return formatter
+    }()
+
     static let shared: Logger = {
         let logger = Logger()
         #if DEBUG
@@ -22,6 +28,8 @@ import Foundation
     }()
 
     @objc class func sharedInstance() -> Logger { return shared }
+
+    // MARK: - Public
 
     func debug(
         _ message: String,
@@ -78,6 +86,8 @@ import Foundation
         }
     }
 
+    // MARK: - Private
+
     private func formatMessage(
         _ message: String,
         level: LogLevel,
@@ -85,8 +95,9 @@ import Foundation
         function: String = #function,
         line: Int = #line
     ) -> String {
+        let timestamp = timestampFormatter.string(from: Date())
         let logLevelTitle = "\(level)".uppercased()
-        return "\(level.emoji) \(logLevelTitle) \(filename(from: file)).\(function):\(line) - \(message)"
+        return "\(timestamp) \(level.emoji) \(logLevelTitle) \(filename(from: file)).\(function):\(line) - \(message)"
     }
 
     private func filename(from file: String) -> String {

--- a/Blockchain/ModalPresenter.swift
+++ b/Blockchain/ModalPresenter.swift
@@ -65,7 +65,7 @@ typealias OnModalResumed = () -> Void
 
     @objc func closeModal(withTransition transition: String) {
         guard let modalView = modalView else {
-            print("Cannot close modal. modalView is nil.")
+            Logger.shared.warning("Cannot close modal. modalView is nil.")
             return
         }
 

--- a/Blockchain/Models/ExchangeRate.swift
+++ b/Blockchain/Models/ExchangeRate.swift
@@ -51,13 +51,13 @@ import JavaScriptCore
 @objc extension ExchangeRate {
     convenience init?(javaScriptValue: JSValue) {
         guard let dictionary = javaScriptValue.toDictionary() else {
-            print("Could not create dictionary from JSValue")
+            Logger.shared.error("Could not create dictionary from JSValue")
             return nil
         }
 
         let convertToDecimalNumber = { (value: Any?) -> NSDecimalNumber? in
             guard let number = value as? NSNumber else {
-                print("Could not create NSNumber from dictionary value")
+                Logger.shared.error("Could not create NSNumber from dictionary value")
                 return nil
             }
             return NSDecimalNumber(decimal: number.decimalValue)

--- a/Blockchain/Models/Trade.swift
+++ b/Blockchain/Models/Trade.swift
@@ -25,11 +25,11 @@ struct Trade {
 extension Trade {
     init?(dict: [String: String]) {
         guard let tradeHash = dict[Trade.Keys.tradeHash] else {
-            print("Trade hash not found")
+            Logger.shared.warning("Trade hash not found")
             return nil
         }
         guard let tradeDate = dict[Trade.Keys.created] else {
-            print("Trade date not found")
+            Logger.shared.warning("Trade date not found")
             return nil
         }
         hash = tradeHash

--- a/Blockchain/Network/Extensions/HTTPCookieStorage.swift
+++ b/Blockchain/Network/Extensions/HTTPCookieStorage.swift
@@ -12,7 +12,7 @@ extension HTTPCookieStorage {
     func deleteAllCookies() {
         let cookieStorage = HTTPCookieStorage.shared
         guard let cookies = cookieStorage.cookies else {
-            print("No cookies to delete")
+            Logger.shared.info("No cookies to delete")
             return
         }
         cookies.forEach { cookieStorage.deleteCookie($0) }

--- a/Blockchain/Network/Extensions/NetworkManager+PushNotifications.swift
+++ b/Blockchain/Network/Extensions/NetworkManager+PushNotifications.swift
@@ -26,7 +26,7 @@ extension NetworkManager {
         notificationRequest.addValue("application/json", forHTTPHeaderField: "Accept")
         let task = NetworkManager.shared.session.dataTask(with: notificationRequest, completionHandler: { data, response, error in
             guard error == nil else {
-                print("Error registering device with backend: %@", error!.localizedDescription)
+                Logger.shared.error("Error registering device with backend: \(error!.localizedDescription)")
                 return
             }
             guard

--- a/Blockchain/Network/NetworkManager.swift
+++ b/Blockchain/Network/NetworkManager.swift
@@ -103,7 +103,7 @@ class NetworkManager: NSObject, URLSessionDelegate {
 
     func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping AuthChallengeHandler) {
         let host = challenge.protectionSpace.host
-        print("Received challenge from \(host)")
+        Logger.shared.info("Received challenge from \(host)")
         if BlockchainAPI.Endpoints.rawValues.contains(host) ||
             BlockchainAPI.PartnerEndpoints.rawValues.contains(host) {
             completionHandler(.performDefaultHandling, nil)

--- a/Blockchain/Notifications/PushNotificationManager.swift
+++ b/Blockchain/Notifications/PushNotificationManager.swift
@@ -30,11 +30,11 @@ class PushNotificationManager: NSObject {
         let userNotificationCenter = UNUserNotificationCenter.current()
         userNotificationCenter.requestAuthorization(options: [.sound, .alert, .badge]) { _, error in
             guard error == nil else {
-                print("Push registration FAILED")
-                print("ERROR: \(error!.localizedDescription)")
+                Logger.shared.error("Push registration FAILED")
+                Logger.shared.error("ERROR: \(error!.localizedDescription)")
                 return
             }
-            print("Push registration success.")
+            Logger.shared.info("Push registration success.")
             DispatchQueue.main.async {
                 UIApplication.shared.registerForRemoteNotifications()
             }

--- a/Blockchain/Reminder/ReminderPresenter.swift
+++ b/Blockchain/Reminder/ReminderPresenter.swift
@@ -95,7 +95,7 @@ import Foundation
 
     func checkIfSettingsLoadedAndShowTwoFactorReminder() {
         guard !walletManager.wallet.hasEnabledTwoStep() else {
-            print("Two factor already enabled, no need to show a reminder.")
+            Logger.shared.info("Two factor already enabled, no need to show a reminder.")
             return
         }
 

--- a/Blockchain/URL/AssetURLPayloadFactory.swift
+++ b/Blockchain/URL/AssetURLPayloadFactory.swift
@@ -24,7 +24,7 @@ import Foundation
     @objc static func create(fromString string: String, assetType: AssetType) -> AssetURLPayload? {
         if string.contains(":") {
             guard let url = URL(string: string) else {
-                print("Could not create payload from URL \(string)")
+                Logger.shared.warning("Could not create payload from URL \(string)")
                 return nil
             }
             return create(from: url)
@@ -42,7 +42,7 @@ import Foundation
 
     @objc static func create(from url: URL) -> AssetURLPayload? {
         guard let scheme = url.scheme else {
-            print("Cannot create AssetURLPayload. Scheme is nil.")
+            Logger.shared.warning("Cannot create AssetURLPayload. Scheme is nil.")
             return nil
         }
 

--- a/Blockchain/Views/BCPriceMarker.swift
+++ b/Blockchain/Views/BCPriceMarker.swift
@@ -108,7 +108,7 @@ open class BCPriceMarker: MarkerImage {
                 fatalError("Chart data entry has bad data")
         }
         guard let number = NumberFormatter.fiatString(from: entry.y) else {
-            print("Could not generate number string from chart data entry")
+            Logger.shared.warning("Could not generate number string from chart data entry")
             setLabel(currency)
             return
         }

--- a/Blockchain/Wallet/JSContextWithDOM.swift
+++ b/Blockchain/Wallet/JSContextWithDOM.swift
@@ -54,7 +54,7 @@ class JSContextWithDOM: JSContext {
 
         consoleNames.forEach { name in
             let consoleLog: @convention(block) (String) -> Void = { message in
-                print("Javascript \(name): \(message)")
+                Logger.shared.debug("Javascript \(name): \(message)")
             }
             self.objectForKeyedSubscript("console").setObject(consoleLog, forKeyedSubscript: name as NSString)
         }
@@ -63,24 +63,24 @@ class JSContextWithDOM: JSContext {
     private func setupExceptionHandler() {
         self.exceptionHandler = { context, exception in
             guard let exception = exception else {
-                print("Exception handler error: could not get exception")
+                Logger.shared.error("Exception handler error: could not get exception")
                 return
             }
             guard let message = exception.toString() else {
-                print("Exception handler error: could not get message")
+                Logger.shared.error("Exception handler error: could not get message")
                 return
             }
             guard let stackTrace = exception.objectForKeyedSubscript("stack").toString() else {
-                print("Exception handler error: could not get stack trace")
-                print("Message: \(message)")
+                Logger.shared.error("Exception handler error: could not get stack trace")
+                Logger.shared.error("Message: \(message)")
                 return
             }
             guard let lineNumber = exception.objectForKeyedSubscript("line").toString() else {
-                print("Exception handler error: could not get line number")
-                print("Message: \(message) \nstack:\(stackTrace)")
+                Logger.shared.error("Exception handler error: could not get line number")
+                Logger.shared.error("Message: \(message) \nstack:\(stackTrace)")
                 return
             }
-            print("\(message) \nstack: \(stackTrace)\nline number: \(lineNumber)")
+            Logger.shared.error("\(message) \nstack: \(stackTrace)\nline number: \(lineNumber)")
         }
     }
 

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -133,11 +133,11 @@ class WalletManager: NSObject {
 
     private func updateFiatSymbols() {
         guard let fiatCode = self.wallet.accountInfo["currency"] as? String else {
-            print("Could not get fiat code")
+            Logger.shared.warning("Could not get fiat code")
             return
         }
         guard let currencySymbols = self.wallet.btcRates[fiatCode] as? [AnyHashable: Any] else {
-            print("Currency symbols dictionary is nil")
+            Logger.shared.warning("Currency symbols dictionary is nil")
             return
         }
         let symbolLocalDict = NSMutableDictionary(dictionary: currencySymbols)
@@ -147,7 +147,7 @@ class WalletManager: NSObject {
 
     private func updateBtcSymbols() {
         guard let code = self.wallet.accountInfo["btc_currency"] as? String else {
-            print("Could not get btc code")
+            Logger.shared.warning("Could not get btc code")
             return
         }
         self.latestMultiAddressResponse?.symbol_btc = CurrencySymbol.btcSymbol(fromCode: code)
@@ -163,12 +163,12 @@ extension WalletManager: WalletDelegate {
     // MARK: - Auth
 
     func walletDidLoad() {
-        print("walletDidLoad()")
+        Logger.shared.info("walletDidLoad()")
         endBackgroundUpdateTask()
     }
 
     func walletDidDecrypt() {
-        print("walletDidDecrypt()")
+        Logger.shared.info("walletDidDecrypt()")
 
         DispatchQueue.main.async { [unowned self] in
             self.authDelegate?.didDecryptWallet(
@@ -182,7 +182,7 @@ extension WalletManager: WalletDelegate {
     }
 
     func walletDidFinishLoad() {
-        print("walletDidFinishLoad()")
+        Logger.shared.info("walletDidFinishLoad()")
 
         wallet.btcSwipeAddressToSubscribe = nil
         wallet.bchSwipeAddressToSubscribe = nil
@@ -194,7 +194,7 @@ extension WalletManager: WalletDelegate {
     }
 
     func walletFailedToDecrypt() {
-        print("walletFailedToDecrypt()")
+        Logger.shared.info("walletFailedToDecrypt()")
         DispatchQueue.main.async { [unowned self] in
             self.authDelegate?.authenticationError(error:
                 AuthenticationError(code: AuthenticationError.ErrorCode.errorDecryptingWallet.rawValue)
@@ -203,7 +203,7 @@ extension WalletManager: WalletDelegate {
     }
 
     func walletFailedToLoad() {
-        print("walletFailedToLoad()")
+        Logger.shared.info("walletFailedToLoad()")
         DispatchQueue.main.async { [unowned self] in
             self.authDelegate?.authenticationError(error: AuthenticationError(
                 code: AuthenticationError.ErrorCode.failedToLoadWallet.rawValue
@@ -240,7 +240,7 @@ extension WalletManager: WalletDelegate {
 
     func didCompleteTrade(_ tradeDict: [AnyHashable: Any]!) {
         guard let trade = Trade(dict: tradeDict as! [String: String]) else {
-            print("Failed to create Trade object.")
+            Logger.shared.warning("Failed to create Trade object.")
             return
         }
         DispatchQueue.main.async { [unowned self] in


### PR DESCRIPTION
### Summary

Created a `Logger` class for consolidating all logging into one class. Logging can now be done through using any of the following methods depending on severity: `debug()`, `info()`, `warning()`, `error()`.

Example usage:
```
Logger.shared.debug("A debug statement.")
```

The logged statement will then be displayed on the console which displays a timestamp, the file, method, and line number that invoked the log statement:

<img width="947" alt="screen shot 2018-07-24 at 5 59 10 pm" src="https://user-images.githubusercontent.com/38220701/43173905-1ddfe852-8f6c-11e8-8548-dbe5e91c4097.png">

The `Logger` is also configured differently depending if the build is configured as DEBUG (i.e. no such print statements will be done on release builds).

### Context
A performance problem we have right now is that we are explicitly calling the Swift method `print()` whenever we want to print out information for debugging/error. Although the Swift compiler on occasion can optimize this and remove these calls, that's not always the case. With this new `Logger` class, we can hide ugly `#if DEBUG` calls inside this class.

### Extensibility
In the future, if we also want to add different log destinations (e.g. to file, to a remote server, etc.) we can easily do so by adding another destination in the `Logger` lazy initializer.

...still need to replace NSLog calls but wanted to do a PR to get input before I get too far.

Inspired by: https://github.com/SwiftyBeaver/SwiftyBeaver