### PR TITLE
feat(KYC): IOS-1052 Updating enter phone number screen for KYC

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -2709,6 +2709,7 @@
 		AA24D4C620D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetTypeLegacyHelper.swift; sourceTree = "<group>"; };
 		AA2BA64320DC754600F01954 /* BitcoinAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinAddressTests.swift; sourceTree = "<group>"; };
 		AA2D000020D96FA300B7BE0E /* SwipeToReceiveAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeToReceiveAddressView.swift; sourceTree = "<group>"; };
+		AA2F96FF2118C04700EE7F21 /* KYCVerifyIdentity.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = KYCVerifyIdentity.storyboard; sourceTree = "<group>"; };
 		AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AlertViewPresenter+Wallet.swift"; sourceTree = "<group>"; };
 		AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuItem.swift; sourceTree = "<group>"; };
 		AA31A7D02099310B00FE6268 /* WalletBuySellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletBuySellDelegate.swift; sourceTree = "<group>"; };
@@ -4821,6 +4822,7 @@
 		60459BAF2118BEE500AE08C8 /* private */ = {
 			isa = PBXGroup;
 			children = (
+				AA2F96FF2118C04700EE7F21 /* KYCVerifyIdentity.storyboard */,
 			);
 			path = private;
 			sourceTree = "<group>";
@@ -5232,13 +5234,6 @@
 			path = Source;
 			sourceTree = "<group>";
 		};
-		60FBE062211255BD00AD514A /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 		60FBE082211258F300AD514A /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -5463,7 +5458,6 @@
 				9FB3637414B60128004BEA02 /* Frameworks */,
 				9FB3637214B60128004BEA02 /* Products */,
 				C9D4B2AE193E020D00EDA9EA /* Third Party */,
-				60FBE062211255BD00AD514A /* Recovered References */,
 				0A0B7B23D8DF7938F9E9CD06 /* Pods */,
 			);
 			sourceTree = "<group>";
@@ -6599,6 +6593,7 @@
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/Charts/Charts.framework",
 				"${PODS_ROOT}/Onfido/Onfido.framework",
+				"${BUILT_PRODUCTS_DIR}/PhoneNumberKit/PhoneNumberKit.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
@@ -6611,6 +6606,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Charts.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Onfido.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PhoneNumberKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -491,6 +491,14 @@
 		AACE320B20978EB100B7B806 /* MockWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE320A20978EB100B7B806 /* MockWallet.swift */; };
 		AACF56C520EAC87A0039978B /* OnboardingSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACF56C420EAC87A0039978B /* OnboardingSettings.swift */; };
 		AACF56C620EAC87A0039978B /* OnboardingSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACF56C420EAC87A0039978B /* OnboardingSettings.swift */; };
+		AAD0D2522112908F002E63BF /* KYCConfirmPhoneNumber.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AAD0D2512112908E002E63BF /* KYCConfirmPhoneNumber.storyboard */; };
+		AAD0D26F21129319002E63BF /* KYCConfirmPhoneNumberController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD0D26E21129319002E63BF /* KYCConfirmPhoneNumberController.swift */; };
+		AAD0D27021129319002E63BF /* KYCConfirmPhoneNumberController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD0D26E21129319002E63BF /* KYCConfirmPhoneNumberController.swift */; };
+		AAD0D29B2113B0AD002E63BF /* KYCVerifyPhoneNumberPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD0D29A2113B0AD002E63BF /* KYCVerifyPhoneNumberPresenter.swift */; };
+		AAD0D29D2113B118002E63BF /* KYCVerifyPhoneNumberPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD0D29C2113B118002E63BF /* KYCVerifyPhoneNumberPresenterTests.swift */; };
+		AAD0D29E2113D092002E63BF /* KYCVerifyPhoneNumberPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD0D29A2113B0AD002E63BF /* KYCVerifyPhoneNumberPresenter.swift */; };
+		AAD0D29F2113D173002E63BF /* PostalAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3047E5210B8E1300C09E6D /* PostalAddress.swift */; };
+		AAD0D2A22113D1FB002E63BF /* KYCAddressController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD7EE7221122612006B924F /* KYCAddressController.swift */; };
 		AAD279B0209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD279AF209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift */; };
 		AAD279E0209A99DA00C0EAFC /* AVCaptureDeviceInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD279DF209A99D900C0EAFC /* AVCaptureDeviceInput.swift */; };
 		AAD27A28209CFE2100C0EAFC /* PasswordConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD27A27209CFE2100C0EAFC /* PasswordConfirmView.swift */; };
@@ -6695,6 +6703,7 @@
 				C72B851B210FC098002EBDB9 /* ExchangeCreateView.swift in Sources */,
 				602B9D0F2118E23C00BD3D60 /* KYCPersonalDetailsController.swift in Sources */,
 				C74E866220B3272B00F7263D /* TransferAllCoordinator.swift in Sources */,
+				5197913F210A25960096E50B /* KYCCountry.swift in Sources */,
 				AAE94F3D20C70F4B005A3595 /* BIP21URI.swift in Sources */,
 				51A862BE2090DD6400B338E0 /* PairingInstructionsView.swift in Sources */,
 				AA722C1A20B4BBA900262A5F /* AssetAddressRepository.swift in Sources */,

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -19,6 +19,12 @@ final class KYCCountrySelectionController: UITableViewController {
         }
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // TODO: Remove debug
+        performSegue(withIdentifier: "promptForPersonalDetails", sender: self)
+    }
+
     // MARK: UITableViewDataSource
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Blockchain/KYC/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/KYCPersonalDetailsController.swift
@@ -82,7 +82,13 @@ final class KYCPersonalDetailsController: UIViewController {
 
     // MARK: - Navigation
 
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {}
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let enterPhoneNumberController = segue.destination as? KYCEnterPhoneNumberController else {
+            return
+        }
+        // TODO: pass in actual userID
+        enterPhoneNumberController.userId = "userId"
+    }
 }
 
 extension KYCPersonalDetailsController: UITextFieldDelegate {

--- a/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
@@ -86,6 +86,7 @@ class KYCConfirmPhoneNumberController: UIViewController {
         UIView.setAnimationDuration(payload.animationDuration)
         UIView.setAnimationCurve(payload.animationCurve)
         layoutConstraintBottomButton.constant = originalBottomButtonConstraint + payload.endingFrame.height
+        view.layoutIfNeeded()
         UIView.commitAnimations()
     }
 
@@ -94,6 +95,7 @@ class KYCConfirmPhoneNumberController: UIViewController {
         UIView.setAnimationDuration(payload.animationDuration)
         UIView.setAnimationCurve(payload.animationCurve)
         layoutConstraintBottomButton.constant = originalBottomButtonConstraint
+        view.layoutIfNeeded()
         UIView.commitAnimations()
     }
 }

--- a/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
@@ -38,6 +38,7 @@ class KYCConfirmPhoneNumberController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        // TICKET: IOS-1141 display correct % in the progress view
         labelPhoneNumber.text = phoneNumber
         nextButton.isEnabled = false
         originalBottomButtonConstraint = layoutConstraintBottomButton.constant

--- a/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
@@ -27,6 +27,7 @@ class KYCConfirmPhoneNumberController: UIViewController {
     private lazy var presenter: KYCVerifyPhoneNumberPresenter = {
         return KYCVerifyPhoneNumberPresenter(view: self)
     }()
+
     private var originalBottomButtonConstraint: CGFloat!
 
     deinit {

--- a/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
 //
 
+import PhoneNumberKit
 import UIKit
 
 final class KYCEnterPhoneNumberController: UIViewController {
@@ -15,13 +16,31 @@ final class KYCEnterPhoneNumberController: UIViewController {
     var userId: String?
 
     @IBOutlet var textFieldMobileNumber: UITextField!
+    @IBOutlet var layoutConstraintBottomButton: NSLayoutConstraint!
+
+    private var originalBottomButtonConstraint: CGFloat!
 
     private lazy var presenter: KYCVerifyPhoneNumberPresenter = { [unowned self] in
         return KYCVerifyPhoneNumberPresenter(view: self)
     }()
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        originalBottomButtonConstraint = layoutConstraintBottomButton.constant
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        NotificationCenter.when(NSNotification.Name.UIKeyboardWillShow) {
+            self.keyboardWillShow(with: KeyboardPayload(notification: $0))
+        }
+        NotificationCenter.when(NSNotification.Name.UIKeyboardWillHide) {
+            self.keyboardWillHide(with: KeyboardPayload(notification: $0))
+        }
         textFieldMobileNumber.becomeFirstResponder()
     }
 
@@ -47,6 +66,24 @@ final class KYCEnterPhoneNumberController: UIViewController {
         }
         confirmPhoneNumberViewController.userId = userId
         confirmPhoneNumberViewController.phoneNumber = textFieldMobileNumber.text ?? ""
+    }
+
+    // MARK: - Private
+
+    private func keyboardWillShow(with payload: KeyboardPayload) {
+        UIView.beginAnimations(nil, context: nil)
+        UIView.setAnimationDuration(payload.animationDuration)
+        UIView.setAnimationCurve(payload.animationCurve)
+        layoutConstraintBottomButton.constant = originalBottomButtonConstraint + payload.endingFrame.height
+        UIView.commitAnimations()
+    }
+
+    private func keyboardWillHide(with payload: KeyboardPayload) {
+        UIView.beginAnimations(nil, context: nil)
+        UIView.setAnimationDuration(payload.animationDuration)
+        UIView.setAnimationCurve(payload.animationCurve)
+        layoutConstraintBottomButton.constant = originalBottomButtonConstraint
+        UIView.commitAnimations()
     }
 }
 

--- a/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
@@ -43,6 +43,7 @@ final class KYCEnterPhoneNumberController: UIViewController {
         super.viewDidLoad()
         // TICKET: IOS-1141 display correct % in the progress view
         buttonNext.isEnabled = false
+        validationTextFieldMobileNumber.keyboardType = .numberPad
         validationTextFieldMobileNumber.contentType = .telephoneNumber
         validationTextFieldMobileNumber.textChangedBlock = { [unowned self] text in
             guard let text = text else {

--- a/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
@@ -43,11 +43,8 @@ final class KYCEnterPhoneNumberController: UIViewController {
         // TICKET: IOS-1141 display correct % in the progress view
         validationTextFieldMobileNumber.keyboardType = .numberPad
         validationTextFieldMobileNumber.contentType = .telephoneNumber
-        validationTextFieldMobileNumber.textChangedBlock = { [unowned self] text in
-            guard let text = text else {
-                return
-            }
-            self.validationTextFieldMobileNumber.text = self.phoneNumberPartialFormatter.formatPartial(text)
+        validationTextFieldMobileNumber.textReplacementBlock = { [unowned self] in
+            return self.phoneNumberPartialFormatter.formatPartial($0)
         }
         validationTextFieldMobileNumber.returnTappedBlock = { [unowned self] in
             self.validationTextFieldMobileNumber.resignFocus()

--- a/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
@@ -98,6 +98,7 @@ final class KYCEnterPhoneNumberController: UIViewController {
         UIView.setAnimationDuration(payload.animationDuration)
         UIView.setAnimationCurve(payload.animationCurve)
         layoutConstraintBottomButton.constant = originalBottomButtonConstraint + payload.endingFrame.height
+        view.layoutIfNeeded()
         UIView.commitAnimations()
     }
 
@@ -106,6 +107,7 @@ final class KYCEnterPhoneNumberController: UIViewController {
         UIView.setAnimationDuration(payload.animationDuration)
         UIView.setAnimationCurve(payload.animationCurve)
         layoutConstraintBottomButton.constant = originalBottomButtonConstraint
+        view.layoutIfNeeded()
         UIView.commitAnimations()
     }
 }

--- a/Blockchain/KYC/Storyboards/KYCConfirmPhoneNumber.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCConfirmPhoneNumber.storyboard
@@ -29,20 +29,27 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="724"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="wiv-Pe-rE0">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="8"/>
+                                <color key="tintColor" red="0.011764705882352941" green="0.66274509803921566" blue="0.44705882352941173" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="8" id="ZGc-ss-mBq"/>
+                                </constraints>
+                            </progressView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter the code sent to" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5ml-0c-co0">
-                                <rect key="frame" x="16" y="20" width="133.66666666666666" height="14.666666666666664"/>
+                                <rect key="frame" x="16" y="24" width="133.66666666666666" height="14.666666666666664"/>
                                 <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="12"/>
                                 <color key="textColor" red="0.30588235294117649" green="0.30588235294117649" blue="0.30588235294117649" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+1 (714) 333-4920" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cDf-1e-GvH">
-                                <rect key="frame" x="16" y="36.666666666666671" width="99" height="14"/>
+                                <rect key="frame" x="16" y="40.666666666666657" width="99" height="15"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="12"/>
                                 <color key="textColor" red="0.30588235289999999" green="0.30588235289999999" blue="0.30588235289999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Confirmation Code" textAlignment="natural" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="XY9-D0-0ZJ">
-                                <rect key="frame" x="16" y="66.666666666666657" width="343" height="56"/>
+                                <rect key="frame" x="16" y="71.666666666666657" width="343" height="56"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="u3q-gM-O0w"/>
                                 </constraints>
@@ -80,8 +87,12 @@
                         <constraints>
                             <constraint firstItem="XY9-D0-0ZJ" firstAttribute="top" secondItem="cDf-1e-GvH" secondAttribute="bottom" constant="16" id="4hP-SW-w97"/>
                             <constraint firstItem="IIQ-vZ-lk7" firstAttribute="trailing" secondItem="36T-B3-yyh" secondAttribute="trailing" constant="16" id="6D8-hT-1ZS"/>
-                            <constraint firstItem="5ml-0c-co0" firstAttribute="top" secondItem="IIQ-vZ-lk7" secondAttribute="top" constant="20" id="FfS-2e-zY9"/>
+                            <constraint firstItem="IIQ-vZ-lk7" firstAttribute="trailing" secondItem="wiv-Pe-rE0" secondAttribute="trailing" id="9eL-GR-wOY"/>
+                            <constraint firstItem="wiv-Pe-rE0" firstAttribute="top" secondItem="IIQ-vZ-lk7" secondAttribute="top" id="BEn-HB-WCV"/>
+                            <constraint firstItem="wiv-Pe-rE0" firstAttribute="top" secondItem="IIQ-vZ-lk7" secondAttribute="top" id="CoK-xA-XIb"/>
+                            <constraint firstItem="wiv-Pe-rE0" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" id="K9p-cd-ZWj"/>
                             <constraint firstItem="cDf-1e-GvH" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" constant="16" id="RmE-gg-2ja"/>
+                            <constraint firstItem="5ml-0c-co0" firstAttribute="top" secondItem="wiv-Pe-rE0" secondAttribute="bottom" constant="16" id="bCs-MV-efH"/>
                             <constraint firstItem="XY9-D0-0ZJ" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" constant="16" id="bMw-Ek-e8a"/>
                             <constraint firstItem="36T-B3-yyh" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" constant="16" id="cQs-wq-eL8"/>
                             <constraint firstItem="KYo-qh-R2k" firstAttribute="centerX" secondItem="IIQ-vZ-lk7" secondAttribute="centerX" id="fsr-0d-Jfv"/>

--- a/Blockchain/KYC/Storyboards/KYCEnterPhoneNumber.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCEnterPhoneNumber.storyboard
@@ -10,8 +10,14 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
+        <array key="Montserrat-Medium.ttf">
+            <string>Montserrat-Medium</string>
+        </array>
         <array key="Montserrat-Regular.ttf">
             <string>Montserrat-Regular</string>
+        </array>
+        <array key="Montserrat-SemiBold.ttf">
+            <string>Montserrat-SemiBold</string>
         </array>
     </customFonts>
     <scenes>
@@ -23,6 +29,34 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="724"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="iDg-3K-PTa">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="8"/>
+                                <color key="tintColor" red="0.011764705882352941" green="0.66274509803921566" blue="0.44705882352941173" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="8" id="f2X-6v-9TL"/>
+                                </constraints>
+                            </progressView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Why do you need this?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PtR-Ju-hsT">
+                                <rect key="frame" x="16" y="23" width="343" height="14"/>
+                                <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="12"/>
+                                <color key="textColor" red="0.30588235294117649" green="0.30588235294117649" blue="0.30588235294117649" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm your device to secure your wallet." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fxC-dO-8GT">
+                                <rect key="frame" x="16" y="39" width="343" height="14"/>
+                                <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="12"/>
+                                <color key="textColor" red="0.30588235294117649" green="0.30588235294117649" blue="0.30588235294117649" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Mobile Number" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Kwe-pA-MQg">
+                                <rect key="frame" x="16" y="69" width="343" height="55"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="55" id="fhw-Jw-qx4"/>
+                                </constraints>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="17"/>
+                                <textInputTraits key="textInputTraits" keyboardType="phonePad" returnKeyType="continue" textContentType="tel"/>
+                            </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KX0-wF-bqu" customClass="PrimaryButton" customModule="Blockchain" customModuleProvider="target">
                                 <rect key="frame" x="16" y="630" width="343" height="44"/>
                                 <color key="backgroundColor" red="0.29803921568627451" green="0.6705882352941176" blue="0.87450980392156863" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -37,41 +71,24 @@
                                     <action selector="primaryButtonTapped:" destination="7WR-uN-K1i" eventType="touchUpInside" id="mPE-5e-fgU"/>
                                 </connections>
                             </button>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Mobile Number" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Kwe-pA-MQg">
-                                <rect key="frame" x="16" y="16" width="343" height="55"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="fhw-Jw-qx4"/>
-                                </constraints>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="17"/>
-                                <textInputTraits key="textInputTraits" keyboardType="phonePad" returnKeyType="continue" textContentType="tel"/>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lXd-eX-J03" userLabel="Description Label">
-                                <rect key="frame" x="16" y="504.33333333333343" width="343" height="50.666666666666686"/>
-                                <attributedString key="attributedText">
-                                    <fragment>
-                                        <string key="content">Confirming your phone number allows us to secure your account. Don't worry, we won't double text you (unless you have to resend your code)</string>
-                                        <attributes>
-                                            <color key="NSColor" red="0.32940999999999998" green="0.32940999999999998" blue="0.33724999999999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <font key="NSFont" metaFont="system"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="2" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
-                                        </attributes>
-                                    </fragment>
-                                </attributedString>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstAttribute="trailing" secondItem="iDg-3K-PTa" secondAttribute="trailing" id="3fE-xr-1dJ"/>
+                            <constraint firstItem="PtR-Ju-hsT" firstAttribute="top" secondItem="iDg-3K-PTa" secondAttribute="bottom" constant="15" id="B6q-H9-Ov8"/>
+                            <constraint firstItem="iDg-3K-PTa" firstAttribute="top" secondItem="icW-B4-iKS" secondAttribute="top" id="LTO-Db-Zfp"/>
+                            <constraint firstItem="fxC-dO-8GT" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="MAY-oN-SGQ"/>
                             <constraint firstItem="icW-B4-iKS" firstAttribute="bottom" secondItem="KX0-wF-bqu" secondAttribute="bottom" constant="16" id="SXE-nw-OlT"/>
-                            <constraint firstItem="lXd-eX-J03" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="Yq0-6Z-oJ3"/>
+                            <constraint firstItem="PtR-Ju-hsT" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="VO6-ZC-OAT"/>
+                            <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="PtR-Ju-hsT" secondAttribute="trailing" constant="16" id="XuD-GS-eJm"/>
                             <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="Kwe-pA-MQg" secondAttribute="trailing" constant="16" id="ajR-3v-Hcl"/>
                             <constraint firstItem="KX0-wF-bqu" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="clN-WD-rx6"/>
                             <constraint firstItem="Kwe-pA-MQg" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="gLX-zu-pov"/>
-                            <constraint firstItem="Kwe-pA-MQg" firstAttribute="top" secondItem="icW-B4-iKS" secondAttribute="top" constant="16" id="jgS-Rg-PnN"/>
+                            <constraint firstItem="iDg-3K-PTa" firstAttribute="leading" secondItem="m4i-aL-8OI" secondAttribute="leading" id="lyM-53-dJg"/>
+                            <constraint firstItem="Kwe-pA-MQg" firstAttribute="top" secondItem="fxC-dO-8GT" secondAttribute="bottom" constant="16" id="pDw-pN-huO"/>
                             <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="KX0-wF-bqu" secondAttribute="trailing" constant="16" id="tP6-WH-8XD"/>
-                            <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="lXd-eX-J03" secondAttribute="trailing" constant="16" id="uzR-te-vBJ"/>
-                            <constraint firstItem="KX0-wF-bqu" firstAttribute="top" secondItem="lXd-eX-J03" secondAttribute="bottom" constant="75" id="yop-Fd-ZtT"/>
+                            <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="fxC-dO-8GT" secondAttribute="trailing" constant="16" id="typ-jK-hlr"/>
+                            <constraint firstItem="fxC-dO-8GT" firstAttribute="top" secondItem="PtR-Ju-hsT" secondAttribute="bottom" constant="2" id="vMC-hS-pLe"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="icW-B4-iKS"/>
                     </view>
@@ -80,6 +97,7 @@
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
+                        <outlet property="layoutConstraintBottomButton" destination="SXE-nw-OlT" id="B4p-XA-yz6"/>
                         <outlet property="textFieldMobileNumber" destination="Kwe-pA-MQg" id="30j-zZ-aGz"/>
                         <segue destination="xVk-FG-HTS" kind="show" identifier="verifyMobileNumber" id="Ppp-kU-LhA"/>
                     </connections>

--- a/Blockchain/KYC/Storyboards/KYCEnterPhoneNumber.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCEnterPhoneNumber.storyboard
@@ -106,7 +106,6 @@
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
-                        <outlet property="buttonNext" destination="KX0-wF-bqu" id="ZYo-RT-HwX"/>
                         <outlet property="layoutConstraintBottomButton" destination="SXE-nw-OlT" id="B4p-XA-yz6"/>
                         <outlet property="validationTextFieldMobileNumber" destination="VGy-nv-chh" id="ary-Gi-hlU"/>
                         <segue destination="xVk-FG-HTS" kind="show" identifier="verifyMobileNumber" id="Ppp-kU-LhA"/>

--- a/Blockchain/KYC/Storyboards/KYCEnterPhoneNumber.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCEnterPhoneNumber.storyboard
@@ -48,15 +48,24 @@
                                 <color key="textColor" red="0.30588235294117649" green="0.30588235294117649" blue="0.30588235294117649" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Mobile Number" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Kwe-pA-MQg">
-                                <rect key="frame" x="16" y="69" width="343" height="55"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VGy-nv-chh" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
+                                <rect key="frame" x="16" y="69" width="343" height="56"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="fhw-Jw-qx4"/>
+                                    <constraint firstAttribute="height" constant="56" id="iJm-BX-BTS"/>
                                 </constraints>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="17"/>
-                                <textInputTraits key="textInputTraits" keyboardType="phonePad" returnKeyType="continue" textContentType="tel"/>
-                            </textField>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
+                                        <color key="value" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Your Mobile Number"/>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                        <color key="value" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KX0-wF-bqu" customClass="PrimaryButton" customModule="Blockchain" customModuleProvider="target">
                                 <rect key="frame" x="16" y="630" width="343" height="44"/>
                                 <color key="backgroundColor" red="0.29803921568627451" green="0.6705882352941176" blue="0.87450980392156863" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -75,19 +84,19 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="iDg-3K-PTa" secondAttribute="trailing" id="3fE-xr-1dJ"/>
+                            <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="VGy-nv-chh" secondAttribute="trailing" constant="16" id="6TD-fc-Pbr"/>
                             <constraint firstItem="PtR-Ju-hsT" firstAttribute="top" secondItem="iDg-3K-PTa" secondAttribute="bottom" constant="15" id="B6q-H9-Ov8"/>
                             <constraint firstItem="iDg-3K-PTa" firstAttribute="top" secondItem="icW-B4-iKS" secondAttribute="top" id="LTO-Db-Zfp"/>
                             <constraint firstItem="fxC-dO-8GT" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="MAY-oN-SGQ"/>
                             <constraint firstItem="icW-B4-iKS" firstAttribute="bottom" secondItem="KX0-wF-bqu" secondAttribute="bottom" constant="16" id="SXE-nw-OlT"/>
                             <constraint firstItem="PtR-Ju-hsT" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="VO6-ZC-OAT"/>
                             <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="PtR-Ju-hsT" secondAttribute="trailing" constant="16" id="XuD-GS-eJm"/>
-                            <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="Kwe-pA-MQg" secondAttribute="trailing" constant="16" id="ajR-3v-Hcl"/>
                             <constraint firstItem="KX0-wF-bqu" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="clN-WD-rx6"/>
-                            <constraint firstItem="Kwe-pA-MQg" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="gLX-zu-pov"/>
                             <constraint firstItem="iDg-3K-PTa" firstAttribute="leading" secondItem="m4i-aL-8OI" secondAttribute="leading" id="lyM-53-dJg"/>
-                            <constraint firstItem="Kwe-pA-MQg" firstAttribute="top" secondItem="fxC-dO-8GT" secondAttribute="bottom" constant="16" id="pDw-pN-huO"/>
+                            <constraint firstItem="VGy-nv-chh" firstAttribute="top" secondItem="fxC-dO-8GT" secondAttribute="bottom" constant="16" id="qsK-GB-jpe"/>
                             <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="KX0-wF-bqu" secondAttribute="trailing" constant="16" id="tP6-WH-8XD"/>
                             <constraint firstItem="icW-B4-iKS" firstAttribute="trailing" secondItem="fxC-dO-8GT" secondAttribute="trailing" constant="16" id="typ-jK-hlr"/>
+                            <constraint firstItem="VGy-nv-chh" firstAttribute="leading" secondItem="icW-B4-iKS" secondAttribute="leading" constant="16" id="ug0-ZA-LUy"/>
                             <constraint firstItem="fxC-dO-8GT" firstAttribute="top" secondItem="PtR-Ju-hsT" secondAttribute="bottom" constant="2" id="vMC-hS-pLe"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="icW-B4-iKS"/>
@@ -97,8 +106,9 @@
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
+                        <outlet property="buttonNext" destination="KX0-wF-bqu" id="ZYo-RT-HwX"/>
                         <outlet property="layoutConstraintBottomButton" destination="SXE-nw-OlT" id="B4p-XA-yz6"/>
-                        <outlet property="textFieldMobileNumber" destination="Kwe-pA-MQg" id="30j-zZ-aGz"/>
+                        <outlet property="validationTextFieldMobileNumber" destination="VGy-nv-chh" id="ary-Gi-hlU"/>
                         <segue destination="xVk-FG-HTS" kind="show" identifier="verifyMobileNumber" id="Ppp-kU-LhA"/>
                     </connections>
                 </viewController>

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.swift
@@ -133,6 +133,11 @@ class ValidationTextField: NibBasedView {
     /// inside the contained UITextField
     var textChangedBlock: ((String?) -> Void)?
 
+    /// This closure is called before the text in the text field is replaced.
+    /// You can use this replacement block if you wish to format the text
+    /// before it gets replaced.
+    var textReplacementBlock: ((String) -> String)?
+
     // MARK: Private IBOutlets
 
     @IBOutlet fileprivate var textField: UITextField!
@@ -204,6 +209,18 @@ class ValidationTextField: NibBasedView {
 }
 
 extension ValidationTextField: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else {
+            return true
+        }
+        guard let textReplacementBlock = textReplacementBlock else {
+            return true
+        }
+
+        let replacedString = (text as NSString).replacingCharacters(in: range, with: string)
+        textField.text = textReplacementBlock(replacedString)
+        return false
+    }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
         if let responderBlock = becomeFirstResponderBlock {

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.swift
@@ -129,6 +129,10 @@ class ValidationTextField: NibBasedView {
     /// is shown.
     var validationBlock: ValidationBlock?
 
+    /// This closure is called whenever the text is changed
+    /// inside the contained UITextField
+    var textChangedBlock: ((String?) -> Void)?
+
     // MARK: Private IBOutlets
 
     @IBOutlet fileprivate var textField: UITextField!
@@ -163,6 +167,12 @@ class ValidationTextField: NibBasedView {
 
         applyValidity(animated: true)
         return validity
+    }
+
+    // MARK: Private IBActions
+
+    @IBAction fileprivate func onTextFieldChanged(_ sender: Any) {
+        textChangedBlock?(textField.text)
     }
 
     // MARK: Private Functions
@@ -208,7 +218,7 @@ extension ValidationTextField: UITextFieldDelegate {
             return
         }
 
-        if (textField.text?.count == 0 || textField.text == nil) {
+        if textField.text?.count == 0 || textField.text == nil {
             validity = optionalField ? .valid : .invalid(nil)
         } else {
             validity = .valid

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.xib
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.xib
@@ -34,6 +34,7 @@
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="16"/>
                     <textInputTraits key="textInputTraits"/>
                     <connections>
+                        <action selector="onTextFieldChanged:" destination="-1" eventType="editingChanged" id="Bsn-iK-xW0"/>
                         <outlet property="delegate" destination="-1" id="GrD-iU-cbW"/>
                     </connections>
                 </textField>

--- a/Podfile
+++ b/Podfile
@@ -6,18 +6,19 @@ target 'Blockchain' do
   use_frameworks!
   inhibit_all_warnings!
   # Pods for Blockchain
-	pod 'SwiftLint'
-	pod 'Onfido'
-	pod 'Alamofire', '~> 4.7'
-	pod 'Charts'
-	pod 'RxSwift',    '~> 4.0'
-	pod 'RxCocoa',    '~> 4.0'
+    pod 'SwiftLint'
+    pod 'Onfido'
+    pod 'Alamofire', '~> 4.7'
+    pod 'Charts'
+    pod 'RxSwift', '~> 4.0'
+    pod 'RxCocoa', '~> 4.0'
+    pod 'PhoneNumberKit', '~> 2.1'
 
   target 'BlockchainTests' do
     inherit! :search_paths
     # Pods for testing
     pod 'RxBlocking', '~> 4.0'
-    pod 'RxTest',     '~> 4.0'
+    pod 'RxTest', '~> 4.0'
   end
 
 end


### PR DESCRIPTION
## Objective

Updating the UI and improving the UX for the SMS verification flow during KYC.

## Description

Updating the UI and improving the UX for the SMS verification flow during KYC. 

UI Changes:
* added a progress view to indicate the user's progress during KYC (actual % needs to be updated and displayed)

UX Changes:
* Added PhoneNumberKit to autoformat the phone # as the user types

Other Changes:
* Added some debug code so that you can get past the country selection screen

## How to Test

Run the app, tap on "Debug", and tap "Launch KYC"

## Screenshot
![simulator screen shot - iphone x - 2018-08-06 at 15 36 38](https://user-images.githubusercontent.com/38220701/43744350-85457184-998e-11e8-9bfa-3254aad1897f.png)

## Related Information

* Ticket Number: IOS-1052

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [X] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
