### PR TITLE
fix(NetworkManager): IOS-1147 only whitelist partners

### DIFF
--- a/Blockchain/LocalizationConstants.h
+++ b/Blockchain/LocalizationConstants.h
@@ -124,10 +124,6 @@
 #define BC_STRING_OPEN_MAIL_APP NSLocalizedString(@"Open Mail App", nil)
 #define BC_STRING_CANNOT_OPEN_MAIL_APP NSLocalizedString(@"Cannot open Mail App", nil)
 
-#define BC_STRING_FAILED_VALIDATION_CERTIFICATE_TITLE NSLocalizedString(@"Failed to validate server certificate", nil)
-#define BC_STRING_FAILED_VALIDATION_CERTIFICATE_MESSAGE NSLocalizedString(@"A connection cannot be established because the server certificate could not be validated. Please check your network settings and ensure that you are using a secure connection.", nil)
-#define BC_STRING_FAILED_VALIDATION_CERTIFICATE_MESSAGE_CONTACT_SUPPORT_ARGUMENT NSLocalizedString(@"Please contact support:\n%@", nil)
-
 //#define BC_STRING_REQUEST_FAILED_PLEASE_CHECK_INTERNET_CONNECTION NSLocalizedString(@"Request failed. Please check your internet connection.", nil)
 #define BC_STRING_SOMETHING_WENT_WRONG_CHECK_INTERNET_CONNECTION NSLocalizedString(@"An error occurred while updating your spendable balance. Please check your internet connection and try again.", nil)
 #define BC_STRING_EMPTY_RESPONSE NSLocalizedString(@"Empty response from server.", nil)

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -84,6 +84,11 @@ struct LocalizationConstants {
         static let inputError = NSLocalizedString("There was an error with the device input.", comment: "AVCaptureDeviceError: inputError")
         static let noEmail = NSLocalizedString("Please provide an email address.", comment: "")
         static let differentEmail = NSLocalizedString("New email must be different", comment: "")
+        static let failedToValidateCertificateTitle = NSLocalizedString("Failed to validate server certificate", comment: "Message shown when the app has detected a possible man-in-the-middle attack.")
+        static let failedToValidateCertificateMessage = NSLocalizedString(
+            """
+            A connection cannot be established because the server certificate could not be validated. Please check your network settings and ensure that you are using a secure connection.
+            """, comment: "Message shown when the app has detected a possible man-in-the-middle attack.")
     }
 
     struct Authentication {

--- a/Blockchain/Network/CertificatePinner.swift
+++ b/Blockchain/Network/CertificatePinner.swift
@@ -111,8 +111,14 @@ final class CertificatePinner: NSObject {
         }
     }
 
-    // TODO: implement when required changes are merged into `swift` branch.
     func didFailToValidate() {
-
+        let action = UIAlertAction(title: LocalizationConstants.okString, style: .cancel) { _ in
+            UIApplication.shared.suspendApp()
+        }
+        AlertViewPresenter.shared.standardNotify(
+            message: LocalizationConstants.Errors.failedToValidateCertificateMessage,
+            title: LocalizationConstants.Errors.failedToValidateCertificateTitle,
+            actions: [action]
+        )
     }
 }

--- a/Blockchain/Network/NetworkManager.swift
+++ b/Blockchain/Network/NetworkManager.swift
@@ -105,8 +105,7 @@ class NetworkManager: NSObject, URLSessionDelegate {
         let host = challenge.protectionSpace.host
         Logger.shared.info("Received challenge from \(host)")
 
-        if BlockchainAPI.Hosts.rawValues.contains(host) ||
-            BlockchainAPI.PartnerHosts.rawValues.contains(host) {
+        if BlockchainAPI.PartnerHosts.rawValues.contains(host) {
             completionHandler(.performDefaultHandling, nil)
         } else {
             CertificatePinner.shared.didReceive(challenge, completion: completionHandler)


### PR DESCRIPTION
## Objective

- Remove whitelisting of our own servers so that public key pinning can be performed
- Add back alert showing that a secure connection cannot be made

## Description

- Removed whitelisting of our own servers in the `didReceiveChallenge` `NSURLSession` delegate method.
- Implemented `didFailToValidate()` in `CertificatePinner`

## How to Test

See `Testing Certificate Pinning` in iOS wiki.

## Screenshot

![screen shot 2018-08-13 at 10 25 25 am](https://user-images.githubusercontent.com/10579422/44037799-4200e1f6-9ee3-11e8-901c-1211f90a353e.png)

## Related Information

* Ticket Number: 1147

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [ ] All unit tests pass - Currently not compiling on `dev`
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
