### PR TITLE
fix(URL): move retail core URL to .xcconfig.

### DIFF
--- a/Blockchain/Blockchain-Info.plist
+++ b/Blockchain/Blockchain-Info.plist
@@ -90,8 +90,8 @@
 	<false/>
 	<key>WALLET_SERVER</key>
 	<string>$(WALLET_SERVER)</string>
-	<key>KYC_ENDPOINT</key>
-	<string>$(KYC_ENDPOINT)</string>
+	<key>RETAIL_CORE_URL</key>
+	<string>$(RETAIL_CORE_URL)</string>
 	<key>WEBSOCKET_SERVER</key>
 	<string>$(WEBSOCKET_SERVER)</string>
 	<key>WEBSOCKET_SERVER_BCH</key>

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -14,14 +14,6 @@ final class KYCNetworkRequest {
     typealias TaskSuccess = (Data) -> Void
     typealias TaskFailure = (HTTPRequestError) -> Void
 
-    /*
-     let kycUrl = BlockchainAPI.shared.kycCredentials
-     guard let url = URL(string: kycUrl) else {
-     fatalError("Failed to get kyc url from Bundle.")
-     }
-     */
-    // TODO: read from .xcconfig
-    fileprivate static let rootUrl = "https://api.dev.blockchain.info/nabu-app"
     private let timeoutInterval = TimeInterval(exactly: 30)!
     private var request: URLRequest
 
@@ -76,7 +68,7 @@ final class KYCNetworkRequest {
         taskSuccess: @escaping TaskSuccess,
         taskFailure: @escaping TaskFailure
     ) {
-        self.init(url: URL(string: KYCNetworkRequest.rootUrl + url.rawValue)!, httpMethod: "GET")
+        self.init(url: URL(string: BlockchainAPI.shared.retailCoreUrl + url.rawValue)!, httpMethod: "GET")
         send(taskSuccess: taskSuccess, taskFailure: taskFailure)
     }
 
@@ -87,7 +79,7 @@ final class KYCNetworkRequest {
         taskSuccess: @escaping TaskSuccess,
         taskFailure: @escaping TaskFailure
     ) {
-        self.init(url: URL(string: KYCNetworkRequest.rootUrl + url.rawValue)!, httpMethod: "POST")
+        self.init(url: URL(string: BlockchainAPI.shared.retailCoreUrl + url.rawValue)!, httpMethod: "POST")
         let postBody = parameters.reduce("", { initialResult, nextPartialResult in
             let delimeter = initialResult.count > 0 ? "&" : ""
             return "\(initialResult)\(delimeter)\(nextPartialResult.key)=\(nextPartialResult.value)"
@@ -106,7 +98,7 @@ final class KYCNetworkRequest {
         taskSuccess: @escaping TaskSuccess,
         taskFailure: @escaping TaskFailure
     ) {
-        self.init(url: URL(string: KYCNetworkRequest.rootUrl + url.path)!, httpMethod: "PUT")
+        self.init(url: URL(string: BlockchainAPI.shared.retailCoreUrl + url.path)!, httpMethod: "PUT")
         do {
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .formatted(DateFormatter.birthday)

--- a/Blockchain/Network/Extensions/BlockchainAPI+URL.swift
+++ b/Blockchain/Network/Extensions/BlockchainAPI+URL.swift
@@ -20,8 +20,8 @@ extension BlockchainAPI {
         return "https://\(host)"
     }
     
-    var kycCredentials: String {
-        let host = Bundle.main.infoDictionary!["KYC_ENDPOINT"] as! String
+    var retailCoreUrl: String {
+        let host = Bundle.main.infoDictionary!["RETAIL_CORE_URL"] as! String
         return "https://\(host)"
     }
 
@@ -60,7 +60,7 @@ extension BlockchainAPI {
 
     enum Nabu {
         static var quotes: String {
-            return BlockchainAPI.shared.apiUrl + "/nabu-app/markets/quotes"
+            return BlockchainAPI.shared.retailCoreUrl + "/markets/quotes"
         }
     }
 }


### PR DESCRIPTION
## Objective

Moving the retail core URL to .xcconfig

## Description

All *.xcconfig files need to have `RETAIL_CORE_URL` defined.

## How to Test

Populate the value of `RETAIL_CORE_URL` in your *.xcconfig files and verify that the KYC flow works (probably can't really verify this yet since a lot of the endpoints don't work). 

## Screenshot

N/A

## Related Information

* Ticket Number:

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
