### PR TITLE
feat(KYC): IOS-1049 creating account status view.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -400,6 +400,8 @@
 		AA3CA9B92107F66E00C2AD46 /* ConsoleLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3CA9B72107F66E00C2AD46 /* ConsoleLogDestination.swift */; };
 		AA477084211B73D1006356B1 /* BottomButtonContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA477083211B73D1006356B1 /* BottomButtonContainerView.swift */; };
 		AA47709D211B7BC3006356B1 /* BottomButtonContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA477083211B73D1006356B1 /* BottomButtonContainerView.swift */; };
+		AA4770B7211BA984006356B1 /* KYCAccountStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4770B6211BA984006356B1 /* KYCAccountStatus.swift */; };
+		AA4770B8211BA984006356B1 /* KYCAccountStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4770B6211BA984006356B1 /* KYCAccountStatus.swift */; };
 		AA54277C20D88DD900D5FEEE /* SwipeToReceiveAddressView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AA54277B20D88DD900D5FEEE /* SwipeToReceiveAddressView.xib */; };
 		AA56423820DDBDAA0092A022 /* PinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA56421D20DDBDA90092A022 /* PinTests.swift */; };
 		AA56423B20DDBDBB0092A022 /* String+EscapeJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA56423920DDBDBB0092A022 /* String+EscapeJSTests.swift */; };
@@ -2746,6 +2748,7 @@
 		AA3CA9B42107F36700C2AD46 /* LogLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevel.swift; sourceTree = "<group>"; };
 		AA3CA9B72107F66E00C2AD46 /* ConsoleLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogDestination.swift; sourceTree = "<group>"; };
 		AA477083211B73D1006356B1 /* BottomButtonContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonContainerView.swift; sourceTree = "<group>"; };
+		AA4770B6211BA984006356B1 /* KYCAccountStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCAccountStatus.swift; sourceTree = "<group>"; };
 		AA54277B20D88DD900D5FEEE /* SwipeToReceiveAddressView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SwipeToReceiveAddressView.xib; sourceTree = "<group>"; };
 		AA56421D20DDBDA90092A022 /* PinTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinTests.swift; sourceTree = "<group>"; };
 		AA56423920DDBDBB0092A022 /* String+EscapeJSTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+EscapeJSTests.swift"; sourceTree = "<group>"; };
@@ -3452,6 +3455,7 @@
 		602B9CBA2118E15200BD3D60 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				AA4770B6211BA984006356B1 /* KYCAccountStatus.swift */,
 				602B9CBB2118E15200BD3D60 /* KYCCountry.swift */,
 			);
 			path = Models;
@@ -6857,6 +6861,7 @@
 				602B9D152118E25400BD3D60 /* LocationSuggestionCell.swift in Sources */,
 				C74FEA2620979259007CAB5D /* JSContextWithDOMTests.swift in Sources */,
 				AA2D000220D96FA300B7BE0E /* SwipeToReceiveAddressView.swift in Sources */,
+				AA4770B8211BA984006356B1 /* KYCAccountStatus.swift in Sources */,
 				AADB01EA20C09FA7000FFFEC /* WalletService.swift in Sources */,
 				AACE31C72092A99B00B7B806 /* LocalizationConstants.swift in Sources */,
 				AA7E773E210BA487009DFB4C /* Strings.swift in Sources */,
@@ -7213,6 +7218,7 @@
 				51943596208E3005001EF882 /* BlockchainAPI+URL.swift in Sources */,
 				23BF733C1C455DDB00204503 /* AccountsAndAddressesViewController.m in Sources */,
 				AA94965E20CB5FA600A9C2DD /* AssetAddressFactory.swift in Sources */,
+				AA4770B7211BA984006356B1 /* KYCAccountStatus.swift in Sources */,
 				AACE31222091004A00B7B806 /* UIApplication+Suspend.m in Sources */,
 				AAFA97B6211511D000D19ED3 /* Settings+Table.swift in Sources */,
 				602B9CED2118E15300BD3D60 /* LocationSuggestionService.swift in Sources */,

--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -55,6 +55,7 @@ struct Constants {
         static let montserratRegular = "Montserrat-Regular"
         static let montserratSemiBold = "Montserrat-SemiBold"
         static let montserratLight = "Montserrat-Light"
+        static let montserratMedium = "Montserrat-Medium"
         static let montserratSemiExtraLight = "Montserrat-ExtraLight"
         static let gillSans = "GillSans"
         static let gillSansLight = "GillSans-Light"

--- a/Blockchain/Extensions/URLs.swift
+++ b/Blockchain/Extensions/URLs.swift
@@ -19,6 +19,11 @@ extension URL {
         return query.queryArgs
     }
 
+    /// Attempts to launch this URL
+    func launch() {
+        UIApplication.shared.open(self, options: [:])
+    }
+
     public static func endpoint(_ baseURL: URL, pathComponents: [String]?, queryParameters:[String: String]?) -> URL? {
         guard var mutableBaseURL: URL = (baseURL as NSURL).copy() as? URL else { return nil }
 

--- a/Blockchain/KYC/KYCAccountStatusController.swift
+++ b/Blockchain/KYC/KYCAccountStatusController.swift
@@ -14,12 +14,10 @@ struct KYCAccountStatusViewConfig {
 }
 
 extension KYCAccountStatusViewConfig {
-    static func defaultConfig() -> KYCAccountStatusViewConfig {
-        return KYCAccountStatusViewConfig(
-            titleColor: UIColor.gray5,
-            isPrimaryButtonEnabled: false
-        )
-    }
+    static let defaultConfig: KYCAccountStatusViewConfig = KYCAccountStatusViewConfig(
+        titleColor: UIColor.gray5,
+        isPrimaryButtonEnabled: false
+    )
 
     static func create(for accountStatus: KYCAccountStatus) -> KYCAccountStatusViewConfig {
         let titleColor: UIColor
@@ -69,7 +67,7 @@ final class KYCAccountStatusController: UIViewController {
     }
 
     /// The view configuration for this view
-    var viewConfig: KYCAccountStatusViewConfig = KYCAccountStatusViewConfig.defaultConfig()
+    var viewConfig: KYCAccountStatusViewConfig = KYCAccountStatusViewConfig.defaultConfig
 
     // MARK: - Lifecycle Methods
 

--- a/Blockchain/KYC/KYCAccountStatusController.swift
+++ b/Blockchain/KYC/KYCAccountStatusController.swift
@@ -8,72 +8,90 @@
 
 import UIKit
 
+struct KYCAccountStatusViewConfig {
+    let titleColor: UIColor
+    let isPrimaryButtonEnabled: Bool
+}
+
+extension KYCAccountStatusViewConfig {
+    static func defaultConfig() -> KYCAccountStatusViewConfig {
+        return KYCAccountStatusViewConfig(
+            titleColor: UIColor.gray5,
+            isPrimaryButtonEnabled: false
+        )
+    }
+
+    static func create(for accountStatus: KYCAccountStatus) -> KYCAccountStatusViewConfig {
+        let titleColor: UIColor
+        let isPrimaryButtonEnabled: Bool
+        switch accountStatus {
+        case .approved:
+            titleColor = UIColor.green
+            isPrimaryButtonEnabled = true
+        case .failed:
+            titleColor = UIColor.error
+            isPrimaryButtonEnabled = true
+        case .inProgress:
+            titleColor = UIColor.orange
+            isPrimaryButtonEnabled = !UIApplication.shared.isRegisteredForRemoteNotifications
+        case .underReview:
+            titleColor = UIColor.orange
+            isPrimaryButtonEnabled = false
+        }
+        return KYCAccountStatusViewConfig(
+            titleColor: titleColor,
+            isPrimaryButtonEnabled: isPrimaryButtonEnabled
+        )
+    }
+}
+
 final class KYCAccountStatusController: UIViewController {
+
+    /// typealias for an action to be taken when the primary button/CTA is tapped
+    typealias PrimaryButtonAction = ((KYCAccountStatusController) -> Void)
 
     // MARK: - Properties
 
-    enum AccountStatus {
-        case approved, failed, inReview
-        /// Graphic which visually represents the account status
-        var image: UIImage {
-            switch self {
-            case .approved: return UIImage(named: "AccountApproved")!
-            case .failed:   return UIImage(named: "AccountFailed")!
-            case .inReview: return UIImage(named: "AccountInReview")!
-            }
-        }
-        /// Title which represents the account status
-        var title: String {
-            switch self {
-            case .approved: return "Account Approved!"
-            case .failed:   return "Verification Failed"
-            case .inReview: return "Account In Review"
-            }
-        }
-        /// Description of the account status
-        var description: String {
-            switch self {
-            case .approved: return "Congratulations! We verified your identity and you can now buy, sell, and exchange."
-            case .failed:   return """
-                We had some trouble verifying your account with the documents provided.
-                Our support team will contact you shortly to help you with this issue.
-                """
-            case .inReview: return "Great job - you are now done. Your account should be approved in minutes."
-            }
-        }
-        /// Title of the primary button
-        var primaryButtonTitle: String? {
-            switch self {
-            case .approved: return "Get Started"
-            case .failed:   return nil
-            case .inReview: return "Notify Me"
-            }
-        }
-    }
+    @IBOutlet private var imageView: UIImageView!
+    @IBOutlet private var labelTitle: UILabel!
+    @IBOutlet private var labelSubtitle: UILabel!
+    @IBOutlet private var labelDescription: UILabel!
+    @IBOutlet private var buttonPrimary: PrimaryButton!
+
+    /// Action invoked when the primary button is tapped
+    var primaryButtonAction: PrimaryButtonAction?
 
     /// Describes the status of the user's account
-    var accountStatus: AccountStatus = .failed {
+    var accountStatus: KYCAccountStatus = .failed {
         didSet {
-            setUpInterfaceFor(accountStatus)
+            viewConfig = KYCAccountStatusViewConfig.create(for: accountStatus)
         }
     }
 
-    // MARK: - Private Methods
+    /// The view configuration for this view
+    var viewConfig: KYCAccountStatusViewConfig = KYCAccountStatusViewConfig.defaultConfig()
 
-    private func setUpInterfaceFor(_ accountStatus: AccountStatus) {
+    // MARK: - Lifecycle Methods
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        imageView.image = accountStatus.image
+        labelTitle.text = accountStatus.title
+        if let subtitle = accountStatus.subtitle {
+            labelSubtitle.text = subtitle
+        } else {
+            labelSubtitle.superview?.removeFromSuperview()
+        }
+        labelDescription.text = accountStatus.description
+        buttonPrimary.setTitle(accountStatus.primaryButtonTitle, for: .normal)
+
+        labelTitle.textColor = viewConfig.titleColor
+        buttonPrimary.isHidden = !viewConfig.isPrimaryButtonEnabled
     }
 
     // MARK: - Actions
 
     @IBAction func primaryButtonTapped(_ sender: Any) {
-        // TODO: implement primaryButtonTapped
-    }
-
-    // MARK: - Navigation
-
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destinationViewController.
-        // Pass the selected object to the new view controller.
+        primaryButtonAction?(self)
     }
 }

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+/// Coordinates the KYC flow. This component can be used to start a new KYC flow, or if
+/// the user drops off mid-KYC and decides to continue through it again, the coordinator
+/// will handle recovering where they left off.
 @objc class KYCCoordinator: NSObject, Coordinator {
 
     func start() {
@@ -19,15 +22,56 @@ import Foundation
     }
 
     @objc func start(from viewController: UIViewController) {
-        let navigationController = UIStoryboard(name: "KYCOnboardingNavigation", bundle: nil)
-            .instantiateViewController(withIdentifier: "OnboardingNavigation") as! KYCOnboardingNavigationController
+        guard let welcomeViewController = UIStoryboard(
+            name: "KYCWelcome",
+            bundle: Bundle.main
+        ).instantiateInitialViewController() as? KYCWelcomeController else {
+            Logger.shared.warning("Could not instantiated KYCWelcomeController")
+            return
+        }
+        presentInNavigationController(welcomeViewController, in: viewController)
+    }
 
-        let welcomeViewController = UIStoryboard(name: "KYCWelcome", bundle: nil)
-            .instantiateViewController(withIdentifier: "KYCWelcomeController") as! KYCWelcomeController
+    func presentAccountStatusView(for status: KYCAccountStatus, in viewController: UIViewController) {
+        guard let accountStatusViewController = UIStoryboard(
+            name: "KYCAccountStatus",
+            bundle: Bundle.main
+        ).instantiateInitialViewController() as? KYCAccountStatusController else {
+            Logger.shared.warning("Could not instantiated KYCAccountStatusController")
+            return
+        }
+        accountStatusViewController.accountStatus = status
+        accountStatusViewController.primaryButtonAction = { viewController in
+            switch viewController.accountStatus {
+            case .approved:
+                viewController.dismiss(animated: true) {
+                    ExchangeCoordinator.shared.start()
+                }
+            case .inProgress:
+                PushNotificationManager.shared.requestAuthorization()
+            case .failed:
+                // Confirm with design that this is how we should handle this
+                guard let url = URL(string: Constants.Url.blockchainSupport) else { return }
+                UIApplication.shared.open(url)
+            default:
+                return
+            }
+        }
+        presentInNavigationController(accountStatusViewController, in: viewController)
+    }
 
-        navigationController.pushViewController(welcomeViewController, animated: true)
+    // MARK: Private Methods
+
+    private func presentInNavigationController(_ viewController: UIViewController, in presentingViewController: UIViewController) {
+        guard let navigationController = UIStoryboard(
+            name: "KYCOnboardingNavigation",
+            bundle: Bundle.main
+        ).instantiateInitialViewController() as? KYCOnboardingNavigationController else {
+            Logger.shared.warning("Could not instantiated KYCOnboardingNavigationController")
+            return
+        }
+        navigationController.pushViewController(viewController, animated: false)
         navigationController.modalTransitionStyle = .coverVertical
-
-        viewController.present(navigationController, animated: true)
+        presentingViewController.present(navigationController, animated: true)
     }
 }

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -51,8 +51,7 @@ import Foundation
                 PushNotificationManager.shared.requestAuthorization()
             case .failed:
                 // Confirm with design that this is how we should handle this
-                guard let url = URL(string: Constants.Url.blockchainSupport) else { return }
-                UIApplication.shared.open(url)
+                URL(string: Constants.Url.blockchainSupport)?.launch()
             default:
                 return
             }

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -52,7 +52,7 @@ import Foundation
             case .failed:
                 // Confirm with design that this is how we should handle this
                 URL(string: Constants.Url.blockchainSupport)?.launch()
-            default:
+            case .underReview:
                 return
             }
         }

--- a/Blockchain/KYC/Models/KYCAccountStatus.swift
+++ b/Blockchain/KYC/Models/KYCAccountStatus.swift
@@ -1,0 +1,61 @@
+//
+//  KYCAccountStatus.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/8/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+enum KYCAccountStatus: Int {
+    case approved, failed, underReview, inProgress
+
+    /// Graphic which visually represents the account status
+    var image: UIImage? {
+        switch self {
+        case .approved: return UIImage(named: "AccountApproved")
+        case .failed:   return UIImage(named: "AccountFailed")
+        case .underReview: return UIImage(named: "AccountInReview")
+        case .inProgress: return UIImage(named: "AccountInReview")
+        }
+    }
+
+    /// Title which represents the account status
+    var title: String {
+        switch self {
+        case .approved: return LocalizationConstants.KYC.accountApproved
+        case .failed:   return LocalizationConstants.KYC.verificationFailed
+        case .underReview: return LocalizationConstants.KYC.verificationUnderReview
+        case .inProgress: return LocalizationConstants.KYC.verificationInProgress
+        }
+    }
+
+    /// Subtitle for the account status
+    var subtitle: String? {
+        switch self {
+        case .inProgress: return LocalizationConstants.KYC.whatHappensNext
+        default: return nil
+        }
+    }
+
+    /// Description of the account status
+    var description: String {
+        switch self {
+        case .approved: return LocalizationConstants.KYC.accountApprovedDescription
+        case .failed:   return LocalizationConstants.KYC.verificationFailedDescription
+        case .underReview: return LocalizationConstants.KYC.verificationUnderReviewDescription
+        case .inProgress: return LocalizationConstants.KYC.verificationInProgressDescription
+        }
+    }
+
+    /// Title of the primary button.
+    var primaryButtonTitle: String? {
+        switch self {
+        case .approved: return LocalizationConstants.KYC.getStarted
+        case .failed:   return LocalizationConstants.KYC.contactSupport
+        case .underReview: return nil
+        case .inProgress: return LocalizationConstants.KYC.notifyMe
+        }
+    }
+}

--- a/Blockchain/KYC/Models/KYCAccountStatus.swift
+++ b/Blockchain/KYC/Models/KYCAccountStatus.swift
@@ -12,12 +12,12 @@ enum KYCAccountStatus: Int {
     case approved, failed, underReview, inProgress
 
     /// Graphic which visually represents the account status
-    var image: UIImage? {
+    var image: UIImage {
         switch self {
-        case .approved: return UIImage(named: "AccountApproved")
-        case .failed:   return UIImage(named: "AccountFailed")
-        case .underReview: return UIImage(named: "AccountInReview")
-        case .inProgress: return UIImage(named: "AccountInReview")
+        case .approved: return #imageLiteral(resourceName: "AccountApproved")
+        case .failed:   return #imageLiteral(resourceName: "AccountFailed")
+        case .underReview: return #imageLiteral(resourceName: "AccountInReview")
+        case .inProgress: return #imageLiteral(resourceName: "AccountInReview")
         }
     }
 

--- a/Blockchain/KYC/Storyboards/KYCAccountStatus.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCAccountStatus.storyboard
@@ -1,33 +1,154 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina5_9" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="uMm-1o-bGV">
+    <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="Montserrat-Medium.ttf">
+            <string>Montserrat-Medium</string>
+        </array>
+        <array key="Montserrat-Regular.ttf">
+            <string>Montserrat-Regular</string>
+        </array>
+        <array key="Montserrat-SemiBold.ttf">
+            <string>Montserrat-SemiBold</string>
+        </array>
+    </customFonts>
     <scenes>
-        <!--Exchange-->
+        <!--Account Status View Controller-->
         <scene sceneID="e4w-8P-Gec">
             <objects>
-                <viewController id="uMm-1o-bGV" customClass="KYCAccountStatusController" customModule="Blockchain" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="Account Status View Controller" id="uMm-1o-bGV" customClass="KYCAccountStatusController" customModule="Blockchain" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="udR-Wr-SpO">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="724"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="okp-Sf-YF7">
+                                <rect key="frame" x="0.0" y="123" width="375" height="293"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1cf-8E-ugK">
+                                        <rect key="frame" x="120.5" y="0.0" width="134" height="134"/>
+                                        <subviews>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="AccountApproved" translatesAutoresizingMaskIntoConstraints="NO" id="Kbm-ay-Ji2">
+                                                <rect key="frame" x="0.0" y="0.0" width="134" height="110"/>
+                                            </imageView>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="Kbm-ay-Ji2" secondAttribute="bottom" constant="24" id="7pn-Y1-gXZ"/>
+                                            <constraint firstAttribute="height" constant="134" id="Jdd-1y-fYl"/>
+                                            <constraint firstAttribute="trailing" secondItem="Kbm-ay-Ji2" secondAttribute="trailing" id="NAH-gP-bOE"/>
+                                            <constraint firstItem="Kbm-ay-Ji2" firstAttribute="top" secondItem="1cf-8E-ugK" secondAttribute="top" id="Toa-wt-PuJ"/>
+                                            <constraint firstItem="Kbm-ay-Ji2" firstAttribute="leading" secondItem="1cf-8E-ugK" secondAttribute="leading" id="rtn-Cr-Xsg"/>
+                                            <constraint firstAttribute="width" secondItem="1cf-8E-ugK" secondAttribute="height" multiplier="1:1" id="sR6-XD-st3"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gxK-9R-lKT">
+                                        <rect key="frame" x="0.0" y="134" width="375" height="50"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Account Pending" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EDd-mu-FSN">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="26"/>
+                                                <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="18"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="EDd-mu-FSN" secondAttribute="bottom" constant="24" id="WeY-nt-WFW"/>
+                                            <constraint firstItem="EDd-mu-FSN" firstAttribute="leading" secondItem="gxK-9R-lKT" secondAttribute="leading" id="feE-1B-rTs"/>
+                                            <constraint firstItem="EDd-mu-FSN" firstAttribute="top" secondItem="gxK-9R-lKT" secondAttribute="top" id="mR5-eZ-N53"/>
+                                            <constraint firstAttribute="trailing" secondItem="EDd-mu-FSN" secondAttribute="trailing" id="xx7-Ve-RdC"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9EL-4t-eLH">
+                                        <rect key="frame" x="0.0" y="184" width="375" height="50"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What happens next?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="esv-ja-LNX">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
+                                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="esv-ja-LNX" firstAttribute="top" secondItem="9EL-4t-eLH" secondAttribute="top" id="AC6-c6-xnu"/>
+                                            <constraint firstAttribute="bottom" secondItem="esv-ja-LNX" secondAttribute="bottom" constant="6" id="PZb-2P-BlH"/>
+                                            <constraint firstAttribute="trailing" secondItem="esv-ja-LNX" secondAttribute="trailing" id="QnP-De-NK4"/>
+                                            <constraint firstItem="esv-ja-LNX" firstAttribute="leading" secondItem="9EL-4t-eLH" secondAttribute="leading" id="bvB-4c-Y3k"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your information is being reviewed. When all looks good, you're clear to Buy, Sell and Transfer on the Exchange." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumFontSize="12" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rfj-zv-olj">
+                                        <rect key="frame" x="16" y="234" width="343" height="59"/>
+                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="16"/>
+                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="rfj-zv-olj" secondAttribute="trailing" constant="16" id="0X8-B9-69z"/>
+                                    <constraint firstItem="rfj-zv-olj" firstAttribute="top" secondItem="9EL-4t-eLH" secondAttribute="bottom" id="EoE-YZ-9x2"/>
+                                    <constraint firstAttribute="bottom" secondItem="rfj-zv-olj" secondAttribute="bottom" id="Q8j-0Y-1Zr"/>
+                                    <constraint firstItem="9EL-4t-eLH" firstAttribute="top" secondItem="gxK-9R-lKT" secondAttribute="bottom" id="TrH-3F-mYk"/>
+                                    <constraint firstItem="rfj-zv-olj" firstAttribute="leading" secondItem="okp-Sf-YF7" secondAttribute="leading" constant="16" id="ba6-MN-Guq"/>
+                                    <constraint firstAttribute="trailing" secondItem="gxK-9R-lKT" secondAttribute="trailing" id="lCQ-NR-C0N"/>
+                                    <constraint firstItem="gxK-9R-lKT" firstAttribute="leading" secondItem="okp-Sf-YF7" secondAttribute="leading" id="mAt-tB-ReP"/>
+                                    <constraint firstItem="9EL-4t-eLH" firstAttribute="leading" secondItem="okp-Sf-YF7" secondAttribute="leading" id="mky-sH-0Rs"/>
+                                    <constraint firstAttribute="trailing" secondItem="9EL-4t-eLH" secondAttribute="trailing" id="t7a-WC-onD"/>
+                                    <constraint firstItem="gxK-9R-lKT" firstAttribute="top" secondItem="1cf-8E-ugK" secondAttribute="bottom" id="wWo-or-kpe"/>
+                                </constraints>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5rk-Y8-Nij" customClass="PrimaryButton" customModule="Blockchain" customModuleProvider="target">
+                                <rect key="frame" x="16" y="543" width="343" height="44"/>
+                                <color key="backgroundColor" red="0.29803921568627451" green="0.6705882352941176" blue="0.87450980392156863" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="5su-re-LrJ"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="20"/>
+                                <state key="normal" title="Hello"/>
+                                <connections>
+                                    <action selector="primaryButtonTapped:" destination="uMm-1o-bGV" eventType="touchUpInside" id="rgh-3G-4jt"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="okp-Sf-YF7" secondAttribute="trailing" id="1ZZ-xn-qZp"/>
+                            <constraint firstItem="VtZ-bg-pfR" firstAttribute="bottom" secondItem="5rk-Y8-Nij" secondAttribute="bottom" constant="16" id="AeG-Zs-Kb3"/>
+                            <constraint firstItem="5rk-Y8-Nij" firstAttribute="leading" secondItem="VtZ-bg-pfR" secondAttribute="leading" constant="16" id="CPS-Ce-7rn"/>
+                            <constraint firstItem="5rk-Y8-Nij" firstAttribute="top" relation="greaterThanOrEqual" secondItem="okp-Sf-YF7" secondAttribute="bottom" constant="16" id="OJ2-EY-FgZ"/>
+                            <constraint firstItem="VtZ-bg-pfR" firstAttribute="trailing" secondItem="5rk-Y8-Nij" secondAttribute="trailing" constant="16" id="Yza-7n-QyD"/>
+                            <constraint firstItem="okp-Sf-YF7" firstAttribute="centerY" secondItem="VtZ-bg-pfR" secondAttribute="centerY" constant="-32" id="q1a-PW-imt"/>
+                            <constraint firstItem="okp-Sf-YF7" firstAttribute="leading" secondItem="VtZ-bg-pfR" secondAttribute="leading" id="rU6-oe-CzS"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="VtZ-bg-pfR"/>
                     </view>
                     <navigationItem key="navigationItem" title="Exchange" id="8I1-K6-NnG">
                         <barButtonItem key="backBarButtonItem" id="Vba-S8-Hwv"/>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
+                    <connections>
+                        <outlet property="buttonPrimary" destination="5rk-Y8-Nij" id="yW8-iZ-ac4"/>
+                        <outlet property="imageView" destination="Kbm-ay-Ji2" id="K04-41-urf"/>
+                        <outlet property="labelDescription" destination="rfj-zv-olj" id="uyX-uh-hMb"/>
+                        <outlet property="labelSubtitle" destination="esv-ja-LNX" id="ih4-rb-5jA"/>
+                        <outlet property="labelTitle" destination="EDd-mu-FSN" id="DnF-tf-ity"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Iwg-8p-e55" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="529" y="-116"/>
+            <point key="canvasLocation" x="528.79999999999995" y="-116.49175412293854"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="AccountApproved" width="130" height="130"/>
+    </resources>
 </document>

--- a/Blockchain/KYC/Storyboards/KYCWelcome.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCWelcome.storyboard
@@ -24,7 +24,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UOA-vy-LXW" userLabel="Content Container View">
-                                <rect key="frame" x="0.0" y="189.99999999999997" width="375" height="310.33333333333326"/>
+                                <rect key="frame" x="0.0" y="190.33333333333334" width="375" height="310.33333333333326"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Welcome" translatesAutoresizingMaskIntoConstraints="NO" id="sgf-OY-RMl">
                                         <rect key="frame" x="52.666666666666657" y="0.0" width="270" height="136"/>
@@ -51,7 +51,7 @@ identity verification to start buying and selling cryptocurrencies. This will on
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dv9-ck-b0t" customClass="PrimaryButton" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="24" y="259.33333333333337" width="327" height="44"/>
+                                        <rect key="frame" x="24" y="259.33333333333331" width="327" height="44"/>
                                         <color key="backgroundColor" red="0.062745098040000002" green="0.67843137249999996" blue="0.89411764709999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="pw6-gR-4vR"/>

--- a/Blockchain/KYC/Views/PrimaryButton.swift
+++ b/Blockchain/KYC/Views/PrimaryButton.swift
@@ -20,6 +20,8 @@ public class PrimaryButton: UIButton {
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         layer.cornerRadius = 4.0
+        titleLabel?.font = UIFont(name: Constants.FontNames.montserratMedium, size: 20.0)
+        backgroundColor = UIColor.brandSecondary
     }
 
     override public func setTitle(_ title: String?, for state: UIControlState) {

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -431,6 +431,54 @@ struct LocalizationConstants {
             "By tapping on \"Apply Now\", you agree to Blockchain's %@ & %@",
             comment: "Text displayed to the user notifying them that they implicitly agree to Blockchain's terms of service and privacy policy when they start the KYC process."
         )
+        static let verificationInProgress = NSLocalizedString(
+            "Verification in Progress",
+            comment: "Text displayed when KYC verification is in progress."
+        )
+        static let verificationInProgressDescription = NSLocalizedString(
+            "Your information is being reviewed. When all looks good, you're clear to Buy, Sell and Transfer on the Exchange.",
+            comment: "Description for when KYC verification is in progress."
+        )
+        static let accountApproved = NSLocalizedString(
+            "Account Approved",
+            comment: "Text displayed when KYC verification is approved."
+        )
+        static let accountApprovedDescription = NSLocalizedString(
+            "Congratulations! We successfully verified your identity. You can now Exchange cryptocurrencies at Blockchain.",
+            comment: "Description for when KYC verification is approved."
+        )
+        static let verificationFailed = NSLocalizedString(
+            "Verification Failed",
+            comment: "Text displayed when KYC verification failed."
+        )
+        static let verificationFailedDescription = NSLocalizedString(
+            "Unfortunately we had some trouble verifying your identity with the documents you've supplied.",
+            comment: "Description for when KYC verification failed."
+        )
+        static let verificationUnderReview = NSLocalizedString(
+            "Verification Under Review",
+            comment: "Text displayed when KYC verification is under review."
+        )
+        static let verificationUnderReviewDescription = NSLocalizedString(
+            "We had some trouble verifying your account with the documents provided. Our support team will contact you shortly to resolve this.",
+            comment: "Description for when KYC verification is under review."
+        )
+        static let notifyMe = NSLocalizedString(
+            "Notify Me",
+            comment: "Title of the button the user can tap when they want to be notified of update with their KYC verification process."
+        )
+        static let getStarted = NSLocalizedString(
+            "Get Started",
+            comment: "Title of the button the user can tap when they want to start trading on the Exchange. This is displayed after their KYC verification has been approved."
+        )
+        static let contactSupport = NSLocalizedString(
+            "Contact Support",
+            comment: "Title of the button the user can tap when they want to contact support as a result of a failed KYC verification."
+        )
+        static let whatHappensNext = NSLocalizedString(
+            "What happens next?",
+            comment: "Text displayed (subtitle) when KYC verification is under progress"
+        )
     }
 }
 


### PR DESCRIPTION
## Objective

Implementing the KYC account status view

## Description

Implemented different states for the KYC account status view. There is a function in KYCCoordinator that will handle the presentation of this view. It's currently not called anywhere but should be glued in the flow eventually (should be displayed when tapping on the item in the settings view).

## How to Test

Invoked `KYCCoordinator#presentAccountStatusView()` and test different account statuses.

## Screenshot

![simulator screen shot - iphone 5s - 2018-08-09 at 15 31 34](https://user-images.githubusercontent.com/38220701/43929570-7159bcee-9bea-11e8-8b9b-e9aa3f9603b0.png)
![simulator screen shot - iphone 5s - 2018-08-09 at 15 31 15](https://user-images.githubusercontent.com/38220701/43929573-72d71bfc-9bea-11e8-93ef-88a0644f9e6a.png)
![simulator screen shot - iphone 5s - 2018-08-09 at 15 31 08](https://user-images.githubusercontent.com/38220701/43929574-72ec1b24-9bea-11e8-9585-dce3794b5c3c.png)
![simulator screen shot - iphone 5s - 2018-08-09 at 15 30 59](https://user-images.githubusercontent.com/38220701/43929575-749ac7cc-9bea-11e8-82d2-02cfad5a6692.png)

## Related Information

* Ticket Number: IOS-1049

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
