### PR TITLE
refactor(KYC): URL convenience function

### DIFF
--- a/Blockchain/Extensions/URLs.swift
+++ b/Blockchain/Extensions/URLs.swift
@@ -49,9 +49,7 @@ extension URL {
 
         guard var components: URLComponents = URLComponents(url: mutableBaseURL as URL, resolvingAgainstBaseURL: false) else { return nil }
 
-        if queryItems.count > 0 {
-            components.queryItems = queryItems
-        }
+        components.queryItems = queryItems
 
         return components.url
     }

--- a/Blockchain/Extensions/URLs.swift
+++ b/Blockchain/Extensions/URLs.swift
@@ -18,4 +18,41 @@ extension URL {
 
         return query.queryArgs
     }
+
+    public static func endpoint(_ baseURL: URL, pathComponents: [String]?, queryParameters:[String: String]?) -> URL? {
+        guard var mutableBaseURL: URL = (baseURL as NSURL).copy() as? URL else { return nil }
+
+        if let pathComponents = pathComponents {
+            for compenent in pathComponents {
+                if compenent != pathComponents.last {
+                    mutableBaseURL = mutableBaseURL.appendingPathComponent(compenent, isDirectory: true)
+                } else {
+                    mutableBaseURL = mutableBaseURL.appendingPathComponent(compenent, isDirectory: false)
+                }
+            }
+        }
+
+        var queryItems = [URLQueryItem]()
+
+        if let queryParameters = queryParameters {
+            if queryParameters.keys.count == 0 {
+                return mutableBaseURL
+            }
+
+            for keyValue in queryParameters.keys {
+                if let value = queryParameters[keyValue] {
+                    let queryItem = URLQueryItem(name: keyValue, value: value)
+                    queryItems.append(queryItem)
+                }
+            }
+        }
+
+        guard var components: URLComponents = URLComponents(url: mutableBaseURL as URL, resolvingAgainstBaseURL: false) else { return nil }
+
+        if queryItems.count > 0 {
+            components.queryItems = queryItems
+        }
+
+        return components.url
+    }
 }


### PR DESCRIPTION
## Description

Adds a simple function to `URLs.swift` to make URL endpoint generation a bit easier.

The call site would look like this:

`let parameters = ["method": "do.a.thing", "api_key": Blockchain.key]`

`guard let url = URL.endpoint(Blockchain.baseURL, pathComponents: ["path", "component"], queryParameters: parameters) else { return }`