### PR TITLE
fix(PIN entry): Fix pin entry screen

### DIFF
--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -102,7 +102,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillResignActive(_ application: UIApplication) {
         Logger.shared.debug("applicationWillResignActive")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             if application.applicationState != .active {
                 self.showBlurCurtain()
             }

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -12,9 +12,23 @@ import Crashlytics
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    
+    // The view used as an intermediary privacy screen when the application state changes to inactive
+    fileprivate lazy var visualEffectView: UIVisualEffectView = self.lazyVisualEffectView()
 
+    /// Adds a privacy screen during inactive->activate state transitions
+    ///
+    /// - Returns: UIVisualEffectView added to keyWindow
+    fileprivate func lazyVisualEffectView() -> UIVisualEffectView {
+        let view = UIVisualEffectView(effect: UIBlurEffect(style: .light))
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.masksToBounds = true
+        view.frame = UIScreen.main.bounds
+        view.alpha = 0
+        return view
+    }
+    
     // MARK: - Properties
-
     // NOTE: Xcode automatically creates the file name for each launch image
     /// The overlay shown when the application resigns active state.
     lazy var privacyScreen: UIImageView? = {
@@ -88,9 +102,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillResignActive(_ application: UIApplication) {
         Logger.shared.debug("applicationWillResignActive")
-        if !AuthenticationCoordinator.shared.isPromptingForBiometricAuthentication {
-            showPrivacyScreen()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            if application.applicationState != .active {
+                self.showBlurCurtain()
+            }
         }
+     
         if let pinEntryViewController = AuthenticationCoordinator.shared.pinEntryViewController, pinEntryViewController.verifyOnly {
             pinEntryViewController.reset()
         }
@@ -140,7 +157,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if appSettings.isPinSet {
             AuthenticationCoordinator.shared.showPinEntryView()
         }
-
+        if !AuthenticationCoordinator.shared.isPromptingForBiometricAuthentication {
+            showPrivacyScreen()
+        }
         NetworkManager.shared.session.reset {
             Logger.shared.debug("URLSession reset completed.")
         }
@@ -148,6 +167,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillEnterForeground(_ application: UIApplication) {
         Logger.shared.debug("applicationWillEnterForeground")
+        hidePrivacyScreen()
 
         BlockchainSettings.App.shared.appBecameActiveCount += 1
 
@@ -163,6 +183,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
+        hideBlurCurtain()
         Logger.shared.debug("applicationDidBecomeActive")
         hidePrivacyScreen()
         UIApplication.shared.applicationIconBadgeNumber = 0
@@ -253,11 +274,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     /// Fades out the privacy overlay and removes it from its superview.
     func hidePrivacyScreen() {
-        UIView.animate(withDuration: 0.25, animations: {
+        UIView.animate(withDuration: 0.12, animations: {
             self.privacyScreen?.alpha = 0
         }, completion: { _ in
             self.privacyScreen?.removeFromSuperview()
         })
+    }
+
+    func hideBlurCurtain() {
+        UIView.animate(withDuration: 0.12, animations: {
+            self.visualEffectView.alpha = 0
+        }, completion: { _ in
+            self.visualEffectView.removeFromSuperview()
+        })
+    }
+    
+    func showBlurCurtain() {
+        UIApplication.shared.keyWindow?.addSubview(visualEffectView)
+        UIView.animate(withDuration: 0.64) {
+            self.visualEffectView.alpha = 1
+        }
     }
 
     func showPrivacyScreen() {

--- a/Third Party/PinEntry/Classes/PEViewController.m
+++ b/Third Party/PinEntry/Classes/PEViewController.m
@@ -133,6 +133,10 @@
 
 - (void)keyboardViewDidEnteredNumber:(int)num
 {
+    UIImpactFeedbackGenerator *myGen = [[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleMedium)];
+    [myGen impactOccurred];
+    myGen = NULL;
+    
 	if([self.pin length] < 4) {
 		self.pin = [NSString stringWithFormat:@"%@%d", self.pin, num];
 		[self redrawPins];


### PR DESCRIPTION
## Objective

The PIN entry screen was being called each time the app would resign being active, which meant that if control center or such was launched the user would have to re-enter their PIN.  This changes the lifecycle of the privacy screen to only be called when the app is moved to the background.  When the app is inactive, we apply a blur view and remove it when the app state becomes active again.

## Description

Updates lifecycle methods in the app delegate.

## How to Test
Video is attached.  Run the app, try launching control center and/or switching between apps and verify that the screen is blurred and unblurred when moving back to the app. Also adds haptic feedback during PIN entry.


## Screenshot
![ezgif-4-914b717d15](https://user-images.githubusercontent.com/1316251/43922259-2b8ca030-9bec-11e8-9476-4e6d721511b8.gif)
## Related Information

* Ticket Number:
iOS-554
## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)

