### PR TITLE
refactor(KYC): make network calls reusable

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		513C828620EBF30C00ECDE52 /* UIDevice+Biometrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513C826B20EBF30C00ECDE52 /* UIDevice+Biometrics.swift */; };
 		513C828720EBF30C00ECDE52 /* UIDevice+Biometrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513C826B20EBF30C00ECDE52 /* UIDevice+Biometrics.swift */; };
 		5149BD03205718ED00DC88A0 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 513467FF2056BC6700DE6A1E /* Crashlytics.framework */; };
+		514B29A1210FFA9600D757B5 /* KYCNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514B29A0210FFA9600D757B5 /* KYCNetworkRequest.swift */; };
+		514B29A2210FFA9600D757B5 /* KYCNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514B29A0210FFA9600D757B5 /* KYCNetworkRequest.swift */; };
 		515315F12056C0EE000161DF /* libicucore.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 23C543A21D0F4197007A5F58 /* libicucore.tbd */; };
 		515315F32056C1A0000161DF /* libcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 515315F22056C1A0000161DF /* libcrypto.a */; };
 		51578AEA20B448BF00B0080A /* WalletKeyImportDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51578AE920B448BF00B0080A /* WalletKeyImportDelegate.swift */; };
@@ -1254,6 +1256,7 @@
 		513913EF2081206C002578FD /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		51392045205C60520025EE33 /* Cert */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Cert; sourceTree = "<group>"; };
 		513C826B20EBF30C00ECDE52 /* UIDevice+Biometrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIDevice+Biometrics.swift"; sourceTree = "<group>"; };
+		514B29A0210FFA9600D757B5 /* KYCNetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCNetworkRequest.swift; sourceTree = "<group>"; };
 		515315F22056C1A0000161DF /* libcrypto.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcrypto.a; path = "Submodules/OpenSSL-for-iPhone/lib/libcrypto.a"; sourceTree = "<group>"; };
 		51578AE920B448BF00B0080A /* WalletKeyImportDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletKeyImportDelegate.swift; sourceTree = "<group>"; };
 		51578AED20B44AD400B0080A /* KeyImportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyImportCoordinator.swift; sourceTree = "<group>"; };
@@ -2570,6 +2573,7 @@
 				AA7E7750210BC0C0009DFB4C /* KYCCoordinator.swift */,
 				5138354C210253A700767B2E /* KYCCountrySelectionController.swift */,
 				51979149210B8BEB0096E50B /* KYCCountrySelectionDataSource.swift */,
+				514B29A0210FFA9600D757B5 /* KYCNetworkRequest.swift */,
 				51383543210253A700767B2E /* KYCOnboardingController.swift */,
 				51383549210253A700767B2E /* KYCOnboardingNavigationController.swift */,
 				51383542210253A700767B2E /* KYCPersonalDetailsController.swift */,
@@ -4349,6 +4353,7 @@
 				AAE94F3620C70B97005A3595 /* AssetURLPayload.swift in Sources */,
 				51D17A9A20A33A700071E7E0 /* PrivateKeyReader.swift in Sources */,
 				51135705209CF5E200056D65 /* WalletBuySellDelegate.swift in Sources */,
+				514B29A2210FFA9600D757B5 /* KYCNetworkRequest.swift in Sources */,
 				AA31A7B52098DA5200FE6268 /* AlertViewPresenter+Wallet.swift in Sources */,
 				51C9EBB720DBE4A700AB521D /* UIView+SafeAreaFrame.swift in Sources */,
 				AAE94F6A20C75C4E005A3595 /* MockPinView.swift in Sources */,
@@ -4496,6 +4501,7 @@
 				51A7349320891EB3009727D5 /* NetworkManager.swift in Sources */,
 				C7559CB21F56FE09005B2375 /* TransactionsEtherViewController.m in Sources */,
 				AA1E522B2097CA360099BD10 /* AuthenticationCoordinator.swift in Sources */,
+				514B29A1210FFA9600D757B5 /* KYCNetworkRequest.swift in Sources */,
 				23FDEFAC1D6F669100FC80D6 /* NSURLSession+SendSynchronousRequest.m in Sources */,
 				C74E865220B3043E00F7263D /* WalletHistoryDelegate.swift in Sources */,
 				AABDED70208FACB9002D8BAC /* Reachability.swift in Sources */,

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -1,0 +1,101 @@
+//
+//  KYCNetworkRequest.swift
+//  Blockchain
+//
+//  Created by Maurice A. on 7/30/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Handles network requests for the KYC flow
+final class KYCNetworkRequest {
+
+    typealias TaskSuccess = (Data) -> Void
+    typealias TaskFailure = (HTTPRequestError) -> Void
+
+    fileprivate let rootUrl = "https://api.dev.blockchain.info/nabu-app"
+    private let timeoutInterval = TimeInterval(exactly: 30)!
+
+    // swiftlint:disable nesting
+    struct KYCEndpoints {
+        enum GET: String {
+            case credentials = "/kyc/credentials"
+            case credentialsForProvider = "/kyc/credentials/provider"
+            case healthCheck = "/healthz"
+            case listOfCountries = "/countries?filter=eea"
+            case nextKYCMethod = "/kyc/next-method"
+            case users, userDetails = "/users"
+        }
+
+        enum POST: String {
+            case registerUser = "/users"
+            case verifications = "/verifications"
+            case submitVerification = "/kyc/verifications"
+        }
+
+        enum PUT: String {
+            case updateUserDetails = "/users"
+        }
+    }
+    // swiftlint:enable nesting
+
+    // MARK: - Initialization
+
+    /// HTTP GET Request
+    init(get url: KYCEndpoints.GET, success: @escaping TaskSuccess, error: @escaping TaskFailure) {
+        var request = URLRequest(url: URL(string: rootUrl + url.rawValue)!)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = timeoutInterval
+        doTask(with: request, success, error)
+    }
+
+    /// HTTP POST Request
+    init(post url: KYCEndpoints.POST, parameters: [String: String], success: @escaping TaskSuccess, error: @escaping TaskFailure) {
+        let postBody = parameters.reduce("", { initialResult, nextPartialResult in
+            let delimeter = initialResult.count > 0 ? "&" : ""
+            return "\(initialResult)\(delimeter)\(nextPartialResult.key)=\(nextPartialResult.value)"
+        })
+        let data = postBody.data(using: .utf8)
+        var request = URLRequest(url: URL(string: rootUrl + url.rawValue)!)
+        request.httpMethod = "POST"
+        request.httpBody = data
+        request.timeoutInterval = timeoutInterval
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.addValue(String(describing: data?.count), forHTTPHeaderField: "Content-Length")
+        request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        doTask(with: request, success, error)
+    }
+
+    /// HTTP PUT Request
+    init(put url: KYCEndpoints.PUT, parameters: [String: String], success: @escaping TaskSuccess, error: @escaping TaskFailure) {
+        // TODO: implement method body
+    }
+
+    // MARK: - Private Methods
+
+    private func doTask(with request: URLRequest, _ taskSuccess: @escaping TaskSuccess, _ taskFailure: @escaping TaskFailure) {
+        let task = URLSession.shared.dataTask(with: request, completionHandler: { data, response, error in
+            if let error = error {
+                taskFailure(HTTPRequestClientError.failedRequest(description: error.localizedDescription)); return
+            }
+            guard let httpResponse = response as? HTTPURLResponse else {
+                taskFailure(HTTPRequestServerError.badResponse); return
+            }
+            guard (200...299).contains(httpResponse.statusCode) else {
+                taskFailure(HTTPRequestServerError.badStatusCode(code: httpResponse.statusCode)); return
+            }
+            if let mimeType = httpResponse.mimeType {
+                guard mimeType == "application/json" else {
+                    taskFailure(HTTPRequestPayloadError.invalidMimeType(type: mimeType)); return
+                }
+            }
+            guard let responseData = data else {
+                taskFailure(HTTPRequestPayloadError.emptyData); return
+            }
+            taskSuccess(responseData)
+        })
+        task.resume()
+    }
+}

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -14,6 +14,7 @@ final class KYCNetworkRequest {
     typealias TaskSuccess = (Data) -> Void
     typealias TaskFailure = (HTTPRequestError) -> Void
 
+    // TODO: read from .xcconfig
     fileprivate let rootUrl = "https://api.dev.blockchain.info/nabu-app"
     private let timeoutInterval = TimeInterval(exactly: 30)!
 

--- a/Blockchain/KYC/KYCOnboardingNavigationController.swift
+++ b/Blockchain/KYC/KYCOnboardingNavigationController.swift
@@ -19,7 +19,6 @@ protocol KYCOnboardingNavigation: class {
     var segueIdentifier: String? { get }
 }
 
-/// Entry point to the KYC flow
 /// NOTE: - This class prefetches some of the data to mitigate loading states in subsequent view controllers
 final class KYCOnboardingNavigationController: UINavigationController {
 
@@ -27,38 +26,6 @@ final class KYCOnboardingNavigationController: UINavigationController {
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        KYCCountrySelectionDataSource.dataSource.delegate = self
         KYCCountrySelectionDataSource.dataSource.fetchListOfCountries()
-    }
-}
-
-// MARK: - HTTPRequestErrorDelegate
-
-extension KYCOnboardingNavigationController: HTTPRequestErrorDelegate {
-    func handleClientError(_ error: Error) {
-        Logger.shared.error(error.localizedDescription)
-        AlertViewPresenter.shared.standardError(
-            message: "There was a problem with your request. Please try again in a moment.",
-            title: "Error",
-            in: self
-        )
-    }
-
-    func handlePayloadError(_ error: HTTPRequestPayloadError) {
-        Logger.shared.error(error.localizedDescription)
-        AlertViewPresenter.shared.standardError(
-            message: "There was a problem with your request. Please try again in a moment.",
-            title: "Error",
-            in: self
-        )
-    }
-
-    func handleServerError(_ error: HTTPURLResponseError) {
-        Logger.shared.error(error.localizedDescription)
-        AlertViewPresenter.shared.standardError(
-            message: "There was a problem with your request. Please try again in a moment.",
-            title: "Error",
-            in: self
-        )
     }
 }

--- a/Blockchain/Network/HTTPRequestError/HTTPRequestError.swift
+++ b/Blockchain/Network/HTTPRequestError/HTTPRequestError.swift
@@ -12,13 +12,18 @@ protocol HTTPRequestError: Error {
     var debugDescription: String { get }
 }
 
-protocol HTTPRequestErrorDelegate: class {
-    func handleClientError(_ error: Error)
-    func handleServerError(_ error: HTTPURLResponseError)
-    func handlePayloadError(_ error: HTTPRequestPayloadError)
+// TODO: add more specific client errors based on the error returned by URLSession data task
+// NOTE: the description argument refers to the localized description returned by URLSession data task.
+enum HTTPRequestClientError: HTTPRequestError {
+    case failedRequest(description: String)
+    var debugDescription: String {
+        switch self {
+        case .failedRequest(let description): return description
+        }
+    }
 }
 
-enum HTTPURLResponseError: HTTPRequestError {
+enum HTTPRequestServerError: HTTPRequestError {
     case badResponse, badStatusCode(code: Int)
     var debugDescription: String {
         switch self {
@@ -28,7 +33,7 @@ enum HTTPURLResponseError: HTTPRequestError {
     }
 }
 
-// TODO: use protocol extension to add KYC specific error codes 💭
+// NOTE: in future cases, we may want to allow empty payloads, but this is currently not applicable for the KYC flow.
 enum HTTPRequestPayloadError: HTTPRequestError {
     case badData, emptyData, invalidMimeType(type: String)
     var debugDescription: String {


### PR DESCRIPTION
Highlights in this PR:

- Addresses reusable networking code issue from #358 by adding `KYCNetworkRequest`.
- Simplifies how data is fetched in the KYC flow.
- Deprecates the use of the *delegate* pattern for making network requests.
- Restructures error handling for `KYCNetworkRequest`.
- Updates networking code for country selection screen.