### PR TITLE
fix(Strings): Login URL | Change all .info login copy to .com

### DIFF
--- a/Blockchain/Localization/ar.lproj/Localizable.strings
+++ b/Blockchain/Localization/ar.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "تسجيل الدخول إلى شبكة الإنترنت المحفظة";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "انتقل إلى blockchain.info/wallet/login على جهاز الكمبيوتر الخاص بك.";
+"Go to login.blockchain.com on your computer." = "انتقل إلى login.blockchain.com على جهاز الكمبيوتر الخاص بك.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "حدد تسجيل الدخول عبر المحمول.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "نحن نعمل مع تبادل الشركاء في جميع أنحاء العالم ، حتى تتمكن من شراء و بيع بيتكوين مباشرة من محفظتك.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "المحمول شراء وبيع يتم اعتماد دائرة الرقابة الداخلية 9 وما فوق. الرجاء تشغيل برنامج التحديث أو الدخول في blockchain.info/wallet/login على جهاز الكمبيوتر الخاص بك.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "المحمول شراء وبيع يتم اعتماد دائرة الرقابة الداخلية 9 وما فوق. الرجاء تشغيل برنامج التحديث أو الدخول في login.blockchain.com على جهاز الكمبيوتر الخاص بك.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "بيع و شراء بيتكوين الخاص بك مباشرة من Blockchain المحفظة. تبدأ عن طريق إنشاء حساب في شراء وبيع علامة التبويب.";

--- a/Blockchain/Localization/ar.lproj/MainWindow.strings
+++ b/Blockchain/Localization/ar.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "تسجيل الدخول إلى محفظتك بلوكتشين عن طريق جهاز الكمبيوتر أو ماك في https://blockchain.info/wallet/login";
+"361.text" = "تسجيل الدخول إلى محفظتك بلوكتشين عن طريق جهاز الكمبيوتر أو ماك في https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/cs.lproj/Localizable.strings
+++ b/Blockchain/Localization/cs.lproj/Localizable.strings
@@ -1809,7 +1809,7 @@
 "Log in to Web Wallet" = "Přihlásit se na webovou peněženku";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Přejděte na svém počítači na blockchain.info/wallet/login.";
+"Go to login.blockchain.com on your computer." = "Přejděte na svém počítači na login.blockchain.com.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Vyberte přes mobilní zařízení protokol.";
@@ -2439,7 +2439,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Spolupracujeme s výměnou partnerů po celém světě, takže si můžete koupit a prodat bitcoin přímo z vaší peněženky.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobilní Nákup A Prodej je podporován pro iOS 9 a nahoru. Spusťte aktualizaci softwaru, nebo se přihlásit na blockchain.info/wallet/login na vašem počítači.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobilní Nákup A Prodej je podporován pro iOS 9 a nahoru. Spusťte aktualizaci softwaru, nebo se přihlásit na login.blockchain.com na vašem počítači.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Koupit a prodat bitcoin přímo z vašeho Blockchain peněženky. Začněte tím, že vytvoří účet na Nákup A Prodej tab.";

--- a/Blockchain/Localization/cs.lproj/MainWindow.strings
+++ b/Blockchain/Localization/cs.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Přihlaste se ke své peněžence Blockchain přes počítač nebo Mac na stránce
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/da.lproj/Localizable.strings
+++ b/Blockchain/Localization/da.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Log ind på Web Wallet";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Gå til blockchain.info/wallet/login på din computer.";
+"Go to login.blockchain.com on your computer." = "Gå til login.blockchain.com på din computer.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Vælg Log på via mobil.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Vi arbejder med exchange partnere over hele verden, så kan du købe og sælge bitcoin direkte fra din tegnebog.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobile Køb & Sælg understøttes af iOS 9 og op. Skal du køre en software opdatering eller log på blockchain.info/wallet/login på din computer.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobile Køb & Sælg understøttes af iOS 9 og op. Skal du køre en software opdatering eller log på login.blockchain.com på din computer.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Køb og sælg bitcoin direkte fra din Blokkæden tegnebog. Start med at oprette en konto i Køb & Sælg-fanen.";

--- a/Blockchain/Localization/da.lproj/MainWindow.strings
+++ b/Blockchain/Localization/da.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Log ind på din Blockchain tegnebog via din PC eller Mac på https://blockchain.info/wallet/login";
+"361.text" = "Log ind på din Blockchain tegnebog via din PC eller Mac på https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/de.lproj/Localizable.strings
+++ b/Blockchain/Localization/de.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "Melden Sie sich bei der Web-Wallet an";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Gehen Sie dazu auf Ihrem Computer zu blockchain.info/wallet/login.";
+"Go to login.blockchain.com on your computer." = "Gehen Sie dazu auf Ihrem Computer zu login.blockchain.com.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Wählen Sie ‚Mit Mobilgerät anmelden‘.";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Wir arbeiten mit exchange Partner in aller Welt, so dass Sie können, kaufen und verkaufen Sie Bitcoins direkt von Ihrem Geldbeutel.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobile Kaufen & Verkaufen unterstützt wird iOS 9 und up. Bitte führen Sie ein software-update oder dem login auf der blockchain.info/wallet/login auf Ihrem computer.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobile Kaufen & Verkaufen unterstützt wird iOS 9 und up. Bitte führen Sie ein software-update oder dem login auf der login.blockchain.com auf Ihrem computer.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Kaufen und verkaufen Sie Bitcoins direkt von Ihrem Blockchain wallet. Beginnen Sie, indem Sie ein Konto in der Kaufen & Verkaufen tab.";

--- a/Blockchain/Localization/de.lproj/MainWindow.strings
+++ b/Blockchain/Localization/de.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Zur Anmeldung bei Ihrer Blockchain-Wallet per PC oder Mac gehen Sie bitte zu
-https://blockchain.info/wallet/login";
+login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/el.lproj/Localizable.strings
+++ b/Blockchain/Localization/el.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Συνδεθείτε στο Web Πορτοφόλι";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Πάμε να blockchain.info/wallet/login στον υπολογιστή σας.";
+"Go to login.blockchain.com on your computer." = "Πάμε να login.blockchain.com στον υπολογιστή σας.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Επιλέξτε σύνδεση μέσω κινητής τηλεφωνίας.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Συνεργαζόμαστε με τις συναλλαγματικές συνεργάτες σε όλο τον κόσμο, ώστε να μπορείτε να αγοράζουν και να πωλούν bitcoin απευθείας από το πορτοφόλι σας.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Κινητό αγορά & πώληση υποστηρίζεται για iOS 9 και πάνω. Παρακαλούμε να εκτελέσετε μια ενημέρωση λογισμικού ή να συνδεθείτε στο blockchain.info/wallet/login στον υπολογιστή σας.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Κινητό αγορά & πώληση υποστηρίζεται για iOS 9 και πάνω. Παρακαλούμε να εκτελέσετε μια ενημέρωση λογισμικού ή να συνδεθείτε στο login.blockchain.com στον υπολογιστή σας.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Αγοράζουν και να πωλούν bitcoin απευθείας από το Blockchain πορτοφόλι. Ξεκινήστε δημιουργώντας ένα λογαριασμό στο Buy & sell στην καρτέλα.";

--- a/Blockchain/Localization/el.lproj/MainWindow.strings
+++ b/Blockchain/Localization/el.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Συνδεθείτε στο πορτοφόλι σας Blockchain μέσω σας PC ή Mac στο https://blockchain.info/wallet/login";
+"361.text" = "Συνδεθείτε στο πορτοφόλι σας Blockchain μέσω σας PC ή Mac στο https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/en.lproj/MainWindow.strings
+++ b/Blockchain/Localization/en.lproj/MainWindow.strings
@@ -14,8 +14,8 @@
 /* Class = "IBUILabel"; text = "1"; ObjectID = "360"; */
 "360.text" = "1";
 
-/* Class = "IBUITextView"; text = "Login to your Blockchain Wallet via your PC or Mac at https://blockchain.info/wallet/login"; ObjectID = "361"; */
-"361.text" = "Log in to your Blockchain Wallet via your PC or Mac at\nhttps://blockchain.info/wallet/login";
+/* Class = "IBUITextView"; text = "Login to your Blockchain Wallet via your PC or Mac at https://login.blockchain.com"; ObjectID = "361"; */
+"361.text" = "Log in to your Blockchain Wallet via your PC or Mac at\nlogin.blockchain.com";
 
 /* Class = "IBUILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/es-ES.lproj/Localizable.strings
+++ b/Blockchain/Localization/es-ES.lproj/Localizable.strings
@@ -1756,7 +1756,7 @@
 "Log in to Web Wallet" = "Iniciar sesión en Web Wallet";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Visite blockchain.info/wallet/login en su computadora.";
+"Go to login.blockchain.com on your computer." = "Visite login.blockchain.com en su computadora.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Seleccione Iniciar sesión con móvil.";
@@ -2146,7 +2146,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Trabajamos con nuestros socios de intercambio en todo el mundo, así que usted puede comprar y vender bitcoin directamente de su bolsillo.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Móvil Comprar Y Vender es compatible para iOS 9 y hasta. Por favor, ejecute una actualización de software o de inicio de sesión en blockchain.info/wallet/login en su equipo.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Móvil Comprar Y Vender es compatible para iOS 9 y hasta. Por favor, ejecute una actualización de software o de inicio de sesión en login.blockchain.com en su equipo.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Comprar y vender bitcoin directamente desde su monedero de Blockchain. Comience por crear una cuenta en la Compra Y venta de la ficha.";

--- a/Blockchain/Localization/es-ES.lproj/MainWindow.strings
+++ b/Blockchain/Localization/es-ES.lproj/MainWindow.strings
@@ -24,7 +24,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Inicie sesión en su monedero de Blockchain través de su PC o Mac en
-https://blockchain.info/Wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/es-MX.lproj/Localizable.strings
+++ b/Blockchain/Localization/es-MX.lproj/Localizable.strings
@@ -1756,7 +1756,7 @@
 "Log in to Web Wallet" = "Iniciar sesión en Web Wallet";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Visite blockchain.info/wallet/login en su computadora.";
+"Go to login.blockchain.com on your computer." = "Visite login.blockchain.com en su computadora.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Seleccione Iniciar sesión con móvil.";
@@ -2146,7 +2146,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Trabajamos con nuestros socios de intercambio en todo el mundo, así que usted puede comprar y vender bitcoin directamente de su bolsillo.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Móvil Comprar Y Vender es compatible para iOS 9 y hasta. Por favor, ejecute una actualización de software o de inicio de sesión en blockchain.info/wallet/login en su equipo.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Móvil Comprar Y Vender es compatible para iOS 9 y hasta. Por favor, ejecute una actualización de software o de inicio de sesión en login.blockchain.com en su equipo.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Comprar y vender bitcoin directamente desde su monedero de Blockchain. Comience por crear una cuenta en la Compra Y venta de la ficha.";

--- a/Blockchain/Localization/es-MX.lproj/MainWindow.strings
+++ b/Blockchain/Localization/es-MX.lproj/MainWindow.strings
@@ -24,7 +24,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Inicie sesión en su monedero de Blockchain través de su PC o Mac en
-https://blockchain.info/Wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/es.lproj/Localizable.strings
+++ b/Blockchain/Localization/es.lproj/Localizable.strings
@@ -1756,7 +1756,7 @@
 "Log in to Web Wallet" = "Iniciar sesión en Web Wallet";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Visite blockchain.info/wallet/login en su computadora.";
+"Go to login.blockchain.com on your computer." = "Visite login.blockchain.com en su computadora.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Seleccione Iniciar sesión con móvil.";
@@ -2146,7 +2146,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Trabajamos con nuestros socios de intercambio en todo el mundo, así que usted puede comprar y vender bitcoin directamente de su bolsillo.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Móvil Comprar Y Vender es compatible para iOS 9 y hasta. Por favor, ejecute una actualización de software o de inicio de sesión en blockchain.info/wallet/login en su equipo.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Móvil Comprar Y Vender es compatible para iOS 9 y hasta. Por favor, ejecute una actualización de software o de inicio de sesión en login.blockchain.com en su equipo.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Comprar y vender bitcoin directamente desde su monedero de Blockchain. Comience por crear una cuenta en la Compra Y venta de la ficha.";

--- a/Blockchain/Localization/es.lproj/MainWindow.strings
+++ b/Blockchain/Localization/es.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Inicia sesión en tu monedero Blockchain con tu PC o Mac en
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/fi.lproj/Localizable.strings
+++ b/Blockchain/Localization/fi.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Kirjaudu sisään Web-Lompakko";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Mene blockchain.info/wallet/login teidän tietokone.";
+"Go to login.blockchain.com on your computer." = "Mene login.blockchain.com teidän tietokone.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Valitse Kirjaudu sisään kautta mobiili.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Työskentelemme vaihto kumppaneita ympäri maailmaa, joten voit ostaa ja myydä bitcoin suoraan lompakon.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobile Ostaa Ja Myydä on tuettu iOS 9 ja ylös. Suorita ohjelmiston päivitys tai kirjautuminen klo blockchain.info/wallet/login teidän tietokone.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobile Ostaa Ja Myydä on tuettu iOS 9 ja ylös. Suorita ohjelmiston päivitys tai kirjautuminen klo login.blockchain.com teidän tietokone.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Ostaa ja myydä bitcoin suoraan Blockchain lompakko. Aloita luomalla tilin Ostaa Ja Myydä-välilehti.";

--- a/Blockchain/Localization/fi.lproj/MainWindow.strings
+++ b/Blockchain/Localization/fi.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Kirjaudu Blockchain-lompakon kautta PC- tai Mac osoitteessa https://blockchain.info/wallet/login";
+"361.text" = "Kirjaudu Blockchain-lompakon kautta PC- tai Mac osoitteessa https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/fr.lproj/Localizable.strings
+++ b/Blockchain/Localization/fr.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "Se connecter au portefeuille électronique";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Accédez à blockchain.info/wallet/login sur votre ordinateur.";
+"Go to login.blockchain.com on your computer." = "Accédez à login.blockchain.com sur votre ordinateur.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Sélectionnez Se connecter via mobile.";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Nous travaillons avec des partenaires d'échange partout dans le monde, de sorte que vous pouvez acheter et vendre bitcoin directement à partir de votre porte-monnaie.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobile Acheter Et de Vendre est prise en charge pour iOS 9 et. S'il vous plaît exécuter une mise à jour de logiciel ou de connexion à blockchain.info/wallet/login sur votre ordinateur.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobile Acheter Et de Vendre est prise en charge pour iOS 9 et. S'il vous plaît exécuter une mise à jour de logiciel ou de connexion à login.blockchain.com sur votre ordinateur.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Acheter et vendre bitcoin directement à partir de votre Blockchain porte-monnaie. Commencez par créer un compte en Acheter Et Vendre de l'onglet.";

--- a/Blockchain/Localization/fr.lproj/MainWindow.strings
+++ b/Blockchain/Localization/fr.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Connectez-vous à votre portefeuille Blockchain par le biais de votre PC ou MAC en passant par l'adresse
- https://blockchain.info/wallet/login";
+ https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/he.lproj/Localizable.strings
+++ b/Blockchain/Localization/he.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "היכנס לאתר האינטרנט הארנק";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "ללכת blockchain.info/wallet/login במחשב שלך.";
+"Go to login.blockchain.com on your computer." = "ללכת login.blockchain.com במחשב שלך.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "בחר באפשרות התחבר באמצעות הנייד.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "אנחנו עובדים עם exchange שותפים בכל רחבי העולם, אז אתה יכול לקנות ולמכור ביטקוין ישירות לארנק שלך.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "נייד לקנות & למכור נתמך עבור iOS 9 ומעלה. בבקשה להריץ עדכון תוכנה או התחברות ב blockchain.info/wallet/login במחשב שלך.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "נייד לקנות & למכור נתמך עבור iOS 9 ומעלה. בבקשה להריץ עדכון תוכנה או התחברות ב login.blockchain.com במחשב שלך.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "לקנות ולמכור ביטקוין ישירות מה-Blockchain הארנק. התחל על ידי יצירת חשבון לקנות & למכור כרטיסייה.";

--- a/Blockchain/Localization/he.lproj/MainWindow.strings
+++ b/Blockchain/Localization/he.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "התחבר עם הארנק שלך Blockchain דרך PC או Mac שלך ב- https://blockchain.info/wallet/login";
+"361.text" = "התחבר עם הארנק שלך Blockchain דרך PC או Mac שלך ב- https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/hi.lproj/MainWindow.strings
+++ b/Blockchain/Localization/hi.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "अपने पीसी या मैक के जरिए अपने Blockchain बटुए में, https://blockchain.info/wallet/login में प्रवेश करें";
+"361.text" = "अपने पीसी या मैक के जरिए अपने Blockchain बटुए में, https://login.blockchain.com में प्रवेश करें";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/hr.lproj/Localizable.strings
+++ b/Blockchain/Localization/hr.lproj/Localizable.strings
@@ -1719,7 +1719,7 @@
 "Log in to Web Wallet" = "Prijavite se na web-novčanik";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Idi na blockchain.info/wallet/login na vašem računalu.";
+"Go to login.blockchain.com on your computer." = "Idi na login.blockchain.com na vašem računalu.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Odaberite Prijavite se koristeći svoj mobilni.";
@@ -2088,7 +2088,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Mi radimo s poslovnim partnerima širom svijeta, tako da možete kupiti i prodati bitcoin izravno s Vašeg novčanika.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobilni Kupiti i prodati održava na iOS 9 i gore. Molimo vas ažurirajte softver ili se prijavite na blockchain.info/wallet/login na vašem računalu.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobilni Kupiti i prodati održava na iOS 9 i gore. Molimo vas ažurirajte softver ili se prijavite na login.blockchain.com na vašem računalu.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Kupovati i prodavati биткойны izravno iz svog novčanika blockchain. Počnite sa stvaranjem računa u odjeljku za Kupiti i prodati.";

--- a/Blockchain/Localization/hr.lproj/MainWindow.strings
+++ b/Blockchain/Localization/hr.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Prijavite se na novčanik Blockchain preko PC ili Mac u https://blockchain.info/wallet/login";
+"361.text" = "Prijavite se na novčanik Blockchain preko PC ili Mac u https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/hu.lproj/Localizable.strings
+++ b/Blockchain/Localization/hu.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Jelentkezzen be Internetes Pénztárca";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Menni blockchain.info/wallet/login a számítógépen.";
+"Go to login.blockchain.com on your computer." = "Menni login.blockchain.com a számítógépen.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Válasszuk a Napló, a via mobil.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Dolgozunk az exchange partnerek a világ minden tájáról, így meg lehet vásárolni, illetve eladni a bitcoin közvetlenül a tárca.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobil Vásárlás & Eladni támogatott iOS 9. Kérjük, fuss egy szoftver frissítés vagy a bejelentkezési blockchain.info/wallet/login a számítógépen.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobil Vásárlás & Eladni támogatott iOS 9. Kérjük, fuss egy szoftver frissítés vagy a bejelentkezési login.blockchain.com a számítógépen.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Vásárolni, illetve eladni a bitcoin közvetlenül a Blokklánc tárca. Először hozzon létre egy fiókot a Buy & Eladni a lapot.";

--- a/Blockchain/Localization/hu.lproj/MainWindow.strings
+++ b/Blockchain/Localization/hu.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Jelentkezz be hogy a Blockchain pénztárca, keresztül a PC vagy Mac https://blockchain.info/wallet/login";
+"361.text" = "Jelentkezz be hogy a Blockchain pénztárca, keresztül a PC vagy Mac https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/id.lproj/Localizable.strings
+++ b/Blockchain/Localization/id.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "Masuk ke Dompet Web";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Kunjungi blockchain.info/wallet/login dari komputer Anda.";
+"Go to login.blockchain.com on your computer." = "Kunjungi login.blockchain.com dari komputer Anda.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Pilih Masuk melalui ponsel.";
@@ -2146,7 +2146,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Kami bekerja dengan mitra di seluruh dunia, sehingga anda dapat membeli dan menjual bitcoin langsung dari dompet anda.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobile Membeli & Menjual didukung untuk iOS 9 dan ke atas. Silahkan jalankan software update atau login di blockchain.info/wallet/login pada komputer anda.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobile Membeli & Menjual didukung untuk iOS 9 dan ke atas. Silahkan jalankan software update atau login di login.blockchain.com pada komputer anda.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Membeli dan menjual bitcoin dari Blockchain wallet. Mulai dengan membuat akun di Beli & Jual tab.";

--- a/Blockchain/Localization/id.lproj/MainWindow.strings
+++ b/Blockchain/Localization/id.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Masuk ke Dompet Blockchain Anda melalui PC atau Mac di
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/it.lproj/Localizable.strings
+++ b/Blockchain/Localization/it.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "Accedi al Web Wallet";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Visita blockchain.info/wallet/login dal tuo computer.";
+"Go to login.blockchain.com on your computer." = "Visita login.blockchain.com dal tuo computer.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Seleziona Accedi via mobile.";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Lavoriamo con partner di scambio in tutto il mondo, in modo che si può comprare e vendere bitcoin direttamente dal vostro portafoglio.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobile Buy & Sell è supportato per iOS 9 e fino. Si prega di eseguire un aggiornamento del software o di accesso a blockchain.info/wallet/login sul tuo computer.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobile Buy & Sell è supportato per iOS 9 e fino. Si prega di eseguire un aggiornamento del software o di accesso a login.blockchain.com sul tuo computer.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Comprare e vendere bitcoin direttamente dalla Blockchain portafoglio. Iniziare creando un account nel Comprare e Vendere tab.";

--- a/Blockchain/Localization/it.lproj/MainWindow.strings
+++ b/Blockchain/Localization/it.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Accedi al tuo Portafoglio Blockchain attraverso il tuo PC o Mac su
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/ja.lproj/Localizable.strings
+++ b/Blockchain/Localization/ja.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "ウェブウォレットにログイン";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "コンピューターからblockchain.info/wallet/loginにアクセス。";
+"Go to login.blockchain.com on your computer." = "コンピューターからlogin.blockchain.comにアクセス。";
 
 /* (No Commment) */
 "Select Log in via mobile." = "モバイル経由でログインを選択。";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "作品にしました交流パートナーは、世界中を購入することができるように売却のビットコインから直接お財布にも優します。";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "モバイル販売できるようになりましたiOS9びます。 を実行してくださいソフトウェアのアップデートまたはログインblockchain.info/wallet/login パソコンです。";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "モバイル販売できるようになりましたiOS9びます。 を実行してくださいソフトウェアのアップデートまたはログインlogin.blockchain.com パソコンです。";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "売買ビットコインから直接Blockchain財布です。 開始によるアカウントを作成したり、の販売す。";

--- a/Blockchain/Localization/ja.lproj/MainWindow.strings
+++ b/Blockchain/Localization/ja.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "https://blockchain.info/wallet/login
+"361.text" = "https://login.blockchain.com
 からPCもしくはMacでブロックチェーンウォレットにログイン";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */

--- a/Blockchain/Localization/ko.lproj/Localizable.strings
+++ b/Blockchain/Localization/ko.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "웹 지갑에 로그인";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "컴퓨터에서 blockchain.info/wallet/login으로 가세요.";
+"Go to login.blockchain.com on your computer." = "컴퓨터에서 login.blockchain.com으로 가세요.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "휴대폰 로그인을 선택하세요.";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "우리는 작품으로 교환 파트너가 세계의 모든,그래서 당신은 살 수 있다고 판매하고 비트코인에서 직접 지갑니다.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "모바일 구매 및 판매 지원에 대한 iOS9 니다. 실행하십시오 소프트웨어 업데이트하거나 로그인 blockchain.info/wallet/login 에서 귀하의 컴퓨터입니다.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "모바일 구매 및 판매 지원에 대한 iOS9 니다. 실행하십시오 소프트웨어 업데이트하거나 로그인 login.blockchain.com 에서 귀하의 컴퓨터입니다.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "구매 및 판매하는 비트코인에서 직접 Blockchain 지갑니다. 시작으로 계정을 만들에서 구매 및 판매하는 탭입니다.";

--- a/Blockchain/Localization/ko.lproj/MainWindow.strings
+++ b/Blockchain/Localization/ko.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "
-https://blockchain.info/wallet/login에서 PC 또는 Mac으로 귀하 블록체인 지갑에 로그인 하세요";
+https://login.blockchain.com에서 PC 또는 Mac으로 귀하 블록체인 지갑에 로그인 하세요";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/ms.lproj/Localizable.strings
+++ b/Blockchain/Localization/ms.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Masuk ke Web Dompet";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Pergi ke blockchain.info/wallet/login pada komputer anda.";
+"Go to login.blockchain.com on your computer." = "Pergi ke login.blockchain.com pada komputer anda.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Memilih masuk melalui telefon bimbit.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Kami bekerja dengan rakan-rakan pertukaran seluruh dunia, jadi kau bisa membeli dan menjual kripto langsung dari dompet anda.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Bergerak Jual Beli disokong hack 9 dan up. Sila menjalankan perangkat kemas atau masuk blockchain.info/wallet/login pada komputer anda.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Bergerak Jual Beli disokong hack 9 dan up. Sila menjalankan perangkat kemas atau masuk login.blockchain.com pada komputer anda.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Membeli dan menjual kripto langsung dari anda Menerima dompet. Mulailah dengan membuat akaun di Jual Beli tab.";

--- a/Blockchain/Localization/ms.lproj/MainWindow.strings
+++ b/Blockchain/Localization/ms.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Log masuk ke dompet Blockchain melalui PC anda atau Mac di https://blockchain.info/wallet/login";
+"361.text" = "Log masuk ke dompet Blockchain melalui PC anda atau Mac di https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/nb.lproj/Localizable.strings
+++ b/Blockchain/Localization/nb.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Logg deg på Web-Pengebok";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Gå til blockchain.info/wallet/login på datamaskinen.";
+"Go to login.blockchain.com on your computer." = "Gå til login.blockchain.com på datamaskinen.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Velg Logg inn via mobil.";
@@ -2028,7 +2028,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Vi jobber med utveksling partnere over hele verden slik at du kan kjøpe og selge bitcoin direkte fra lommeboken.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobile Kjøpe & Selge støttes for iOS 9 og opp. Kjør en programvareoppdatering, eller logg på blockchain.info/wallet/login på datamaskinen.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobile Kjøpe & Selge støttes for iOS 9 og opp. Kjør en programvareoppdatering, eller logg på login.blockchain.com på datamaskinen.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Kjøpe og selge bitcoin direkte fra din Blockchain lommebok. Start med å opprette en konto i Kjøpe & Selge kategorien.";

--- a/Blockchain/Localization/nb.lproj/MainWindow.strings
+++ b/Blockchain/Localization/nb.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Logg på lommeboken Blockchain via PC eller Mac på https://blockchain.info/wallet/login";
+"361.text" = "Logg på lommeboken Blockchain via PC eller Mac på https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/nl.lproj/Localizable.strings
+++ b/Blockchain/Localization/nl.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "Log in op Web Wallet";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Ga naar blockchain.info/wallet/login op uw computer.";
+"Go to login.blockchain.com on your computer." = "Ga naar login.blockchain.com op uw computer.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Selecteer Log in via mobiel.";
@@ -2389,7 +2389,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Wij werken met de partners over de hele wereld, zodat u kunt kopen en verkopen bitcoin rechtstreeks uit uw portemonnee.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobiel Kopen & Verkopen wordt ondersteund voor iOS 9 en hoger. Voer een software-update of login aan blockchain.info/wallet/login op uw computer.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobiel Kopen & Verkopen wordt ondersteund voor iOS 9 en hoger. Voer een software-update of login aan login.blockchain.com op uw computer.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Kopen en verkopen van bitcoin direct van uw Blockchain portemonnee. Begin met het aanmaken van een account in het Kopen & Verkopen tabblad.";

--- a/Blockchain/Localization/nl.lproj/MainWindow.strings
+++ b/Blockchain/Localization/nl.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Log in op uw Blockchain Portemonnee via uw pc of Mac op
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/pl.lproj/Localizable.strings
+++ b/Blockchain/Localization/pl.lproj/Localizable.strings
@@ -1834,7 +1834,7 @@
 "Log in to Web Wallet" = "Zaloguj się do Portfela internetowego";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Przejdź do blockchain.info/wallet/login na swoim komputerze.";
+"Go to login.blockchain.com on your computer." = "Przejdź do login.blockchain.com na swoim komputerze.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Wybierz Logowanie przez urządzenie mobilne.";
@@ -2203,7 +2203,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Współpracujemy z partnerami na całym świecie, tak, że można kupić i sprzedać bitcoin bezpośrednio z Twojego portfela.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Telefon Kupić i sprzedać obsługiwane na iOS 9 i wyżej. Proszę wykonać aktualizację oprogramowania lub zaloguj się na blockchain.info/wallet/login na swoim komputerze.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Telefon Kupić i sprzedać obsługiwane na iOS 9 i wyżej. Proszę wykonać aktualizację oprogramowania lub zaloguj się na login.blockchain.com na swoim komputerze.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Kupować i sprzedawać bitcoiny bezpośrednio ze swojego portfela blockchain. Zacznij od utworzenia konta w dziale Kupić i sprzedać.";

--- a/Blockchain/Localization/pl.lproj/MainWindow.strings
+++ b/Blockchain/Localization/pl.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Zaloguj się do swojego Portfela Blockchain za pomocą swojego PC lub Maca pod adresem 
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/pt-BR.lproj/Localizable.strings
+++ b/Blockchain/Localization/pt-BR.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "Faça login na Carteira Web";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Acesse blockchain.info/wallet/login no seu computador.";
+"Go to login.blockchain.com on your computer." = "Acesse login.blockchain.com no seu computador.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Selecione a opção Login via celular.";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Trabalhamos com troca de parceiros em todo o mundo, assim você pode comprar e vender bitcoin diretamente de sua carteira.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Móveis de Compra & Venda é suportado para iOS de 9 e para cima. Por favor, execute uma atualização de software ou o login em blockchain.info/wallet/login em seu computador.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Móveis de Compra & Venda é suportado para iOS de 9 e para cima. Por favor, execute uma atualização de software ou o login em login.blockchain.com em seu computador.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Comprar e vender bitcoin directamente a partir do seu Blockchain carteira. Comece por criar uma conta na Compra & Venda de guia.";

--- a/Blockchain/Localization/pt-BR.lproj/MainWindow.strings
+++ b/Blockchain/Localization/pt-BR.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Acesse sua Carteira Blockchain com PC ou Mac em
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/pt-PT.lproj/Localizable.strings
+++ b/Blockchain/Localization/pt-PT.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Iniciar sessão no Web Carteira";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Ir para blockchain.info/wallet/login em seu computador.";
+"Go to login.blockchain.com on your computer." = "Ir para login.blockchain.com em seu computador.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Seleccione Registo na via celular.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Trabalhamos com troca de parceiros em todo o mundo, assim você pode comprar e vender bitcoin diretamente de sua carteira.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Móveis de Compra & Venda é suportado para iOS de 9 e para cima. Por favor, execute uma atualização de software ou o login em blockchain.info/wallet/login em seu computador.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Móveis de Compra & Venda é suportado para iOS de 9 e para cima. Por favor, execute uma atualização de software ou o login em login.blockchain.com em seu computador.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Comprar e vender bitcoin directamente a partir do seu Blockchain carteira. Comece por criar uma conta na Compra & Venda de guia.";

--- a/Blockchain/Localization/pt-PT.lproj/MainWindow.strings
+++ b/Blockchain/Localization/pt-PT.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Faça logon sua carteira de Blockchain através do seu PC ou Mac em https://blockchain.info/wallet/login";
+"361.text" = "Faça logon sua carteira de Blockchain através do seu PC ou Mac em https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/pt.lproj/Localizable.strings
+++ b/Blockchain/Localization/pt.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Iniciar sessão no Web Carteira";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Ir para blockchain.info/wallet/login em seu computador.";
+"Go to login.blockchain.com on your computer." = "Ir para login.blockchain.com em seu computador.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Seleccione Registo na via celular.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Trabalhamos com troca de parceiros em todo o mundo, assim você pode comprar e vender bitcoin diretamente de sua carteira.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Móveis de Compra & Venda é suportado para iOS de 9 e para cima. Por favor, execute uma atualização de software ou o login em blockchain.info/wallet/login em seu computador.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Móveis de Compra & Venda é suportado para iOS de 9 e para cima. Por favor, execute uma atualização de software ou o login em login.blockchain.com em seu computador.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Comprar e vender bitcoin directamente a partir do seu Blockchain carteira. Comece por criar uma conta na Compra & Venda de guia.";

--- a/Blockchain/Localization/pt.lproj/MainWindow.strings
+++ b/Blockchain/Localization/pt.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Faça logon sua carteira de Blockchain através do seu PC ou Mac em https://blockchain.info/wallet/login";
+"361.text" = "Faça logon sua carteira de Blockchain através do seu PC ou Mac em https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/ro.lproj/Localizable.strings
+++ b/Blockchain/Localization/ro.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Conectați-vă la Web Portofel";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Du-te la blockchain.info/wallet/login de pe computer.";
+"Go to login.blockchain.com on your computer." = "Du-te la login.blockchain.com de pe computer.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Selectați Conectați-vă prin intermediul telefoanelor mobile.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Noi lucram cu parteneri de schimb peste tot în lume, astfel încât să puteți cumpăra și vinde bitcoin direct din portofel.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobile Cumpara Si Vinde este acceptată pentru iOS 9 și în sus. Vă rugăm să executați o actualizare de software sau de conectare la blockchain.info/wallet/login de pe computer.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobile Cumpara Si Vinde este acceptată pentru iOS 9 și în sus. Vă rugăm să executați o actualizare de software sau de conectare la login.blockchain.com de pe computer.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Cumpăra și vinde bitcoin direct de pe Blockchain portofel. Începeți prin crearea unui cont în Cumpar & vand tab.";

--- a/Blockchain/Localization/ro.lproj/MainWindow.strings
+++ b/Blockchain/Localization/ro.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Conectaţi la portofel Blockchain prin intermediul PC sau Mac la https://blockchain.info/wallet/login";
+"361.text" = "Conectaţi la portofel Blockchain prin intermediul PC sau Mac la https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/ru.lproj/Localizable.strings
+++ b/Blockchain/Localization/ru.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "Войти в онлайн кошелек";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Зайдите на blockchain.info/wallet/login на своем компьютере.";
+"Go to login.blockchain.com on your computer." = "Зайдите на login.blockchain.com на своем компьютере.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Выбрать вход через телефон.";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Мы работаем с деловыми партнерами по всему миру, так что вы можете купить и продать bitcoin напрямую с Вашего кошелька.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Мобильный Купить и продать поддерживается на iOS 9 и выше. Пожалуйста, выполните обновление программного обеспечения или войдите на blockchain.info/wallet/login на вашем компьютере.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Мобильный Купить и продать поддерживается на iOS 9 и выше. Пожалуйста, выполните обновление программного обеспечения или войдите на login.blockchain.com на вашем компьютере.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Покупать и продавать биткойны прямо из своего кошелька blockchain. Начните с создания учетной записи в разделе Купить и продать.";

--- a/Blockchain/Localization/ru.lproj/MainWindow.strings
+++ b/Blockchain/Localization/ru.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Войдите в свой кошелек Blockchain со своего ПК или Mac по ссылке
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/sk.lproj/Localizable.strings
+++ b/Blockchain/Localization/sk.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Prihlásenie na Web Peňaženky";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Prejsť na blockchain.info/wallet/login na vašom počítači.";
+"Go to login.blockchain.com on your computer." = "Prejsť na login.blockchain.com na vašom počítači.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Vyberte Prihlásiť cez mobil.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Pracujeme s výmenou partnerov po celom svete, takže môžete nakupovať a predávať bitcoin priamo z peňaženky.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobile Kúpiť A Predať je podporované pre iOS 9 a hore. Prosím, spustite aktualizáciu softvéru, alebo sa prihlásiť na blockchain.info/wallet/login na vašom počítači.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobile Kúpiť A Predať je podporované pre iOS 9 a hore. Prosím, spustite aktualizáciu softvéru, alebo sa prihlásiť na login.blockchain.com na vašom počítači.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Nákup a predaj bitcoin priamo z vášho Blockchain peňaženky. Začnite vytvorením účtu v Buy & Sell tab.";

--- a/Blockchain/Localization/sk.lproj/MainWindow.strings
+++ b/Blockchain/Localization/sk.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Prihláste sa do vašej peňaženky Blockchain cez PC alebo Mac na https://blockchain.info/wallet/login";
+"361.text" = "Prihláste sa do vašej peňaženky Blockchain cez PC alebo Mac na https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/sl.lproj/Localizable.strings
+++ b/Blockchain/Localization/sl.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Prijavite se v Spletne Denarnice";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Pojdi na blockchain.info/wallet/login na vaš računalnik.";
+"Go to login.blockchain.com on your computer." = "Pojdi na login.blockchain.com na vaš računalnik.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Izberite Prijavite prek mobilnih.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Sodelujemo z izmenjavo partnerjev po vsem svetu, tako da boste lahko kupujejo in prodajajo bitcoin neposredno iz vaše denarnice.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobilni Kupiti In Prodati, je podprta za iOS 9 in navzgor. Prosimo, da zaženete posodobitev programske opreme, ali prijava na blockchain.info/wallet/login na vaš računalnik.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobilni Kupiti In Prodati, je podprta za iOS 9 in navzgor. Prosimo, da zaženete posodobitev programske opreme, ali prijava na login.blockchain.com na vaš računalnik.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Nakup in prodaja bitcoin neposredno iz vašega Blockchain denarnice. Začnete z ustvarjanjem računa v Nakup & Prodaja zavihek.";

--- a/Blockchain/Localization/sl.lproj/MainWindow.strings
+++ b/Blockchain/Localization/sl.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Prijavite se v denarnici Blockchain preko PC ali Mac na https://blockchain.info/wallet/login";
+"361.text" = "Prijavite se v denarnici Blockchain preko PC ali Mac na https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/sv-SE.lproj/Localizable.strings
+++ b/Blockchain/Localization/sv-SE.lproj/Localizable.strings
@@ -1731,7 +1731,7 @@
 "Log in to Web Wallet" = "Logga in på Webben Plånbok";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Gå till blockchain.info/wallet/login på din dator.";
+"Go to login.blockchain.com on your computer." = "Gå till login.blockchain.com på din dator.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Välj att Logga in via mobilen.";
@@ -2100,7 +2100,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Vi arbetar med utbyte partners över hela världen, så att du kan köpa och sälja bitcoin direkt från din plånbok.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobila Köp & Sälj är stöd för iOS-9 och uppåt. Kör en uppdatering av programvaran eller logga in på blockchain.info/wallet/login på din dator.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobila Köp & Sälj är stöd för iOS-9 och uppåt. Kör en uppdatering av programvaran eller logga in på login.blockchain.com på din dator.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Köpa och sälja bitcoin direkt från din Blockchain plånbok. Börja med att skapa ett konto i Köp & Sälj-fliken.";

--- a/Blockchain/Localization/sv-SE.lproj/MainWindow.strings
+++ b/Blockchain/Localization/sv-SE.lproj/MainWindow.strings
@@ -23,7 +23,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Logga in på din Blockchain plånbok via din PC eller Mac på https://blockchain.info/wallet/login";
+"361.text" = "Logga in på din Blockchain plånbok via din PC eller Mac på https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/sv.lproj/Localizable.strings
+++ b/Blockchain/Localization/sv.lproj/Localizable.strings
@@ -1731,7 +1731,7 @@
 "Log in to Web Wallet" = "Logga in på Webben Plånbok";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Gå till blockchain.info/wallet/login på din dator.";
+"Go to login.blockchain.com on your computer." = "Gå till login.blockchain.com på din dator.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Välj att Logga in via mobilen.";
@@ -2100,7 +2100,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Vi arbetar med utbyte partners över hela världen, så att du kan köpa och sälja bitcoin direkt från din plånbok.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobila Köp & Sälj är stöd för iOS-9 och uppåt. Kör en uppdatering av programvaran eller logga in på blockchain.info/wallet/login på din dator.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobila Köp & Sälj är stöd för iOS-9 och uppåt. Kör en uppdatering av programvaran eller logga in på login.blockchain.com på din dator.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Köpa och sälja bitcoin direkt från din Blockchain plånbok. Börja med att skapa ett konto i Köp & Sälj-fliken.";

--- a/Blockchain/Localization/sv.lproj/MainWindow.strings
+++ b/Blockchain/Localization/sv.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "Logga in på din Blockchain plånbok via din PC eller Mac på https://blockchain.info/wallet/login";
+"361.text" = "Logga in på din Blockchain plånbok via din PC eller Mac på https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/th.lproj/Localizable.strings
+++ b/Blockchain/Localization/th.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "ล็อกอินไปยังกระเป๋าเงินบนเว็บ";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "ไปยัง blockchain.info/wallet/login บนคอมพิวเตอร์ของคุณ";
+"Go to login.blockchain.com on your computer." = "ไปยัง login.blockchain.com บนคอมพิวเตอร์ของคุณ";
 
 /* (No Commment) */
 "Select Log in via mobile." = "เลือกล็อกอินผ่านมือถือ";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "เราทำงานกับการแลกเปลี่ยนคู่ทำแล็บทั่วโลกดังนั้นคุณสามารถซื้อและขาย bitcoin โดยตรงจากกระเป๋าเงินของนาย";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "เคลื่อนที่ซื้อของ&ขายคือการรองรับสำหรับ iOS 9 แล้ว ได้โปรดไปโปรแกรมปรับปรุงหรือล็อกอินที่ blockchain.info/wallet/login บนคอมพิวเตอร์ของคุณ.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "เคลื่อนที่ซื้อของ&ขายคือการรองรับสำหรับ iOS 9 แล้ว ได้โปรดไปโปรแกรมปรับปรุงหรือล็อกอินที่ login.blockchain.com บนคอมพิวเตอร์ของคุณ.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "ซื้อและขาย bitcoin โดยตรงจากของคุณ Blockchain กระเป๋าคุมข้อมูลนะ เริ่มด้วยการสร้างบัญชีในการซื้อ-ขา&ขายแท็บอก";

--- a/Blockchain/Localization/th.lproj/MainWindow.strings
+++ b/Blockchain/Localization/th.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "ล็อกอินไปยังกระเป๋าเงิน Blockchain ของคุณผ่านทาง PC หรือ Mac ของคุณที่
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/tr.lproj/Localizable.strings
+++ b/Blockchain/Localization/tr.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "Web Cüzdanında Oturum Açmak";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Bilgisayarınızda blockchain.info/wallet/login adresine gidin.";
+"Go to login.blockchain.com on your computer." = "Bilgisayarınızda login.blockchain.com adresine gidin.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Bir mobil cihazla oturum açmayı seçin.";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Exchange ortakları ile çalışıyoruz tüm dünyada, doğrudan cüzdanından bitcoin satın almak ve satmak.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Mobil Satın almak Ve Satmak, 9 ve iOS için desteklenir. Bilgisayarınızda blockchain.info/wallet/login yazılım güncellemesi veya giriş çalıştırın.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Mobil Satın almak Ve Satmak, 9 ve iOS için desteklenir. Bilgisayarınızda login.blockchain.com yazılım güncellemesi veya giriş çalıştırın.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Doğrudan Blockchain cüzdanından bitcoin satın almak ve satmak. Satın almak Ve Satmak sekmesinde bir hesap oluşturarak başlayın.";

--- a/Blockchain/Localization/tr.lproj/MainWindow.strings
+++ b/Blockchain/Localization/tr.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Cüzdanınıza
-https://blockchain.info/wallet/login adresinden PC veya Mac cihazınızla giriş yapın.";
+https://login.blockchain.com adresinden PC veya Mac cihazınızla giriş yapın.";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/uk.lproj/Localizable.strings
+++ b/Blockchain/Localization/uk.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "Вхід у веб-гаманець";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Перейдіть на blockchain.info/wallet/login на своєму комп'ютері.";
+"Go to login.blockchain.com on your computer." = "Перейдіть на login.blockchain.com на своєму комп'ютері.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Виберіть увійти через мобільний пристрій.";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Ми працюємо з діловими партнерами по всьому світу, так що ви можете купити і продати bitcoin безпосередньо з Вашого гаманця.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Мобільний Купити і продати підтримується на iOS 9 і вище. Будь ласка, виконайте оновлення програмного забезпечення або увійдіть на blockchain.info/wallet/login на вашому комп'ютері.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Мобільний Купити і продати підтримується на iOS 9 і вище. Будь ласка, виконайте оновлення програмного забезпечення або увійдіть на login.blockchain.com на вашому комп'ютері.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Купувати і продавати біткойни прямо зі свого гаманця blockchain. Почніть зі створення облікового запису в розділі Купити і продати.";

--- a/Blockchain/Localization/uk.lproj/MainWindow.strings
+++ b/Blockchain/Localization/uk.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Увійдіть у свій гаманець Blockchain з ПК чи Mac на
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/vi.lproj/Localizable.strings
+++ b/Blockchain/Localization/vi.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "Đăng nhập Ví trên Web";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "Truy cập blockchain.info/wallet/login trên máy tính của bạn.";
+"Go to login.blockchain.com on your computer." = "Truy cập login.blockchain.com trên máy tính của bạn.";
 
 /* (No Commment) */
 "Select Log in via mobile." = "Chọn Đăng nhập bằng di động.";
@@ -2103,7 +2103,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "Chúng tôi làm việc trao đổi với các đối tác, tất cả các nơi trên thế giới, do đó bạn có thể mua cho tiền trực tiếp từ ví của bạn.";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "Điện thoại di động Mua Và Bán được hỗ trợ cho trên windows 9 và lên. Xin vui lòng chạy một phần hoặc nhập vào blockchain.info/wallet/login trên máy tính.";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "Điện thoại di động Mua Và Bán được hỗ trợ cho trên windows 9 và lên. Xin vui lòng chạy một phần hoặc nhập vào login.blockchain.com trên máy tính.";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "Mua cho tiền trực tiếp từ Tiểu ví. Bắt đầu bằng cách tạo ra một tài khoản ở đảo Mua Và Bán tab.";

--- a/Blockchain/Localization/vi.lproj/MainWindow.strings
+++ b/Blockchain/Localization/vi.lproj/MainWindow.strings
@@ -27,7 +27,7 @@
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
 "361.text" = "Đăng nhập ví Blockchain của bạn bằng PC hoặc Mac tại
-https://blockchain.info/wallet/login";
+https://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/zh-CN.lproj/Localizable.strings
+++ b/Blockchain/Localization/zh-CN.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "登录web钱包";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "在您的电脑上前往 blockchain.info/wallet/login 。";
+"Go to login.blockchain.com on your computer." = "在您的电脑上前往 login.blockchain.com 。";
 
 /* (No Commment) */
 "Select Log in via mobile." = "选择通过手机登录。";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "我们的工作与交换世界各地的合作伙伴，所以你可以购买和出售特币直接从你的钱包。";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在blockchain.info/wallet/login 上你的计算机。";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在login.blockchain.com 上你的计算机。";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "购买和出售特币直接从你的块链的钱包。 开始通过创建一个帐户在购买和出售标签。";

--- a/Blockchain/Localization/zh-CN.lproj/MainWindow.strings
+++ b/Blockchain/Localization/zh-CN.lproj/MainWindow.strings
@@ -23,7 +23,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "使用您的PC或Mac在https://blockchain.info/wallet/login登录您的Blockchain钱包";
+"361.text" = "使用您的PC或Mac在https://login.blockchain.com登录您的Blockchain钱包";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Blockchain/Localization/zh-Hans.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "登录web钱包";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "在您的电脑上前往 blockchain.info/wallet/login 。";
+"Go to login.blockchain.com on your computer." = "在您的电脑上前往 login.blockchain.com 。";
 
 /* (No Commment) */
 "Select Log in via mobile." = "选择通过手机登录。";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "我们的工作与交换世界各地的合作伙伴，所以你可以购买和出售特币直接从你的钱包。";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在blockchain.info/wallet/login 上你的计算机。";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在login.blockchain.com 上你的计算机。";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "购买和出售特币直接从你的块链的钱包。 开始通过创建一个帐户在购买和出售标签。";

--- a/Blockchain/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Blockchain/Localization/zh-Hant.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "登录到网的钱包";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "去blockchain.info/wallet/login 上你的计算机。";
+"Go to login.blockchain.com on your computer." = "去login.blockchain.com 上你的计算机。";
 
 /* (No Commment) */
 "Select Log in via mobile." = "选择通过移动。";
@@ -2040,7 +2040,7 @@
 
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "我们的工作与交换世界各地的合作伙伴，所以你可以购买和出售特币直接从你的钱包。";
 
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在blockchain.info/wallet/login 上你的计算机。";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在login.blockchain.com 上你的计算机。";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "购买和出售特币直接从你的块链的钱包。 开始通过创建一个帐户在购买和出售标签。";

--- a/Blockchain/Localization/zh-Hant.lproj/MainWindow.strings
+++ b/Blockchain/Localization/zh-Hant.lproj/MainWindow.strings
@@ -26,7 +26,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "登錄到您通過您的 PC 或 Mac 的 Blockchain Wallet 在 HTTPs://blockchain.info/wallet/login";
+"361.text" = "登錄到您通過您的 PC 或 Mac 的 Blockchain Wallet 在 HTTPs://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/zh-TW.lproj/Localizable.strings
+++ b/Blockchain/Localization/zh-TW.lproj/Localizable.strings
@@ -1734,7 +1734,7 @@
 "Log in to Web Wallet" = "登录到网的钱包";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "去blockchain.info/wallet/login 上你的计算机。";
+"Go to login.blockchain.com on your computer." = "去login.blockchain.com 上你的计算机。";
 
 /* (No Commment) */
 "Select Log in via mobile." = "选择通过移动。";
@@ -2040,7 +2040,7 @@
 
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "我们的工作与交换世界各地的合作伙伴，所以你可以购买和出售特币直接从你的钱包。";
 
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在blockchain.info/wallet/login 上你的计算机。";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在login.blockchain.com 上你的计算机。";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "购买和出售特币直接从你的块链的钱包。 开始通过创建一个帐户在购买和出售标签。";

--- a/Blockchain/Localization/zh-TW.lproj/MainWindow.strings
+++ b/Blockchain/Localization/zh-TW.lproj/MainWindow.strings
@@ -23,7 +23,7 @@
 "360.text" = "1";
 
 /* Class = "UILabel"; text = "Login to your Blockchain Wallet via your PC or Mac at\nhttp://blockchain.info/wallet"; ObjectID = "361"; */
-"361.text" = "登錄到您通過您的 PC 或 Mac 的 Blockchain Wallet 在 HTTPs://blockchain.info/wallet/login";
+"361.text" = "登錄到您通過您的 PC 或 Mac 的 Blockchain Wallet 在 HTTPs://login.blockchain.com";
 
 /* Class = "UILabel"; text = "2"; ObjectID = "363"; */
 "363.text" = "2";

--- a/Blockchain/Localization/zh.lproj/Localizable.strings
+++ b/Blockchain/Localization/zh.lproj/Localizable.strings
@@ -1759,7 +1759,7 @@
 "Log in to Web Wallet" = "登录web钱包";
 
 /* (No Commment) */
-"Go to blockchain.info/wallet/login on your computer." = "在您的电脑上前往 blockchain.info/wallet/login 。";
+"Go to login.blockchain.com on your computer." = "在您的电脑上前往 login.blockchain.com 。";
 
 /* (No Commment) */
 "Select Log in via mobile." = "选择通过手机登录。";
@@ -2128,7 +2128,7 @@
 "We work with exchange partners all over the world, so you can buy and sell bitcoin directly from your wallet." = "我们的工作与交换世界各地的合作伙伴，所以你可以购买和出售特币直接从你的钱包。";
 
 /* (No Commment) */
-"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在blockchain.info/wallet/login 上你的计算机。";
+"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer." = "移动购买和销售支持iOS9。 请运行的软件更新或登录在login.blockchain.com 上你的计算机。";
 
 /* (No Commment) */
 "Buy and sell bitcoin directly from your Blockchain wallet. Start by creating an account in the Buy & Sell tab." = "购买和出售特币直接从你的块链的钱包。 开始通过创建一个帐户在购买和出售标签。";

--- a/Blockchain/LocalizationConstants.h
+++ b/Blockchain/LocalizationConstants.h
@@ -550,10 +550,10 @@
 #define BC_STRING_CUSTOM_FEE_WARNING NSLocalizedString(@"This feature is recommended for advanced users only. By choosing a custom fee, you risk overpaying or your transaction may get stuck.", nil)
 
 #define BC_STRING_AVAILABLE_NOW_TITLE NSLocalizedString(@"Available now", nil)
-#define BC_STRING_BUY_SELL_NOT_SUPPORTED_IOS_8_WEB_LOGIN NSLocalizedString(@"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at blockchain.info/wallet/login on your computer.", nil)
+#define BC_STRING_BUY_SELL_NOT_SUPPORTED_IOS_8_WEB_LOGIN NSLocalizedString(@"Mobile Buy & Sell is supported for iOS 9 and up. Please run a software update or login at login.blockchain.com on your computer.", nil)
 
 #define BC_STRING_LOG_IN_TO_WEB_WALLET NSLocalizedString(@"Log in to Web Wallet", nil)
-#define BC_STRING_WEB_LOGIN_INSTRUCTION_STEP_ONE NSLocalizedString(@"Go to blockchain.info/wallet/login on your computer.", nil)
+#define BC_STRING_WEB_LOGIN_INSTRUCTION_STEP_ONE NSLocalizedString(@"Go to login.blockchain.com on your computer.", nil)
 #define BC_STRING_WEB_LOGIN_INSTRUCTION_STEP_TWO NSLocalizedString(@"Select Log in via mobile.", nil)
 #define BC_STRING_WEB_LOGIN_INSTRUCTION_STEP_THREE NSLocalizedString(@"Using your computer's camera, scan the QR code below.", nil)
 #define BC_STRING_WEB_LOGIN_QR_INSTRUCTION_LABEL_HIDDEN NSLocalizedString(@"Keep this QR code hidden until you're ready.", nil)

--- a/scripts/build-js.sh
+++ b/scripts/build-js.sh
@@ -7,7 +7,7 @@ echo "Cleaning..."
 rm -rf build dist
 
 echo "Resetting index.js..."
-git co -- src/index.js
+git checkout -- src/index.js
 
 echo "Injecting navigator and global.crypto into index.js..."
 buffer='var Buffer = require('"'"'buffer'"'"').Buffer;'


### PR DESCRIPTION
## Description ##

Updates all instances of `blockchain.info/login` to now use `login.blockchain.com`. This PR also includes updating `build-js.sh` to use `git checkout` rather than the `git co` alias. 

## How to Test ## 

1. Build and run
2. Tap `Login`.
3. Observe the corrected string value.
4. Create a wallet and/or login
5. Tap `Login to Web Wallet`
6. Observe the corrected string value.

For the `build-js.sh` script, please run the script and observe that it completes successfully. 

## Screenshots ##

<img width="342" alt="screen shot 2018-07-25 at 7 43 19 am" src="https://user-images.githubusercontent.com/41585563/43211611-cd4a3cdc-8fe6-11e8-8a48-0f55c6a31a42.png">
<img width="344" alt="screen shot 2018-07-25 at 8 32 50 am" src="https://user-images.githubusercontent.com/41585563/43211618-cfa31788-8fe6-11e8-9dfe-6978384e1a5b.png">
