### PR TITLE
fix(KYC): Improve UX in KYC confirmation code view

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -341,7 +341,6 @@
 		67EEE7731A8E547900288753 /* PEPin-on@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 67EEE7711A8E547900288753 /* PEPin-on@3x.png */; };
 		67FA1A4D1ABA092D000C9196 /* RegExCategories.m in Sources */ = {isa = PBXBuildFile; fileRef = 67FA1A4C1ABA092D000C9196 /* RegExCategories.m */; };
 		6E2D90A21BBEC34800B719EC /* BCRecoveryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2D90A11BBEC34800B719EC /* BCRecoveryView.m */; };
-		7570543E13E69766BF8552A0 /* Pods_BlockchainTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32AA7843695F30B69F3112F4 /* Pods_BlockchainTests.framework */; };
 		84B601C7197ACD6300DA1829 /* UITextField+Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = 84B601C6197ACD6300DA1829 /* UITextField+Blocks.m */; };
 		84B601CA197AD03800DA1829 /* BCModalView.m in Sources */ = {isa = PBXBuildFile; fileRef = 84B601C9197AD03800DA1829 /* BCModalView.m */; };
 		84F4BDFA197F21D700B7BF7B /* PairingCodeParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 84F4BDF9197F21D700B7BF7B /* PairingCodeParser.m */; };
@@ -399,6 +398,8 @@
 		AA3CA9B62107F36800C2AD46 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B42107F36700C2AD46 /* LogLevel.swift */; };
 		AA3CA9B82107F66E00C2AD46 /* ConsoleLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B72107F66E00C2AD46 /* ConsoleLogDestination.swift */; };
 		AA3CA9B92107F66E00C2AD46 /* ConsoleLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B72107F66E00C2AD46 /* ConsoleLogDestination.swift */; };
+		AA477084211B73D1006356B1 /* BottomButtonContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA477083211B73D1006356B1 /* BottomButtonContainerView.swift */; };
+		AA47709D211B7BC3006356B1 /* BottomButtonContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA477083211B73D1006356B1 /* BottomButtonContainerView.swift */; };
 		AA54277C20D88DD900D5FEEE /* SwipeToReceiveAddressView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AA54277B20D88DD900D5FEEE /* SwipeToReceiveAddressView.xib */; };
 		AA56423820DDBDAA0092A022 /* PinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA56421D20DDBDA90092A022 /* PinTests.swift */; };
 		AA56423B20DDBDBB0092A022 /* String+EscapeJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA56423920DDBDBB0092A022 /* String+EscapeJSTests.swift */; };
@@ -2744,6 +2745,7 @@
 		AA3CA9B12107F2B700C2AD46 /* LogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogDestination.swift; sourceTree = "<group>"; };
 		AA3CA9B42107F36700C2AD46 /* LogLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevel.swift; sourceTree = "<group>"; };
 		AA3CA9B72107F66E00C2AD46 /* ConsoleLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogDestination.swift; sourceTree = "<group>"; };
+		AA477083211B73D1006356B1 /* BottomButtonContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonContainerView.swift; sourceTree = "<group>"; };
 		AA54277B20D88DD900D5FEEE /* SwipeToReceiveAddressView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SwipeToReceiveAddressView.xib; sourceTree = "<group>"; };
 		AA56421D20DDBDA90092A022 /* PinTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinTests.swift; sourceTree = "<group>"; };
 		AA56423920DDBDBB0092A022 /* String+EscapeJSTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+EscapeJSTests.swift"; sourceTree = "<group>"; };
@@ -3392,21 +3394,21 @@
 		602B9CA62118E15200BD3D60 /* KYC */ = {
 			isa = PBXGroup;
 			children = (
-				602B9CA72118E15200BD3D60 /* Storyboards */,
-				602B9CB12118E15200BD3D60 /* KYCNetworkRequest.swift */,
-				602B9CB22118E15200BD3D60 /* Mobile Number */,
-				602B9CB72118E15200BD3D60 /* CountrySelector */,
-				602B9CBA2118E15200BD3D60 /* Models */,
-				602B9CBC2118E15200BD3D60 /* Search */,
 				602B9CCD2118E15200BD3D60 /* KYCAccountStatusController.swift */,
 				602B9CCE2118E15200BD3D60 /* KYCCoordinator.swift */,
-				602B9CCF2118E15200BD3D60 /* Address */,
+				602B9CB12118E15200BD3D60 /* KYCNetworkRequest.swift */,
 				602B9CD12118E15200BD3D60 /* KYCOnboardingNavigationController.swift */,
-				602B9CD22118E15200BD3D60 /* KYCVerifyIdentityController.swift */,
-				602B9CD32118E15200BD3D60 /* Views */,
 				602B9CD52118E15200BD3D60 /* KYCPersonalDetailsController.swift */,
+				602B9CD22118E15200BD3D60 /* KYCVerifyIdentityController.swift */,
 				602B9CD62118E15200BD3D60 /* KYCWelcomeController.swift */,
 				601F5EE0211B32AA002697AB /* OnfidoController.swift */,
+				602B9CCF2118E15200BD3D60 /* Address */,
+				602B9CB72118E15200BD3D60 /* CountrySelector */,
+				602B9CB22118E15200BD3D60 /* Mobile Number */,
+				602B9CBA2118E15200BD3D60 /* Models */,
+				602B9CBC2118E15200BD3D60 /* Search */,
+				602B9CA72118E15200BD3D60 /* Storyboards */,
+				602B9CD32118E15200BD3D60 /* Views */,
 			);
 			path = KYC;
 			sourceTree = "<group>";
@@ -3524,6 +3526,7 @@
 		602B9CD32118E15200BD3D60 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				AA477083211B73D1006356B1 /* BottomButtonContainerView.swift */,
 				3A3D5D8A211B44BD00E6C241 /* ProgressableView.swift */,
 				602B9CD42118E15200BD3D60 /* PrimaryButton.swift */,
 			);
@@ -6908,6 +6911,7 @@
 				C78893EF20A4D690003C0A8F /* WalletSendBitcoinDelegate.swift in Sources */,
 				AACE31C62092A99B00B7B806 /* LoadingViewPresenter.swift in Sources */,
 				AAE9113620A520D40093A431 /* WalletAccountInfoDelegate.swift in Sources */,
+				AA47709D211B7BC3006356B1 /* BottomButtonContainerView.swift in Sources */,
 				AACE31D22092A99B00B7B806 /* UINavigationController+PopToRootWithCompletion.swift in Sources */,
 				513C828720EBF30C00ECDE52 /* UIDevice+Biometrics.swift in Sources */,
 				AA63F85120A12DA6002B719B /* BitcoinURLPayload.swift in Sources */,
@@ -7189,6 +7193,7 @@
 				C71859471F3E227D00745A87 /* BCDescriptionView.m in Sources */,
 				678CD7481A2777E600748AA5 /* BCCreateAccountView.m in Sources */,
 				23F8DE531DAEB11C001899AE /* BCNavigationController.m in Sources */,
+				AA477084211B73D1006356B1 /* BottomButtonContainerView.swift in Sources */,
 				C7A0E92E1FA8FFBF004F4267 /* ExchangeConfirmViewController.m in Sources */,
 				C79261B51E8ADF0300C87CED /* BCCardView.m in Sources */,
 				ECD244F719A8B444004B1F40 /* UIImage+Utils.m in Sources */,

--- a/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
@@ -44,7 +44,6 @@ final class KYCConfirmPhoneNumberController: UIViewController, BottomButtonConta
     override func viewDidLoad() {
         super.viewDidLoad()
         // TICKET: IOS-1141 display correct % in the progress view
-        validationTextFieldConfirmationCode.keyboardType = .namePhonePad
         validationTextFieldConfirmationCode.autocapitalizationType = .allCharacters
         labelPhoneNumber.text = phoneNumber
         originalBottomButtonConstraint = layoutConstraintBottomButton.constant

--- a/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
@@ -8,12 +8,9 @@
 
 import Foundation
 
-class KYCConfirmPhoneNumberController: UIViewController {
+final class KYCConfirmPhoneNumberController: UIViewController, BottomButtonContainerView {
 
-    @IBOutlet private var nextButton: PrimaryButton!
-    @IBOutlet private var labelPhoneNumber: UILabel!
-    @IBOutlet private var textFieldConfirmationCode: UITextField!
-    @IBOutlet private var layoutConstraintBottomButton: NSLayoutConstraint!
+    // MARK: Public Properties
 
     var phoneNumber: String = "" {
         didSet {
@@ -24,14 +21,22 @@ class KYCConfirmPhoneNumberController: UIViewController {
 
     var userId: String?
 
+    // MARK: BottomButtonContainerView
+
+    var originalBottomButtonConstraint: CGFloat!
+    @IBOutlet var layoutConstraintBottomButton: NSLayoutConstraint!
+
+    // MARK: IBOutlets
+
+    @IBOutlet private var labelPhoneNumber: UILabel!
+    @IBOutlet private var validationTextFieldConfirmationCode: ValidationTextField!
+
     private lazy var presenter: KYCVerifyPhoneNumberPresenter = {
         return KYCVerifyPhoneNumberPresenter(view: self)
     }()
 
-    private var originalBottomButtonConstraint: CGFloat!
-
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        cleanUp()
     }
 
     // MARK: View Controller Lifecycle
@@ -39,19 +44,16 @@ class KYCConfirmPhoneNumberController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // TICKET: IOS-1141 display correct % in the progress view
+        validationTextFieldConfirmationCode.keyboardType = .namePhonePad
+        validationTextFieldConfirmationCode.autocapitalizationType = .allCharacters
         labelPhoneNumber.text = phoneNumber
-        nextButton.isEnabled = false
         originalBottomButtonConstraint = layoutConstraintBottomButton.constant
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        NotificationCenter.when(NSNotification.Name.UIKeyboardWillShow) {
-            self.keyboardWillShow(with: KeyboardPayload(notification: $0))
-        }
-        NotificationCenter.when(NSNotification.Name.UIKeyboardWillHide) {
-            self.keyboardWillHide(with: KeyboardPayload(notification: $0))
-        }
+        setUpBottomButtonContainerView()
+        validationTextFieldConfirmationCode.becomeFocused()
     }
 
     // MARK: IBActions
@@ -64,39 +66,20 @@ class KYCConfirmPhoneNumberController: UIViewController {
     }
 
     @IBAction func onNextTapped(_ sender: Any) {
-        guard let code = textFieldConfirmationCode.text else {
+        guard case .valid = validationTextFieldConfirmationCode.validate() else {
+            validationTextFieldConfirmationCode.becomeFocused()
+            Logger.shared.warning("text field is invalid.")
+            return
+        }
+        guard let code = validationTextFieldConfirmationCode.text else {
             Logger.shared.warning("code is nil.")
             return
         }
         guard let userId = userId else {
-            Logger.shared.warning("userIs is nil.")
+            Logger.shared.warning("userId is nil.")
             return
         }
         presenter.verify(number: phoneNumber, userId: userId, code: code)
-    }
-
-    @IBAction func onTextFieldChanged(_ sender: Any) {
-        nextButton.isEnabled = !(textFieldConfirmationCode.text?.isEmpty ?? true)
-    }
-
-    // MARK: Private
-
-    private func keyboardWillShow(with payload: KeyboardPayload) {
-        UIView.beginAnimations(nil, context: nil)
-        UIView.setAnimationDuration(payload.animationDuration)
-        UIView.setAnimationCurve(payload.animationCurve)
-        layoutConstraintBottomButton.constant = originalBottomButtonConstraint + payload.endingFrame.height
-        view.layoutIfNeeded()
-        UIView.commitAnimations()
-    }
-
-    private func keyboardWillHide(with payload: KeyboardPayload) {
-        UIView.beginAnimations(nil, context: nil)
-        UIView.setAnimationDuration(payload.animationDuration)
-        UIView.setAnimationCurve(payload.animationCurve)
-        layoutConstraintBottomButton.constant = originalBottomButtonConstraint
-        view.layoutIfNeeded()
-        UIView.commitAnimations()
     }
 }
 

--- a/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
@@ -9,20 +9,22 @@
 import PhoneNumberKit
 import UIKit
 
-final class KYCEnterPhoneNumberController: UIViewController {
+final class KYCEnterPhoneNumberController: UIViewController, BottomButtonContainerView {
 
     // MARK: Properties
 
     var userId: String?
 
+    // MARK: BottomButtonContainerView
+
+    var originalBottomButtonConstraint: CGFloat!
+    @IBOutlet var layoutConstraintBottomButton: NSLayoutConstraint!
+
     // MARK: IBOutlets
 
     @IBOutlet private var validationTextFieldMobileNumber: ValidationTextField!
-    @IBOutlet private var layoutConstraintBottomButton: NSLayoutConstraint!
 
     // MARK: Private Properties
-
-    private var originalBottomButtonConstraint: CGFloat!
 
     private lazy var presenter: KYCVerifyPhoneNumberPresenter = { [unowned self] in
         return KYCVerifyPhoneNumberPresenter(view: self)
@@ -35,7 +37,7 @@ final class KYCEnterPhoneNumberController: UIViewController {
     // MARK: UIViewController Lifecycle Methods
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        cleanUp()
     }
 
     override func viewDidLoad() {
@@ -54,12 +56,7 @@ final class KYCEnterPhoneNumberController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        NotificationCenter.when(NSNotification.Name.UIKeyboardWillShow) {
-            self.keyboardWillShow(with: KeyboardPayload(notification: $0))
-        }
-        NotificationCenter.when(NSNotification.Name.UIKeyboardWillHide) {
-            self.keyboardWillHide(with: KeyboardPayload(notification: $0))
-        }
+        setUpBottomButtonContainerView()
         validationTextFieldMobileNumber.becomeFocused()
     }
 
@@ -67,6 +64,7 @@ final class KYCEnterPhoneNumberController: UIViewController {
 
     @IBAction func primaryButtonTapped(_ sender: Any) {
         guard case .valid = validationTextFieldMobileNumber.validate() else {
+            validationTextFieldMobileNumber.becomeFocused()
             Logger.shared.warning("phone number field is invalid.")
             return
         }
@@ -89,26 +87,6 @@ final class KYCEnterPhoneNumberController: UIViewController {
         }
         confirmPhoneNumberViewController.userId = userId
         confirmPhoneNumberViewController.phoneNumber = validationTextFieldMobileNumber.text ?? ""
-    }
-
-    // MARK: - Private Methods
-
-    private func keyboardWillShow(with payload: KeyboardPayload) {
-        UIView.beginAnimations(nil, context: nil)
-        UIView.setAnimationDuration(payload.animationDuration)
-        UIView.setAnimationCurve(payload.animationCurve)
-        layoutConstraintBottomButton.constant = originalBottomButtonConstraint + payload.endingFrame.height
-        view.layoutIfNeeded()
-        UIView.commitAnimations()
-    }
-
-    private func keyboardWillHide(with payload: KeyboardPayload) {
-        UIView.beginAnimations(nil, context: nil)
-        UIView.setAnimationDuration(payload.animationDuration)
-        UIView.setAnimationCurve(payload.animationCurve)
-        layoutConstraintBottomButton.constant = originalBottomButtonConstraint
-        view.layoutIfNeeded()
-        UIView.commitAnimations()
     }
 }
 

--- a/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
@@ -85,8 +85,12 @@ final class KYCEnterPhoneNumberController: UIViewController, BottomButtonContain
         guard let confirmPhoneNumberViewController = segue.destination as? KYCConfirmPhoneNumberController else {
             return
         }
+        guard let phoneNumber = validationTextFieldMobileNumber.text else {
+            Logger.shared.warning("phone number is nil.")
+            return
+        }
         confirmPhoneNumberViewController.userId = userId
-        confirmPhoneNumberViewController.phoneNumber = validationTextFieldMobileNumber.text ?? ""
+        confirmPhoneNumberViewController.phoneNumber = phoneNumber
     }
 }
 

--- a/Blockchain/KYC/Storyboards/KYCConfirmPhoneNumber.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCConfirmPhoneNumber.storyboard
@@ -48,18 +48,24 @@
                                 <color key="textColor" red="0.30588235289999999" green="0.30588235289999999" blue="0.30588235289999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Confirmation Code" textAlignment="natural" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="XY9-D0-0ZJ">
-                                <rect key="frame" x="16" y="71.666666666666657" width="343" height="56"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eU2-Mk-gi2" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
+                                <rect key="frame" x="16" y="71" width="343" height="56"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="56" id="u3q-gM-O0w"/>
+                                    <constraint firstAttribute="height" constant="56" id="k5k-oQ-VeA"/>
                                 </constraints>
-                                <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
-                                <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="16"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue"/>
-                                <connections>
-                                    <action selector="onTextFieldChanged:" destination="gEL-b2-YEu" eventType="editingChanged" id="LPy-Pu-5Sh"/>
-                                </connections>
-                            </textField>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
+                                        <color key="value" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Confirmation Code"/>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                        <color key="value" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KYo-qh-R2k">
                                 <rect key="frame" x="134.66666666666666" y="574" width="106" height="32"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="16"/>
@@ -85,19 +91,19 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="XY9-D0-0ZJ" firstAttribute="top" secondItem="cDf-1e-GvH" secondAttribute="bottom" constant="16" id="4hP-SW-w97"/>
+                            <constraint firstItem="eU2-Mk-gi2" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" constant="16" id="3ny-n6-04w"/>
                             <constraint firstItem="IIQ-vZ-lk7" firstAttribute="trailing" secondItem="36T-B3-yyh" secondAttribute="trailing" constant="16" id="6D8-hT-1ZS"/>
                             <constraint firstItem="IIQ-vZ-lk7" firstAttribute="trailing" secondItem="wiv-Pe-rE0" secondAttribute="trailing" id="9eL-GR-wOY"/>
+                            <constraint firstItem="IIQ-vZ-lk7" firstAttribute="trailing" secondItem="eU2-Mk-gi2" secondAttribute="trailing" constant="16" id="9iF-tY-9wp"/>
                             <constraint firstItem="wiv-Pe-rE0" firstAttribute="top" secondItem="IIQ-vZ-lk7" secondAttribute="top" id="BEn-HB-WCV"/>
                             <constraint firstItem="wiv-Pe-rE0" firstAttribute="top" secondItem="IIQ-vZ-lk7" secondAttribute="top" id="CoK-xA-XIb"/>
                             <constraint firstItem="wiv-Pe-rE0" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" id="K9p-cd-ZWj"/>
+                            <constraint firstItem="eU2-Mk-gi2" firstAttribute="top" secondItem="cDf-1e-GvH" secondAttribute="bottom" constant="16" id="OLO-Gx-9ol"/>
                             <constraint firstItem="cDf-1e-GvH" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" constant="16" id="RmE-gg-2ja"/>
                             <constraint firstItem="5ml-0c-co0" firstAttribute="top" secondItem="wiv-Pe-rE0" secondAttribute="bottom" constant="16" id="bCs-MV-efH"/>
-                            <constraint firstItem="XY9-D0-0ZJ" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" constant="16" id="bMw-Ek-e8a"/>
                             <constraint firstItem="36T-B3-yyh" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" constant="16" id="cQs-wq-eL8"/>
                             <constraint firstItem="KYo-qh-R2k" firstAttribute="centerX" secondItem="IIQ-vZ-lk7" secondAttribute="centerX" id="fsr-0d-Jfv"/>
                             <constraint firstItem="5ml-0c-co0" firstAttribute="leading" secondItem="IIQ-vZ-lk7" secondAttribute="leading" constant="16" id="gbg-c0-ylX"/>
-                            <constraint firstItem="IIQ-vZ-lk7" firstAttribute="trailing" secondItem="XY9-D0-0ZJ" secondAttribute="trailing" constant="16" id="iSH-hg-xVk"/>
                             <constraint firstItem="IIQ-vZ-lk7" firstAttribute="bottom" secondItem="36T-B3-yyh" secondAttribute="bottom" constant="16" id="lHo-bY-QRU"/>
                             <constraint firstItem="36T-B3-yyh" firstAttribute="top" secondItem="KYo-qh-R2k" secondAttribute="bottom" constant="24" id="mHU-NG-Jq2"/>
                             <constraint firstItem="cDf-1e-GvH" firstAttribute="top" secondItem="5ml-0c-co0" secondAttribute="bottom" constant="2" id="q6L-9H-yLO"/>
@@ -109,8 +115,7 @@
                     <connections>
                         <outlet property="labelPhoneNumber" destination="cDf-1e-GvH" id="JN5-7b-SBR"/>
                         <outlet property="layoutConstraintBottomButton" destination="lHo-bY-QRU" id="amU-3n-8B8"/>
-                        <outlet property="nextButton" destination="36T-B3-yyh" id="SJJ-4H-hLO"/>
-                        <outlet property="textFieldConfirmationCode" destination="XY9-D0-0ZJ" id="nOc-JG-To0"/>
+                        <outlet property="validationTextFieldConfirmationCode" destination="eU2-Mk-gi2" id="y9B-YN-lFc"/>
                         <segue destination="Kem-jm-UpZ" kind="show" id="4J4-wa-RZJ"/>
                     </connections>
                 </viewController>

--- a/Blockchain/KYC/Views/BottomButtonContainerView.swift
+++ b/Blockchain/KYC/Views/BottomButtonContainerView.swift
@@ -1,0 +1,55 @@
+//
+//  BottomButtonContainerView.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/8/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol definition for a view that contains a CTA button at the bottom of it's view.
+/// Conforming to this protocol will auto-adjust the CTA button whenever the keyboard
+/// is presented/hidden.
+protocol BottomButtonContainerView {
+    var originalBottomButtonConstraint: CGFloat! { get set }
+
+    var layoutConstraintBottomButton: NSLayoutConstraint! { get }
+}
+
+extension BottomButtonContainerView where Self: UIViewController {
+
+    /// Sets up this view so that it can respond to keyboard show/hide events.
+    /// This should be called in viewDidAppear()
+    func setUpBottomButtonContainerView() {
+        NotificationCenter.when(NSNotification.Name.UIKeyboardWillShow) {
+            self.keyboardWillShow(with: KeyboardPayload(notification: $0))
+        }
+        NotificationCenter.when(NSNotification.Name.UIKeyboardWillHide) {
+            self.keyboardWillHide(with: KeyboardPayload(notification: $0))
+        }
+    }
+
+    /// Call this in deinit to remove the instance as an observer to the NotificationCenter
+    func cleanUp() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    private func keyboardWillShow(with payload: KeyboardPayload) {
+        UIView.beginAnimations(nil, context: nil)
+        UIView.setAnimationDuration(payload.animationDuration)
+        UIView.setAnimationCurve(payload.animationCurve)
+        layoutConstraintBottomButton.constant = originalBottomButtonConstraint + payload.endingFrame.height
+        view.layoutIfNeeded()
+        UIView.commitAnimations()
+    }
+
+    private func keyboardWillHide(with payload: KeyboardPayload) {
+        UIView.beginAnimations(nil, context: nil)
+        UIView.setAnimationDuration(payload.animationDuration)
+        UIView.setAnimationCurve(payload.animationCurve)
+        layoutConstraintBottomButton.constant = originalBottomButtonConstraint
+        view.layoutIfNeeded()
+        UIView.commitAnimations()
+    }
+}

--- a/Blockchain/KYC/Views/BottomButtonContainerView.swift
+++ b/Blockchain/KYC/Views/BottomButtonContainerView.swift
@@ -22,10 +22,10 @@ extension BottomButtonContainerView where Self: UIViewController {
     /// Sets up this view so that it can respond to keyboard show/hide events.
     /// This should be called in viewDidAppear()
     func setUpBottomButtonContainerView() {
-        NotificationCenter.when(NSNotification.Name.UIKeyboardWillShow) {
+        NotificationCenter.when(.UIKeyboardWillShow) {
             self.keyboardWillShow(with: KeyboardPayload(notification: $0))
         }
-        NotificationCenter.when(NSNotification.Name.UIKeyboardWillHide) {
+        NotificationCenter.when(.UIKeyboardWillHide) {
             self.keyboardWillHide(with: KeyboardPayload(notification: $0))
         }
     }

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.swift
@@ -192,7 +192,7 @@ class ValidationTextField: NibBasedView {
             }
         }
         guard withStyling == true else { return validity }
-        
+
         applyValidity(animated: true)
         return validity
     }


### PR DESCRIPTION
## Objective

Improving UX in the confirmation code view in the KYC flow.

## Description

Improving UX by:
* Using `ValidationTextField` instead of `UITextField`
* Have consistent handling of the CTA in the KYC flow (i.e. it is always enabled, however, if one of the fields are invalid, it will show an error on the `ValidationTextField` and focus)

## How to Test

Launch KYC and go through the different steps until entering your phone #. You won't be able to pass that step though since `userId` isn't passed around yet. To get around that, just replace line 100 in `KYCEnterPhoneNumberController`.

```
self.performSegue(withIdentifier: "verifyMobileNumber", sender: nil)
```

## Screenshot

![simulator screen shot - iphone 5s - 2018-08-08 at 12 13 39](https://user-images.githubusercontent.com/38220701/43859296-1d981992-9b05-11e8-8f2e-c072373ed505.png)

## Related Information

* Ticket Number:

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)