### PR TITLE
feat(KYC): IOS-1046 - Personal Information Screens & IOS-1141 - Progession

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		3A258C15210A4EAC00C023F5 /* LocationDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A258C13210A4EAC00C023F5 /* LocationDataProvider.swift */; };
 		3A3047E4210B664800C09E6D /* LocationSuggestionCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3A3047E3210B664800C09E6D /* LocationSuggestionCell.xib */; };
 		3A3047E6210B8E1300C09E6D /* PostalAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3047E5210B8E1300C09E6D /* PostalAddress.swift */; };
+		3A76F8F52119EDD5002F7946 /* ValidationDateField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A76F8F42119EDD5002F7946 /* ValidationDateField.swift */; };
+		3A76F8F72119EDE0002F7946 /* ValidationDateField.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3A76F8F62119EDE0002F7946 /* ValidationDateField.xib */; };
+		3A76F8FE211A067A002F7946 /* ValidationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A76F8FD211A067A002F7946 /* ValidationFormView.swift */; };
 		3A7F7EE3210F6C77001E20AF /* Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F7EE2210F6C77001E20AF /* Visibility.swift */; };
 		3A7F7EE4210F6C77001E20AF /* Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F7EE2210F6C77001E20AF /* Visibility.swift */; };
 		3A7F7EE6210F95C7001E20AF /* LocationSuggestionInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F7EE5210F95C7001E20AF /* LocationSuggestionInterface.swift */; };
@@ -977,6 +980,9 @@
 		3A258C13210A4EAC00C023F5 /* LocationDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDataProvider.swift; sourceTree = "<group>"; };
 		3A3047E3210B664800C09E6D /* LocationSuggestionCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LocationSuggestionCell.xib; sourceTree = "<group>"; };
 		3A3047E5210B8E1300C09E6D /* PostalAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostalAddress.swift; sourceTree = "<group>"; };
+		3A76F8F42119EDD5002F7946 /* ValidationDateField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationDateField.swift; sourceTree = "<group>"; };
+		3A76F8F62119EDE0002F7946 /* ValidationDateField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ValidationDateField.xib; sourceTree = "<group>"; };
+		3A76F8FD211A067A002F7946 /* ValidationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationFormView.swift; sourceTree = "<group>"; };
 		3A7F7EE2210F6C77001E20AF /* Visibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visibility.swift; sourceTree = "<group>"; };
 		3A7F7EE5210F95C7001E20AF /* LocationSuggestionInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSuggestionInterface.swift; sourceTree = "<group>"; };
 		3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Conveniences.swift"; sourceTree = "<group>"; };
@@ -2218,6 +2224,23 @@
 			path = DataProvider;
 			sourceTree = "<group>";
 		};
+		3A76F8F32119EDC4002F7946 /* ValidationDateField */ = {
+			isa = PBXGroup;
+			children = (
+				3A76F8F42119EDD5002F7946 /* ValidationDateField.swift */,
+				3A76F8F62119EDE0002F7946 /* ValidationDateField.xib */,
+			);
+			path = ValidationDateField;
+			sourceTree = "<group>";
+		};
+		3A76F8FC211A0665002F7946 /* ValidationForm */ = {
+			isa = PBXGroup;
+			children = (
+				3A76F8FD211A067A002F7946 /* ValidationFormView.swift */,
+			);
+			path = ValidationForm;
+			sourceTree = "<group>";
+		};
 		3A7F7EC7210F6C20001E20AF /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -2254,6 +2277,7 @@
 		3AD7EE7421124D56006B924F /* ValidationTextField */ = {
 			isa = PBXGroup;
 			children = (
+				3A76F8F32119EDC4002F7946 /* ValidationDateField */,
 				3AD7EE7521124F0C006B924F /* ValidationTextField.swift */,
 				3AD7EE9F21125156006B924F /* ValidationTextField.xib */,
 			);
@@ -3573,6 +3597,7 @@
 		C9D4B2B2193E032200EDA9EA /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				3A76F8FC211A0665002F7946 /* ValidationForm */,
 				3AD7EE7421124D56006B924F /* ValidationTextField */,
 				C72B8519210FC098002EBDB9 /* ExchangeCreateView.swift */,
 				3A258C0B210A485D00C023F5 /* Cells */,
@@ -3850,6 +3875,7 @@
 				C9BE917E1945D8F600FD516D /* PEViewController.xib in Resources */,
 				515EFAE8210282B4002350B6 /* ReceiveCoins.xib in Resources */,
 				515EFADE210282B4002350B6 /* BCAddressSelectionView.strings in Resources */,
+				3A76F8F72119EDE0002F7946 /* ValidationDateField.xib in Resources */,
 				C9BE91831945D8F600FD516D /* PEKeyboard-1.png in Resources */,
 				515EFAE9210282B4002350B6 /* AccountsAndAddresses.storyboard in Resources */,
 				C9BE91801945D8F600FD516D /* PEKeyboard-1-dot.png in Resources */,
@@ -4298,6 +4324,7 @@
 			files = (
 				C7442E3A1FBB636300695E4C /* FromToView.m in Sources */,
 				AACE31582091681100B7B806 /* WalletManager.swift in Sources */,
+				3A76F8FE211A067A002F7946 /* ValidationFormView.swift in Sources */,
 				AACE31572091680B00B7B806 /* PushNotificationManager.swift in Sources */,
 				3A3047E6210B8E1300C09E6D /* PostalAddress.swift in Sources */,
 				2343E4031CB434BC008DC7D1 /* NSArray+EncodedJSONString.m in Sources */,
@@ -4584,6 +4611,7 @@
 				C7BEE13B20C828B20096003B /* BuySellCoordinator.swift in Sources */,
 				67EE1DCB19E3325900DBBFC9 /* ECSlidingAnimationController.m in Sources */,
 				60639A002110FC2D005B6DF5 /* SRConstants.m in Sources */,
+				3A76F8F52119EDD5002F7946 /* ValidationDateField.swift in Sources */,
 				67470A0819D43AFE00757D46 /* BCManualPairView.m in Sources */,
 				C7E2750E1F59C2D50054EFA5 /* UILabel+Animations.m in Sources */,
 				51383557210253A800767B2E /* KYCPersonalDetailsController.swift in Sources */,

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		3A76F8F72119EDE0002F7946 /* ValidationDateField.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3A76F8F62119EDE0002F7946 /* ValidationDateField.xib */; };
 		3A76F8FE211A067A002F7946 /* ValidationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A76F8FD211A067A002F7946 /* ValidationFormView.swift */; };
 		3A76F900211A255F002F7946 /* ProgressableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A76F8FF211A255F002F7946 /* ProgressableView.swift */; };
+		3A76F902211A3BA5002F7946 /* DateFormatter+Conveniences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A76F901211A3BA5002F7946 /* DateFormatter+Conveniences.swift */; };
 		3A7F7EE3210F6C77001E20AF /* Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F7EE2210F6C77001E20AF /* Visibility.swift */; };
 		3A7F7EE4210F6C77001E20AF /* Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F7EE2210F6C77001E20AF /* Visibility.swift */; };
 		3A7F7EE6210F95C7001E20AF /* LocationSuggestionInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F7EE5210F95C7001E20AF /* LocationSuggestionInterface.swift */; };
@@ -985,6 +986,7 @@
 		3A76F8F62119EDE0002F7946 /* ValidationDateField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ValidationDateField.xib; sourceTree = "<group>"; };
 		3A76F8FD211A067A002F7946 /* ValidationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationFormView.swift; sourceTree = "<group>"; };
 		3A76F8FF211A255F002F7946 /* ProgressableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressableView.swift; sourceTree = "<group>"; };
+		3A76F901211A3BA5002F7946 /* DateFormatter+Conveniences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Conveniences.swift"; sourceTree = "<group>"; };
 		3A7F7EE2210F6C77001E20AF /* Visibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visibility.swift; sourceTree = "<group>"; };
 		3A7F7EE5210F95C7001E20AF /* LocationSuggestionInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSuggestionInterface.swift; sourceTree = "<group>"; };
 		3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Conveniences.swift"; sourceTree = "<group>"; };
@@ -2382,6 +2384,7 @@
 				513913EF2081206C002578FD /* UserDefaults.swift */,
 				3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */,
 				3AE92BDC2110DF33008D7BDC /* NotificationCenter+Conveniences.swift */,
+				3A76F901211A3BA5002F7946 /* DateFormatter+Conveniences.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4363,6 +4366,7 @@
 				C790E1211E5345160063D141 /* BCVerifyEmailViewController.m in Sources */,
 				AA3CA9B22107F2B700C2AD46 /* LogDestination.swift in Sources */,
 				C71859571F4B695700745A87 /* TabControllerManager.m in Sources */,
+				3A76F902211A3BA5002F7946 /* DateFormatter+Conveniences.swift in Sources */,
 				51135701209CEEB900056D65 /* PushNotificationAuthPayload.swift in Sources */,
 				C7A9E7A61FAB5FF600027F22 /* UILabel+CGRectForSubstring.m in Sources */,
 				AAC9FCE520ADF17100E28B7A /* SoundManager.swift in Sources */,

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		3A76F8F52119EDD5002F7946 /* ValidationDateField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A76F8F42119EDD5002F7946 /* ValidationDateField.swift */; };
 		3A76F8F72119EDE0002F7946 /* ValidationDateField.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3A76F8F62119EDE0002F7946 /* ValidationDateField.xib */; };
 		3A76F8FE211A067A002F7946 /* ValidationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A76F8FD211A067A002F7946 /* ValidationFormView.swift */; };
+		3A76F900211A255F002F7946 /* ProgressableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A76F8FF211A255F002F7946 /* ProgressableView.swift */; };
 		3A7F7EE3210F6C77001E20AF /* Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F7EE2210F6C77001E20AF /* Visibility.swift */; };
 		3A7F7EE4210F6C77001E20AF /* Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F7EE2210F6C77001E20AF /* Visibility.swift */; };
 		3A7F7EE6210F95C7001E20AF /* LocationSuggestionInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F7EE5210F95C7001E20AF /* LocationSuggestionInterface.swift */; };
@@ -983,6 +984,7 @@
 		3A76F8F42119EDD5002F7946 /* ValidationDateField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationDateField.swift; sourceTree = "<group>"; };
 		3A76F8F62119EDE0002F7946 /* ValidationDateField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ValidationDateField.xib; sourceTree = "<group>"; };
 		3A76F8FD211A067A002F7946 /* ValidationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationFormView.swift; sourceTree = "<group>"; };
+		3A76F8FF211A255F002F7946 /* ProgressableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressableView.swift; sourceTree = "<group>"; };
 		3A7F7EE2210F6C77001E20AF /* Visibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visibility.swift; sourceTree = "<group>"; };
 		3A7F7EE5210F95C7001E20AF /* LocationSuggestionInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSuggestionInterface.swift; sourceTree = "<group>"; };
 		3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Conveniences.swift"; sourceTree = "<group>"; };
@@ -1844,7 +1846,6 @@
 		AA24D4C620D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetTypeLegacyHelper.swift; sourceTree = "<group>"; };
 		AA2BA64320DC754600F01954 /* BitcoinAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinAddressTests.swift; sourceTree = "<group>"; };
 		AA2D000020D96FA300B7BE0E /* SwipeToReceiveAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeToReceiveAddressView.swift; sourceTree = "<group>"; };
-		AA2F96FE2118C04600EE7F21 /* KYCAddressDetailViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = KYCAddressDetailViewController.storyboard; sourceTree = "<group>"; };
 		AA2F96FF2118C04700EE7F21 /* KYCVerifyIdentity.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = KYCVerifyIdentity.storyboard; sourceTree = "<group>"; };
 		AA31A7B32098DA4800FE6268 /* AlertViewPresenter+Wallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AlertViewPresenter+Wallet.swift"; sourceTree = "<group>"; };
 		AA31A7BA2098DFCF00FE6268 /* SideMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuItem.swift; sourceTree = "<group>"; };
@@ -2438,7 +2439,6 @@
 		51383538210253A700767B2E /* Storyboards */ = {
 			isa = PBXGroup;
 			children = (
-				AA2F96FE2118C04600EE7F21 /* KYCAddressDetailViewController.storyboard */,
 				AA2F96FF2118C04700EE7F21 /* KYCVerifyIdentity.storyboard */,
 				5150E54821134251000966BE /* KYCAccountStatus.storyboard */,
 				5138353A210253A700767B2E /* KYCAddress.storyboard */,
@@ -2456,6 +2456,7 @@
 			isa = PBXGroup;
 			children = (
 				5138354B210253A700767B2E /* PrimaryButton.swift */,
+				3A76F8FF211A255F002F7946 /* ProgressableView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -4557,6 +4558,7 @@
 				23FB5C0A1D9ABB590008C6AB /* TransactionDetailToCell.m in Sources */,
 				AACE32002093FA1A00B7B806 /* ReminderPresenter.swift in Sources */,
 				C76D730420B2052000040B57 /* WalletExchangeDelegate.swift in Sources */,
+				3A76F900211A255F002F7946 /* ProgressableView.swift in Sources */,
 				9F91B607151666EC00ACB32D /* BCCreateWalletView.m in Sources */,
 				AAE94F2E20C644DE005A3595 /* PinPresenter.swift in Sources */,
 				23444F9E1DCD221A00573C8C /* BTCErrors.m in Sources */,

--- a/Blockchain/Extensions/DateFormatter+Conveniences.swift
+++ b/Blockchain/Extensions/DateFormatter+Conveniences.swift
@@ -1,0 +1,18 @@
+//
+//  DateFormatter+Conveniences.swift
+//  Blockchain
+//
+//  Created by Alex McGregor on 8/7/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+extension DateFormatter {
+    static let birthday: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+}

--- a/Blockchain/KYC/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/KYCPersonalDetailsController.swift
@@ -9,12 +9,16 @@
 import UIKit
 
 /// Personal details entry screen in KYC flow
-final class KYCPersonalDetailsController: UIViewController, ValidationFormView {
+final class KYCPersonalDetailsController: UIViewController, ValidationFormView, ProgressableView {
+
+    var barColor: UIColor = .green
+    var startingValue: Float = 0.14
 
     // MARK: - Public IBOutlets
 
     @IBOutlet var scrollView: UIScrollView!
-
+    @IBOutlet var progressView: UIProgressView!
+    
     // MARK: - IBOutlets
 
     @IBOutlet fileprivate var firstNameField: ValidationTextField!
@@ -42,6 +46,20 @@ final class KYCPersonalDetailsController: UIViewController, ValidationFormView {
         setupTextFields()
         handleKeyboardOffset()
         setupNotifications()
+        setupProgressView()
+
+        validationFields.enumerated().forEach { (index, field) in
+            field.returnTappedBlock = { [weak self] in
+                guard let this = self else { return }
+                this.updateProgress(this.progression())
+                guard this.validationFields.count > index + 1 else {
+                    field.resignFocus()
+                    return
+                }
+                let next = this.validationFields[index + 1]
+                next.becomeFocused()
+            }
+        }
     }
 
     // MARK: - Private Methods
@@ -63,6 +81,13 @@ final class KYCPersonalDetailsController: UIViewController, ValidationFormView {
             let keyboard = KeyboardPayload(notification: notification)
             self?.keyboard = keyboard
         }
+    }
+
+    fileprivate func progression() -> Float {
+        let newProgression: Float = validationFields.map({
+            return $0.validate() == .valid ? 0.14 : 0.0
+        }).reduce(startingValue, +)
+        return max(newProgression, startingValue)
     }
 
     // MARK: - Actions

--- a/Blockchain/KYC/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/KYCPersonalDetailsController.swift
@@ -77,7 +77,6 @@ final class KYCPersonalDetailsController: UIViewController, ValidationFormView, 
             if date <= Date.eighteenYears {
                 return .valid
             } else {
-                
                 return .invalid(.minimumDateRequirement)
             }
         }

--- a/Blockchain/KYC/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/KYCPersonalDetailsController.swift
@@ -11,12 +11,11 @@ import UIKit
 /// Personal details entry screen in KYC flow
 final class KYCPersonalDetailsController: UIViewController, ValidationFormView, ProgressableView {
 
+    // MARK: - ProgressableView
+
     var barColor: UIColor = .green
     var startingValue: Float = 0.14
 
-    // MARK: - Public IBOutlets
-
-    @IBOutlet var scrollView: UIScrollView!
     @IBOutlet var progressView: UIProgressView!
 
     // MARK: - IBOutlets
@@ -26,7 +25,9 @@ final class KYCPersonalDetailsController: UIViewController, ValidationFormView, 
     @IBOutlet fileprivate var birthdayField: ValidationDateField!
     @IBOutlet fileprivate var primaryButton: PrimaryButton!
 
-    // MARK: Public Properties
+    // MARK: ValidationFormView
+
+    @IBOutlet var scrollView: UIScrollView!
 
     var validationFields: [ValidationTextField] {
         get {

--- a/Blockchain/KYC/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/KYCPersonalDetailsController.swift
@@ -18,7 +18,7 @@ final class KYCPersonalDetailsController: UIViewController, ValidationFormView, 
 
     @IBOutlet var scrollView: UIScrollView!
     @IBOutlet var progressView: UIProgressView!
-    
+
     // MARK: - IBOutlets
 
     @IBOutlet fileprivate var firstNameField: ValidationTextField!
@@ -70,6 +70,17 @@ final class KYCPersonalDetailsController: UIViewController, ValidationFormView, 
 
         lastNameField.returnKeyType = .next
         lastNameField.contentType = .familyName
+
+        birthdayField.validationBlock = { value in
+            guard let birthday = value else { return .invalid(nil) }
+            guard let date = DateFormatter.birthday.date(from: birthday) else { return .invalid(nil) }
+            if date <= Date.eighteenYears {
+                return .valid
+            } else {
+                
+                return .invalid(.minimumDateRequirement)
+            }
+        }
     }
 
     fileprivate func setupNotifications() {
@@ -107,4 +118,11 @@ extension KYCPersonalDetailsController: UIScrollViewDelegate {
         // TODO: May not be necessary. 
         validationFields.forEach({$0.resignFocus()})
     }
+}
+
+extension Date {
+    static let eighteenYears: Date = Calendar.current.date(
+        byAdding: .year,
+        value: -18,
+        to: Date()) ?? Date()
 }

--- a/Blockchain/KYC/Storyboards/KYCPersonalDetails.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCPersonalDetails.storyboard
@@ -23,69 +23,132 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="724"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="First Name" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="YyL-LD-6vz">
-                                <rect key="frame" x="16" y="16" width="343" height="55"/>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="sxl-FD-HTb">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="8"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="kaW-x4-l0B"/>
+                                    <constraint firstAttribute="height" constant="8" id="VjU-hs-80k"/>
                                 </constraints>
+                            </progressView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="What is my address used for?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmZ-Mg-6Kp">
+                                <rect key="frame" x="16" y="16" width="343" height="15"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
                                 <nil key="textColor"/>
-                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="17"/>
-                                <textInputTraits key="textInputTraits" returnKeyType="next"/>
-                                <connections>
-                                    <outlet property="delegate" destination="VK4-jv-eiz" id="CZq-c7-1Uw"/>
-                                </connections>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Last Name" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Zrq-9J-3by" userLabel="Last Name Field">
-                                <rect key="frame" x="16" y="79" width="343" height="55"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="fNA-cZ-BBm"/>
-                                </constraints>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="999" text="We may send a verification postcard for added security." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IMs-GD-oqE">
+                                <rect key="frame" x="16" y="33" width="343" height="14.333333333333336"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
-                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="17"/>
-                                <textInputTraits key="textInputTraits" returnKeyType="next"/>
-                                <connections>
-                                    <outlet property="delegate" destination="VK4-jv-eiz" id="6Zw-88-iAq"/>
-                                </connections>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Birthdate" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="R8u-2L-YQa" userLabel="Birthdate Field">
-                                <rect key="frame" x="16" y="142" width="343" height="55"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oDQ-tQ-rDw">
+                                <rect key="frame" x="0.0" y="47.333333333333314" width="375" height="642.66666666666674"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFe-4p-8Bl" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
+                                        <rect key="frame" x="16" y="0.0" width="343" height="56"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="56" id="unQ-2Z-OTz"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="First Name"/>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
+                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                                <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Nk-Gd-qS1" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
+                                        <rect key="frame" x="16" y="55.666666666666657" width="343" height="56"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="56" id="JbJ-Qu-aif"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Last Name"/>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
+                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                                <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="38g-Ci-yOA" customClass="ValidationDateField" customModule="Blockchain" customModuleProvider="target">
+                                        <rect key="frame" x="16" y="112" width="343" height="56"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="56" id="wLH-Yd-Id7"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Birthday"/>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
+                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                                <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5a2-YO-4u9" customClass="PrimaryButton" customModule="Blockchain" customModuleProvider="target">
+                                        <rect key="frame" x="16" y="175.99999999999997" width="343" height="44"/>
+                                        <color key="backgroundColor" red="0.062745098040000002" green="0.67843137249999996" blue="0.89411764709999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="c0L-MU-eN2"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="17"/>
+                                        <state key="normal" title="Next"/>
+                                        <connections>
+                                            <action selector="primaryButtonTapped:" destination="VK4-jv-eiz" eventType="touchUpInside" id="K4z-pF-XWd"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="ZEO-vI-zHu"/>
+                                    <constraint firstAttribute="trailing" secondItem="38g-Ci-yOA" secondAttribute="trailing" constant="16" id="2Nv-Xp-mtz"/>
+                                    <constraint firstItem="38g-Ci-yOA" firstAttribute="leading" secondItem="oDQ-tQ-rDw" secondAttribute="leading" constant="16" id="CTl-rG-4bv"/>
+                                    <constraint firstItem="6Nk-Gd-qS1" firstAttribute="leading" secondItem="oDQ-tQ-rDw" secondAttribute="leading" constant="16" id="Ml9-p3-cbv"/>
+                                    <constraint firstAttribute="trailing" secondItem="dFe-4p-8Bl" secondAttribute="trailing" constant="16" id="NVi-mF-g0o"/>
+                                    <constraint firstItem="dFe-4p-8Bl" firstAttribute="top" secondItem="oDQ-tQ-rDw" secondAttribute="top" id="NXv-A1-W8C"/>
+                                    <constraint firstItem="38g-Ci-yOA" firstAttribute="top" secondItem="6Nk-Gd-qS1" secondAttribute="bottom" id="QQC-DJ-NmU"/>
+                                    <constraint firstAttribute="trailing" secondItem="6Nk-Gd-qS1" secondAttribute="trailing" constant="16" id="UuH-7W-WIs"/>
+                                    <constraint firstItem="6Nk-Gd-qS1" firstAttribute="width" secondItem="dFe-4p-8Bl" secondAttribute="width" id="V5R-nI-Lz9"/>
+                                    <constraint firstItem="dFe-4p-8Bl" firstAttribute="leading" secondItem="oDQ-tQ-rDw" secondAttribute="leading" constant="16" id="Vgt-w3-Sgq"/>
+                                    <constraint firstItem="38g-Ci-yOA" firstAttribute="width" secondItem="6Nk-Gd-qS1" secondAttribute="width" id="XCo-fP-XdL"/>
+                                    <constraint firstItem="6Nk-Gd-qS1" firstAttribute="top" secondItem="dFe-4p-8Bl" secondAttribute="bottom" id="b1j-iP-iOP"/>
+                                    <constraint firstItem="5a2-YO-4u9" firstAttribute="trailing" secondItem="38g-Ci-yOA" secondAttribute="trailing" id="hmn-30-aLv"/>
+                                    <constraint firstAttribute="bottom" secondItem="5a2-YO-4u9" secondAttribute="bottom" constant="16" id="nmi-wZ-5ah"/>
+                                    <constraint firstItem="5a2-YO-4u9" firstAttribute="leading" secondItem="38g-Ci-yOA" secondAttribute="leading" id="t3H-jr-8El"/>
+                                    <constraint firstItem="5a2-YO-4u9" firstAttribute="top" secondItem="38g-Ci-yOA" secondAttribute="bottom" constant="8" id="wQ6-Ei-gBC"/>
                                 </constraints>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="17"/>
-                                <textInputTraits key="textInputTraits" returnKeyType="continue"/>
                                 <connections>
-                                    <outlet property="delegate" destination="VK4-jv-eiz" id="b3o-DG-j0M"/>
+                                    <outlet property="delegate" destination="VK4-jv-eiz" id="oke-kY-her"/>
                                 </connections>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5a2-YO-4u9" customClass="PrimaryButton" customModule="Blockchain" customModuleProvider="target">
-                                <rect key="frame" x="16" y="630" width="343" height="44"/>
-                                <color key="backgroundColor" red="0.062745098040000002" green="0.67843137249999996" blue="0.89411764709999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="8cv-Fd-Sh6"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="17"/>
-                                <state key="normal" title="Continue"/>
-                                <connections>
-                                    <action selector="primaryButtonTapped:" destination="VK4-jv-eiz" eventType="touchUpInside" id="K4z-pF-XWd"/>
-                                </connections>
-                            </button>
+                            </scrollView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="bottom" secondItem="5a2-YO-4u9" secondAttribute="bottom" constant="16" id="8bd-OA-FHI"/>
-                            <constraint firstItem="YyL-LD-6vz" firstAttribute="top" secondItem="A6g-7V-Tpb" secondAttribute="top" constant="16" id="Ijr-am-8zd"/>
-                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="R8u-2L-YQa" secondAttribute="trailing" constant="16" id="Jvi-S6-Qvy"/>
-                            <constraint firstItem="Zrq-9J-3by" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" constant="16" id="OVR-uK-MP3"/>
-                            <constraint firstItem="5a2-YO-4u9" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" constant="16" id="QLf-Mi-P0f"/>
-                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="5a2-YO-4u9" secondAttribute="trailing" constant="16" id="XTZ-2n-B9E"/>
-                            <constraint firstItem="R8u-2L-YQa" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" constant="16" id="ge1-nP-6SQ"/>
-                            <constraint firstItem="R8u-2L-YQa" firstAttribute="top" secondItem="Zrq-9J-3by" secondAttribute="bottom" constant="8" id="h7F-er-qk1"/>
-                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="YyL-LD-6vz" secondAttribute="trailing" constant="16" id="kYE-DI-klq"/>
-                            <constraint firstItem="Zrq-9J-3by" firstAttribute="top" secondItem="YyL-LD-6vz" secondAttribute="bottom" constant="8" id="mtG-ot-tNd"/>
-                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="Zrq-9J-3by" secondAttribute="trailing" constant="16" id="qaU-1n-Ykq"/>
-                            <constraint firstItem="YyL-LD-6vz" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" constant="16" id="wYM-KB-aia"/>
+                            <constraint firstItem="tmZ-Mg-6Kp" firstAttribute="top" secondItem="sxl-FD-HTb" secondAttribute="bottom" constant="8" id="2d9-Mo-WIr"/>
+                            <constraint firstItem="sxl-FD-HTb" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" id="7Cp-VL-P0Z"/>
+                            <constraint firstItem="IMs-GD-oqE" firstAttribute="trailing" secondItem="tmZ-Mg-6Kp" secondAttribute="trailing" id="889-1g-2Ck"/>
+                            <constraint firstItem="oDQ-tQ-rDw" firstAttribute="top" secondItem="IMs-GD-oqE" secondAttribute="bottom" id="MyY-WO-lW9"/>
+                            <constraint firstItem="IMs-GD-oqE" firstAttribute="leading" secondItem="tmZ-Mg-6Kp" secondAttribute="leading" id="NP6-i7-SFD"/>
+                            <constraint firstItem="oDQ-tQ-rDw" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" id="NS6-cv-AqF"/>
+                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="bottom" secondItem="oDQ-tQ-rDw" secondAttribute="bottom" id="Ngv-iE-i4Q"/>
+                            <constraint firstItem="dFe-4p-8Bl" firstAttribute="width" secondItem="IMs-GD-oqE" secondAttribute="width" id="Ost-xi-8cb"/>
+                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="oDQ-tQ-rDw" secondAttribute="trailing" id="TaS-qG-rfa"/>
+                            <constraint firstItem="sxl-FD-HTb" firstAttribute="top" secondItem="A6g-7V-Tpb" secondAttribute="top" id="bsI-YJ-JKf"/>
+                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="sxl-FD-HTb" secondAttribute="trailing" id="iy1-0F-Ect"/>
+                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="tmZ-Mg-6Kp" secondAttribute="trailing" constant="16" id="mVs-oS-QDE"/>
+                            <constraint firstItem="tmZ-Mg-6Kp" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" constant="16" id="odu-5Q-U5d"/>
+                            <constraint firstItem="IMs-GD-oqE" firstAttribute="top" secondItem="tmZ-Mg-6Kp" secondAttribute="bottom" constant="2" id="xfM-Eo-Bki"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="A6g-7V-Tpb"/>
                     </view>
@@ -94,16 +157,17 @@
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
-                        <outlet property="birthdateField" destination="R8u-2L-YQa" id="faJ-q2-1Iu"/>
-                        <outlet property="firstNameField" destination="YyL-LD-6vz" id="Zuv-Qh-mI0"/>
-                        <outlet property="lastNameField" destination="Zrq-9J-3by" id="6De-fY-t4Y"/>
+                        <outlet property="birthdayField" destination="38g-Ci-yOA" id="aQP-L4-4V9"/>
+                        <outlet property="firstNameField" destination="dFe-4p-8Bl" id="L3G-QR-mVR"/>
+                        <outlet property="lastNameField" destination="6Nk-Gd-qS1" id="trs-Iy-Ecy"/>
                         <outlet property="primaryButton" destination="5a2-YO-4u9" id="bkL-go-wpB"/>
+                        <outlet property="scrollView" destination="oDQ-tQ-rDw" id="RFu-VN-Nho"/>
                         <segue destination="ikb-aY-GZn" kind="show" identifier="enterMobileNumber" id="EC8-k6-Erk"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="NPZ-Fa-q8L" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-47" y="194"/>
+            <point key="canvasLocation" x="-47.200000000000003" y="193.5960591133005"/>
         </scene>
         <!--KYCEnterPhoneNumber-->
         <scene sceneID="i1U-r4-6wf">

--- a/Blockchain/KYC/Storyboards/KYCPersonalDetails.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCPersonalDetails.storyboard
@@ -28,6 +28,8 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="8" id="VjU-hs-80k"/>
                                 </constraints>
+                                <color key="progressTintColor" red="0.13725490196078433" green="0.58823529411764708" blue="0.42352941176470588" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="trackTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </progressView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="What is my address used for?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmZ-Mg-6Kp">
                                 <rect key="frame" x="16" y="16" width="343" height="15"/>
@@ -161,6 +163,7 @@
                         <outlet property="firstNameField" destination="dFe-4p-8Bl" id="L3G-QR-mVR"/>
                         <outlet property="lastNameField" destination="6Nk-Gd-qS1" id="trs-Iy-Ecy"/>
                         <outlet property="primaryButton" destination="5a2-YO-4u9" id="bkL-go-wpB"/>
+                        <outlet property="progressView" destination="sxl-FD-HTb" id="Op0-Xj-T3U"/>
                         <outlet property="scrollView" destination="oDQ-tQ-rDw" id="RFu-VN-Nho"/>
                         <segue destination="ikb-aY-GZn" kind="show" identifier="enterMobileNumber" id="EC8-k6-Erk"/>
                     </connections>

--- a/Blockchain/KYC/Storyboards/KYCPersonalDetails.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCPersonalDetails.storyboard
@@ -31,13 +31,13 @@
                                 <color key="progressTintColor" red="0.13725490196078433" green="0.58823529411764708" blue="0.42352941176470588" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="trackTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </progressView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="What is my address used for?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmZ-Mg-6Kp">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Why do you need this?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmZ-Mg-6Kp">
                                 <rect key="frame" x="16" y="16" width="343" height="15"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="999" text="We may send a verification postcard for added security." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IMs-GD-oqE">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="999" text="You must be 18 or older to buy, sell on Blockchain." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IMs-GD-oqE">
                                 <rect key="frame" x="16" y="33" width="343" height="14.333333333333336"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>

--- a/Blockchain/KYC/Views/ProgressableView.swift
+++ b/Blockchain/KYC/Views/ProgressableView.swift
@@ -1,0 +1,27 @@
+//
+//  ProgressableView.swift
+//  Blockchain
+//
+//  Created by Alex McGregor on 8/7/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+protocol ProgressableView {
+    var progressView: UIProgressView! { get }
+    var barColor: UIColor { get set }
+    var startingValue: Float { get set }
+
+    func setupProgressView()
+    func updateProgress(_ progress: Float)
+}
+
+extension ProgressableView {
+    func setupProgressView() {
+        progressView.progressTintColor = barColor
+        progressView.setProgress(startingValue, animated: true)
+    }
+
+    func updateProgress(_ progress: Float) {
+        progressView.setProgress(progress, animated: true)
+    }
+}

--- a/Blockchain/Views/ValidationForm/ValidationFormView.swift
+++ b/Blockchain/Views/ValidationForm/ValidationFormView.swift
@@ -1,0 +1,83 @@
+//
+//  ValidationForm.swift
+//  Blockchain
+//
+//  Created by Alex McGregor on 8/7/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// `ValidationFormView` is for views that include multiple
+/// `ValidationTextFields` (or subclasses) that are nested
+/// within a `UIScrollView`.
+protocol ValidationFormView {
+    var validationFields: [ValidationTextField] { get }
+    var scrollView: UIScrollView! { get }
+    var keyboard: KeyboardPayload? { get set }
+
+    /// This should be called on `viewDidLoad`. It sets the
+    /// `becomeFirstResponder` block and handles offseting
+    /// the `UIScrollView` so the currently in focus `ValidationTextField`
+    /// is within the correct field of view.
+    func handleKeyboardOffset()
+
+    /// This validates all the `ValidationTextFields`.
+    /// Should a field not pass validation, that field
+    /// will become the first responder.
+    func checkFieldsValidity() -> Bool
+}
+
+extension ValidationFormView where Self: UIViewController {
+    func handleKeyboardOffset() {
+        /// This is for handling when the `VerificationTextField`
+        /// is covered by the keyboard. Depending on how many
+        /// forms we have in the app this could be a candidate for abstraction.
+        validationFields.forEach { (field) in
+            field.becomeFirstResponderBlock = { [weak self] (validationField) in
+                guard let this = self else { return }
+                var offsetHeight = this.keyboard?.endingFrame.height
+                if let field = validationField as? ValidationDateField {
+                    offsetHeight = field.pickerView.frame.height
+                }
+                guard let height = offsetHeight else { return }
+                let insets = UIEdgeInsets(
+                    top: 0.0,
+                    left: 0.0,
+                    bottom: height,
+                    right: 0.0
+                )
+                this.scrollView.contentInset = insets
+
+                let viewSize = CGSize(
+                    width: this.scrollView.frame.width,
+                    height: this.scrollView.frame.height - height
+                )
+                let viewableFrame = CGRect(
+                    origin: this.scrollView.frame.origin,
+                    size: viewSize
+                )
+
+                if !viewableFrame.contains(validationField.frame.origin) {
+                    this.scrollView.scrollRectToVisible(
+                        validationField.frame,
+                        animated: true
+                    )
+                }
+            }
+        }
+    }
+
+    func checkFieldsValidity() -> Bool {
+        var valid: Bool = true
+        for field in validationFields {
+            guard case .valid = field.validate() else {
+                valid = false
+                guard !validationFields.contains(where: {$0.isFocused() == true}) else { continue }
+                field.becomeFocused()
+                continue
+            }
+        }
+        return valid
+    }
+}

--- a/Blockchain/Views/ValidationForm/ValidationFormView.swift
+++ b/Blockchain/Views/ValidationForm/ValidationFormView.swift
@@ -70,6 +70,7 @@ extension ValidationFormView where Self: UIViewController {
 
     func checkFieldsValidity() -> Bool {
         var valid: Bool = true
+        validationFields.forEach({$0.resignFocus()})
         for field in validationFields {
             guard case .valid = field.validate(withStyling: true) else {
                 valid = false

--- a/Blockchain/Views/ValidationForm/ValidationFormView.swift
+++ b/Blockchain/Views/ValidationForm/ValidationFormView.swift
@@ -71,7 +71,7 @@ extension ValidationFormView where Self: UIViewController {
     func checkFieldsValidity() -> Bool {
         var valid: Bool = true
         for field in validationFields {
-            guard case .valid = field.validate() else {
+            guard case .valid = field.validate(withStyling: true) else {
                 valid = false
                 guard !validationFields.contains(where: {$0.isFocused() == true}) else { continue }
                 field.becomeFocused()

--- a/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.swift
@@ -1,0 +1,54 @@
+//
+//  ValidationDateField.swift
+//  Blockchain
+//
+//  Created by Alex McGregor on 8/7/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+/// `ValidationDateField` is a `ValidationTextField`
+/// that presents a `UIDatePicker` instead of a keyboard.
+/// It does not support manual date entry.
+/// Ideally this would be a `UIPickerView` with its own dataSource
+/// but due to time constraints I am using a `UIDatePicker`.
+class ValidationDateField: ValidationTextField {
+
+    fileprivate static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    lazy var pickerView: UIDatePicker = {
+        let picker = UIDatePicker(frame: .zero)
+        return picker
+    }()
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        pickerView.datePickerMode = .date
+        pickerView.maximumDate = Date()
+        textFieldInputView = pickerView
+        pickerView.addTarget(self, action: #selector(datePickerUpdated(_:)), for: .valueChanged)
+    }
+    
+    @objc func datePickerUpdated(_ sender: UIDatePicker) {
+        text = ValidationDateField.formatter.string(from: sender.date)
+    }
+
+    override func textFieldDidEndEditing(_ textField: UITextField) {
+        super.textFieldDidEndEditing(textField)
+        pickerView.isHidden = true
+    }
+
+    override func textFieldDidBeginEditing(_ textField: UITextField) {
+        super.textFieldDidBeginEditing(textField)
+        pickerView.isHidden = false
+    }
+
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        return false
+    }
+}

--- a/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.swift
@@ -18,8 +18,6 @@ class ValidationDateField: ValidationTextField {
         return picker
     }()
 
-    var minimumDate: Date = Date()
-
     override func awakeFromNib() {
         super.awakeFromNib()
 

--- a/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.swift
@@ -13,17 +13,12 @@
 /// but due to time constraints I am using a `UIDatePicker`.
 class ValidationDateField: ValidationTextField {
 
-    fileprivate static let formatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter
-    }()
-
     lazy var pickerView: UIDatePicker = {
         let picker = UIDatePicker(frame: .zero)
         return picker
     }()
+
+    var minimumDate: Date = Date()
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -35,7 +30,7 @@ class ValidationDateField: ValidationTextField {
     }
     
     @objc func datePickerUpdated(_ sender: UIDatePicker) {
-        text = ValidationDateField.formatter.string(from: sender.date)
+        text = DateFormatter.birthday.string(from: sender.date)
     }
 
     override func textFieldDidEndEditing(_ textField: UITextField) {

--- a/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.xib
+++ b/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.xib
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Montserrat-Regular.ttf">
+            <string>Montserrat-Regular</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ValidationDateField" customModule="Blockchain" customModuleProvider="target">
+            <connections>
+                <outlet property="baselineView" destination="0P6-Gs-yhz" id="4vT-X5-CHP"/>
+                <outlet property="errorImageView" destination="Pc2-bC-sS8" id="TzK-Lb-zRT"/>
+                <outlet property="textField" destination="WwB-vh-Lo8" id="0If-yO-2js"/>
+                <outlet property="textFieldTrailingConstraint" destination="sDk-IA-Wwm" id="yU8-9w-hE8"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clipsSubviews="YES" contentMode="scaleToFill" id="pWn-eT-R29">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="92"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WwB-vh-Lo8">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="91"/>
+                    <nil key="textColor"/>
+                    <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="16"/>
+                    <textInputTraits key="textInputTraits"/>
+                    <connections>
+                        <outlet property="delegate" destination="-1" id="q4J-S6-2bF"/>
+                    </connections>
+                </textField>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0P6-Gs-yhz">
+                    <rect key="frame" x="0.0" y="91" width="375" height="1"/>
+                    <color key="backgroundColor" red="0.59999999999999998" green="0.60784313729999995" blue="0.61960784310000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="1" id="KOr-k3-d2U"/>
+                    </constraints>
+                </view>
+                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Icon_form_invalid" translatesAutoresizingMaskIntoConstraints="NO" id="Pc2-bC-sS8">
+                    <rect key="frame" x="375" y="37.5" width="16" height="16"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="16" id="g2f-sM-esa"/>
+                        <constraint firstAttribute="width" constant="16" id="rlo-O3-U0r"/>
+                    </constraints>
+                </imageView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="Pc2-bC-sS8" firstAttribute="leading" secondItem="WwB-vh-Lo8" secondAttribute="trailing" id="4t3-ne-hyy"/>
+                <constraint firstAttribute="trailing" secondItem="0P6-Gs-yhz" secondAttribute="trailing" id="85n-Qk-z7a"/>
+                <constraint firstItem="WwB-vh-Lo8" firstAttribute="leading" secondItem="9bD-xP-cer" secondAttribute="leading" id="CIG-71-7KF"/>
+                <constraint firstItem="0P6-Gs-yhz" firstAttribute="leading" secondItem="pWn-eT-R29" secondAttribute="leading" id="GGT-ma-Lk7"/>
+                <constraint firstItem="Pc2-bC-sS8" firstAttribute="centerY" secondItem="WwB-vh-Lo8" secondAttribute="centerY" id="ZhY-97-WTT"/>
+                <constraint firstItem="9bD-xP-cer" firstAttribute="bottom" secondItem="0P6-Gs-yhz" secondAttribute="bottom" id="ghe-AE-qgd"/>
+                <constraint firstItem="WwB-vh-Lo8" firstAttribute="top" secondItem="9bD-xP-cer" secondAttribute="top" id="pMs-Tb-Jzq"/>
+                <constraint firstItem="0P6-Gs-yhz" firstAttribute="top" secondItem="WwB-vh-Lo8" secondAttribute="bottom" id="rDO-YT-qYv"/>
+                <constraint firstItem="9bD-xP-cer" firstAttribute="trailing" secondItem="WwB-vh-Lo8" secondAttribute="trailing" id="sDk-IA-Wwm"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="9bD-xP-cer"/>
+            <point key="canvasLocation" x="29.5" y="81"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="Icon_form_invalid" width="16" height="16"/>
+    </resources>
+</document>

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.swift
@@ -95,6 +95,12 @@ class ValidationTextField: NibBasedView {
 
     // MARK: Public Properties
 
+    var autocapitalizationType: UITextAutocapitalizationType = .words {
+        didSet {
+            textField.autocapitalizationType = autocapitalizationType
+        }
+    }
+
     var font: UIFont = ValidationTextField.primaryFont {
         didSet {
             textField.font = font

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.swift
@@ -13,6 +13,21 @@ enum ValidationResult {
     case invalid(Error?)
 }
 
+extension ValidationResult {
+    static func ==(lhs: ValidationResult, rhs: ValidationResult) -> Bool {
+        switch (lhs, rhs) {
+        case (.valid, .valid):
+            return true
+        case (.valid, .invalid):
+            return false
+        case (.invalid, .valid):
+            return false
+        case (.invalid, .invalid):
+            return true
+        }
+    }
+}
+
 typealias ValidationBlock = ((String?) -> ValidationResult)
 
 @IBDesignable
@@ -27,17 +42,7 @@ class ValidationTextField: NibBasedView {
 
     // MARK: Private Properties
 
-    fileprivate var validity: ValidationResult = .valid {
-        didSet {
-            // TODO: Show the `x` when it is invalid.
-            switch validity {
-            case .invalid:
-                baselineFillColor = UIColor.red
-            case .valid:
-                baselineFillColor = UIColor.gray2
-            }
-        }
-    }
+    fileprivate var validity: ValidationResult = .valid
 
     // MARK: IBInspectable Properties
 
@@ -156,7 +161,7 @@ class ValidationTextField: NibBasedView {
         textField.resignFirstResponder()
     }
 
-    func validate() -> ValidationResult {
+    func validate(withStyling: Bool = false) -> ValidationResult {
         if let block = validationBlock {
             validity = block(textField.text)
         } else {
@@ -166,7 +171,8 @@ class ValidationTextField: NibBasedView {
                 validity = .valid
             }
         }
-
+        guard withStyling == true else { return validity }
+        
         applyValidity(animated: true)
         return validity
     }
@@ -178,10 +184,12 @@ class ValidationTextField: NibBasedView {
         case .valid:
             guard textFieldTrailingConstraint.constant != 0 else { return }
             textFieldTrailingConstraint.constant = 0
+            baselineFillColor = .gray2
 
         case .invalid:
             guard textFieldTrailingConstraint.constant != errorImageView.bounds.width else { return }
             textFieldTrailingConstraint.constant = errorImageView.bounds.width
+            baselineFillColor = .red
         }
 
         setNeedsLayout()

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.swift
@@ -115,6 +115,12 @@ class ValidationTextField: NibBasedView {
         }
     }
 
+    var textFieldInputView: UIView? = nil {
+        didSet {
+            textField.inputView = textFieldInputView
+        }
+    }
+
     /// This closure is called when the user taps `next`
     /// or `done` etc. and the `textField` resigns.
     var returnTappedBlock: (() -> Void)?

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.swift
@@ -8,9 +8,14 @@
 
 import UIKit
 
+enum ValidationError: Error {
+    case unknown
+    case minimumDateRequirement
+}
+
 enum ValidationResult {
     case valid
-    case invalid(Error?)
+    case invalid(ValidationError?)
 }
 
 extension ValidationResult {

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.xib
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.xib
@@ -32,7 +32,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="91"/>
                     <nil key="textColor"/>
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="16"/>
-                    <textInputTraits key="textInputTraits"/>
+                    <textInputTraits key="textInputTraits" autocapitalizationType="words"/>
                     <connections>
                         <outlet property="delegate" destination="-1" id="GrD-iU-cbW"/>
                     </connections>


### PR DESCRIPTION
## Objective

**Note:** Marking DNM due to conflict with develop and some minor polish items I'm still addressing. 

This PR includes the new `Personal Information` screen as well as a protocol for handling the `UIProgressView` that should be in all the KYC related screens. 

## Description

In addition to the features described, there's a few areas of code cleanup. 
* Added `ValidationFormView` - This protocol should be used with all `UIViewControllers` that have a `UIScrollView` and a bunch of `ValidationTextFields`. It will handle keeping the selected `UITextField` in the user's field of view when the keyboard is presented as well as checking all the fields' validation state. 
* Added `ValidationDateField` - This is only for when you have a `UITextField` that only takes a date as input. It's not ideal as I'd rather we use `UIPickerView` and configure it with whatever dataSource is necessary but, due to time constraints I'm putting that off. The date is validated with the `validationBlock`. 
* Added`ProgressableView`. I'm assuming this will be tweaked as we get closer to shipping. Per creative, we may end up showing progression per field vs. per screen. 

## How to Test

1. Before building, in the `KYCWelcome` storyboard, set the segue to route to the `KYCPersonalDetails` storyboard. 
2. Build and run
3. Go to the KYC flow.
4. Tap `Apply Now`
5. View the `Personal Details` page. Mess with the fields. 

## Screenshot

**Note:** The `primaryButton` is a bit high. I'd like to offset it based on the keyboards position but haven't gotten to that yet. 

![screen shot 2018-08-07 at 4 18 05 pm](https://user-images.githubusercontent.com/41585563/43803113-8264a712-9a5d-11e8-9593-9c0a1756e896.png)

## Related Information

* Ticket Number: IOS-1141 & IOS-1046

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
