### PR TITLE
feat(KYC): IOS-1045 Updating country selection screen

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -330,8 +330,6 @@
 		60AEA5BF21125DDD0053A753 /* SettingsSelectorTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AEA5BD21125DDD0053A753 /* SettingsSelectorTableViewController.m */; };
 		60B10D442118EC85003F945F /* CountryDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B10D432118EC84003F945F /* CountryDataProvider.swift */; };
 		60B10D452118ED26003F945F /* CountryDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B10D432118EC84003F945F /* CountryDataProvider.swift */; };
-		60B6A5E12121C10800CEBFA2 /* LocationUpdateAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DB5211B96FA00E6C241 /* LocationUpdateAPI.swift */; };
-		60B6A5EC2121C12400CEBFA2 /* PrimaryButtonContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B9CD42118E15200BD3D60 /* PrimaryButtonContainer.swift */; };
 		670595A41AB0F59D00D2D6D9 /* KeychainItemWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 670595A31AB0F59D00D2D6D9 /* KeychainItemWrapper.m */; };
 		6710DA0E1A8E82D80089DDED /* BCLine.m in Sources */ = {isa = PBXBuildFile; fileRef = 6710DA0D1A8E82D80089DDED /* BCLine.m */; };
 		674709EC19D1D14300757D46 /* BCWelcomeView.m in Sources */ = {isa = PBXBuildFile; fileRef = 674709EB19D1D14300757D46 /* BCWelcomeView.m */; };
@@ -451,8 +449,6 @@
 		AA7133B8212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133B7212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift */; };
 		AA7133C021222A7300CB2AA9 /* KYCCountrySelectionPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133BF21222A7300CB2AA9 /* KYCCountrySelectionPresenterTests.swift */; };
 		AA7133CB21222AFC00CB2AA9 /* MockKYCCountrySelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133CA21222AFC00CB2AA9 /* MockKYCCountrySelectionView.swift */; };
-		AA7133CC21222D0400CB2AA9 /* LocationUpdateAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DB5211B96FA00E6C241 /* LocationUpdateAPI.swift */; };
-		AA7133CD21222D0D00CB2AA9 /* PrimaryButtonContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B9CD42118E15200BD3D60 /* PrimaryButtonContainer.swift */; };
 		AA7133CE21222D2400CB2AA9 /* KYCPersonalDetailsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8B2289211E0B380091E706 /* KYCPersonalDetailsController.swift */; };
 		AA7133CF21222D2400CB2AA9 /* PersonalDetailsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DD1211CA4A700E6C241 /* PersonalDetailsCoordinator.swift */; };
 		AA7133D021222D2400CB2AA9 /* PersonalDetailsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8B224B211CA7990091E706 /* PersonalDetailsDelegate.swift */; };
@@ -484,6 +480,8 @@
 		AAA3333B2088115C0019AD55 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333A2088115C0019AD55 /* Coordinator.swift */; };
 		AAA3333D208813040019AD55 /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333C208813040019AD55 /* OnboardingCoordinator.swift */; };
 		AAA3333F2088131D0019AD55 /* ModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333E2088131D0019AD55 /* ModalPresenter.swift */; };
+		AAA6648A21234250009C1C64 /* LocationUpdateAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DB5211B96FA00E6C241 /* LocationUpdateAPI.swift */; };
+		AAA6648B2123426A009C1C64 /* PrimaryButtonContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B9CD42118E15200BD3D60 /* PrimaryButtonContainer.swift */; };
 		AABB74C620D44AE300C0F7C5 /* AboutUsView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AABB74C520D44AE300C0F7C5 /* AboutUsView.storyboard */; };
 		AABB74C820D44B0600C0F7C5 /* AboutUsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB74C720D44B0600C0F7C5 /* AboutUsViewController.swift */; };
 		AABB74C920D44B0600C0F7C5 /* AboutUsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB74C720D44B0600C0F7C5 /* AboutUsViewController.swift */; };
@@ -6850,6 +6848,7 @@
 				602B9D0E2118E23A00BD3D60 /* KYCVerifyIdentityController.swift in Sources */,
 				604598AE2118BAD000AE08C8 /* Settings+Table.swift in Sources */,
 				AA7133D221222D2C00CB2AA9 /* PersonalDetails.swift in Sources */,
+				AAA6648A21234250009C1C64 /* LocationUpdateAPI.swift in Sources */,
 				AAE94DCA20C25124005A3595 /* WalletServiceTests.swift in Sources */,
 				AA69118520D0967300DDB541 /* NetworkError.swift in Sources */,
 				51578AEB20B448BF00B0080A /* WalletKeyImportDelegate.swift in Sources */,
@@ -6893,12 +6892,10 @@
 				AAFA97AE2115110000D19ED3 /* SettingsCell.swift in Sources */,
 				602B9D182118E25A00BD3D60 /* LocationSuggestionAPI.swift in Sources */,
 				602B9D122118E24800BD3D60 /* KYCAddressController.swift in Sources */,
-				60B6A5E12121C10800CEBFA2 /* LocationUpdateAPI.swift in Sources */,
 				51A862E42092686300B338E0 /* CheckForUnusedAddressTests.swift in Sources */,
 				602B9D242118E27100BD3D60 /* KYCConfirmPhoneNumberController.swift in Sources */,
 				C74E865320B3043E00F7263D /* WalletHistoryDelegate.swift in Sources */,
 				AACE31D62092A99B00B7B806 /* Bundle.swift in Sources */,
-				AA7133CD21222D0D00CB2AA9 /* PrimaryButtonContainer.swift in Sources */,
 				AACE31DC2092A99B00B7B806 /* UIViewController.swift in Sources */,
 				3AC4F97B21234940003AA207 /* KYCPageType.swift in Sources */,
 				51A862DF20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift in Sources */,
@@ -6919,7 +6916,6 @@
 				5185E11C208E7F7C00A26B64 /* BlockchainSettings.swift in Sources */,
 				3AC9755B210FBD10006A9263 /* NSAttributedString+Conveniences.swift in Sources */,
 				AA63F86820A27AC6002B719B /* PostAuthenticationRoute.swift in Sources */,
-				60B6A5EC2121C12400CEBFA2 /* PrimaryButtonContainer.swift in Sources */,
 				AA7133C021222A7300CB2AA9 /* KYCCountrySelectionPresenterTests.swift in Sources */,
 				AAE9113220A51C900093A431 /* ReminderType.swift in Sources */,
 				3AC4F97F21234998003AA207 /* PersonalDetailsDelegate.swift in Sources */,
@@ -6929,6 +6925,7 @@
 				C79DD06F20B3B74A00DF3684 /* WalletWatchOnlyDelegate.swift in Sources */,
 				AA7133B621220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift in Sources */,
 				AAFA97AF2115110000D19ED3 /* SettingsTwoStepVC.swift in Sources */,
+				AAA6648B2123426A009C1C64 /* PrimaryButtonContainer.swift in Sources */,
 				51135703209CF5D000056D65 /* AuthenticationTwoFactorType.swift in Sources */,
 				51DC2F5D20B72F4900E03AF2 /* AddressValidator.swift in Sources */,
 				AA7133D321222D3000CB2AA9 /* PersonalDetailsAPI.swift in Sources */,
@@ -7018,7 +7015,6 @@
 				3AC4F97E2123497B003AA207 /* KYCPersonalDetailsController.swift in Sources */,
 				602B9D192118E25F00BD3D60 /* LocationDataProvider.swift in Sources */,
 				AABB74C920D44B0600C0F7C5 /* AboutUsViewController.swift in Sources */,
-				AA7133CC21222D0400CB2AA9 /* LocationUpdateAPI.swift in Sources */,
 				511356BF209B7F6E00056D65 /* BlockchainAPI+Payload.swift in Sources */,
 				602B9D272118E28E00BD3D60 /* ValidationTextField.swift in Sources */,
 				AAE94F2F20C644DE005A3595 /* PinPresenter.swift in Sources */,

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -460,6 +460,8 @@
 		AA7133D221222D2C00CB2AA9 /* PersonalDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DC9211C9A8300E6C241 /* PersonalDetails.swift */; };
 		AA7133D321222D3000CB2AA9 /* PersonalDetailsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DC5211C992B00E6C241 /* PersonalDetailsAPI.swift */; };
 		AA7133D421222D3000CB2AA9 /* PersonalDetailsInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCF211CA2CD00E6C241 /* PersonalDetailsInterface.swift */; };
+		AA7133D921223AE000CB2AA9 /* Arrays.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133D821223AE000CB2AA9 /* Arrays.swift */; };
+		AA7133DA21223AE000CB2AA9 /* Arrays.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133D821223AE000CB2AA9 /* Arrays.swift */; };
 		AA722C1420B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */; };
 		AA722C1520B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */; };
 		AA722C1920B4BBA900262A5F /* AssetAddressRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */; };
@@ -2813,6 +2815,7 @@
 		AA7133B7212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KYCVerifyPhoneNumberPresenterTests.swift; sourceTree = "<group>"; };
 		AA7133BF21222A7300CB2AA9 /* KYCCountrySelectionPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCCountrySelectionPresenterTests.swift; sourceTree = "<group>"; };
 		AA7133CA21222AFC00CB2AA9 /* MockKYCCountrySelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKYCCountrySelectionView.swift; sourceTree = "<group>"; };
+		AA7133D821223AE000CB2AA9 /* Arrays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Arrays.swift; sourceTree = "<group>"; };
 		AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwipeAddressDelegate.swift; sourceTree = "<group>"; };
 		AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressRepository.swift; sourceTree = "<group>"; };
 		AA748358211129DF008F2768 /* MockKYCEnterPhoneNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKYCEnterPhoneNumberView.swift; sourceTree = "<group>"; };
@@ -5674,6 +5677,7 @@
 				9FB3638314B60128004BEA02 /* Blockchain-Prefix.pch */,
 				9FB3637D14B60128004BEA02 /* Blockchain-Info.plist */,
 				AAA3333220880A2B0019AD55 /* AppDelegate.swift */,
+				AA7133D821223AE000CB2AA9 /* Arrays.swift */,
 				511646C4208124E200C43522 /* AssetType.swift */,
 				AA24D4C620D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift */,
 				5171E38F20F4F98000E8913E /* Colors.swift */,
@@ -6989,6 +6993,7 @@
 				AACE31C72092A99B00B7B806 /* LocalizationConstants.swift in Sources */,
 				AA7E773E210BA487009DFB4C /* Strings.swift in Sources */,
 				AACE31CC2092A99B00B7B806 /* BitcoinAddress.swift in Sources */,
+				AA7133DA21223AE000CB2AA9 /* Arrays.swift in Sources */,
 				AAFA97B02115110000D19ED3 /* SettingsProtocols.swift in Sources */,
 				C78893DB20A34DF4003C0A8F /* WalletSettingsDelegate.swift in Sources */,
 				602B9D132118E24C00BD3D60 /* SearchControllerDelegate.swift in Sources */,
@@ -7436,6 +7441,7 @@
 				3AE92BDD2110DF33008D7BDC /* NotificationCenter+Conveniences.swift in Sources */,
 				C7B6855B1F17AE2A00A18A5C /* BCEmptyPageView.m in Sources */,
 				3A8B228A211E0B380091E706 /* KYCPersonalDetailsController.swift in Sources */,
+				AA7133D921223AE000CB2AA9 /* Arrays.swift in Sources */,
 				AA31A7B42098DA4900FE6268 /* AlertViewPresenter+Wallet.swift in Sources */,
 				AAA3333B2088115C0019AD55 /* Coordinator.swift in Sources */,
 				AACE31F12092B1F800B7B806 /* PasswordRequiredView.swift in Sources */,

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -446,9 +446,20 @@
 		AA6911A120D18B6E00DDB541 /* MockWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6911A020D18B6E00DDB541 /* MockWalletService.swift */; };
 		AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F6582086A2720054EFCE /* AppCoordinator.swift */; };
 		AA69F65F2086A7500054EFCE /* BlockchainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */; };
-		AA7133B521220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133B421220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift */; };
-		AA7133B621220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133B421220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift */; };
+		AA7133B521220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133B421220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift */; };
+		AA7133B621220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133B421220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift */; };
 		AA7133B8212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133B7212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift */; };
+		AA7133C021222A7300CB2AA9 /* KYCCountrySelectionPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133BF21222A7300CB2AA9 /* KYCCountrySelectionPresenterTests.swift */; };
+		AA7133CB21222AFC00CB2AA9 /* MockKYCCountrySelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133CA21222AFC00CB2AA9 /* MockKYCCountrySelectionView.swift */; };
+		AA7133CC21222D0400CB2AA9 /* LocationUpdateAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DB5211B96FA00E6C241 /* LocationUpdateAPI.swift */; };
+		AA7133CD21222D0D00CB2AA9 /* PrimaryButtonContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B9CD42118E15200BD3D60 /* PrimaryButtonContainer.swift */; };
+		AA7133CE21222D2400CB2AA9 /* KYCPersonalDetailsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8B2289211E0B380091E706 /* KYCPersonalDetailsController.swift */; };
+		AA7133CF21222D2400CB2AA9 /* PersonalDetailsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DD1211CA4A700E6C241 /* PersonalDetailsCoordinator.swift */; };
+		AA7133D021222D2400CB2AA9 /* PersonalDetailsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8B224B211CA7990091E706 /* PersonalDetailsDelegate.swift */; };
+		AA7133D121222D2900CB2AA9 /* PersonalDetailsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCC211C9C6500E6C241 /* PersonalDetailsService.swift */; };
+		AA7133D221222D2C00CB2AA9 /* PersonalDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DC9211C9A8300E6C241 /* PersonalDetails.swift */; };
+		AA7133D321222D3000CB2AA9 /* PersonalDetailsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DC5211C992B00E6C241 /* PersonalDetailsAPI.swift */; };
+		AA7133D421222D3000CB2AA9 /* PersonalDetailsInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCF211CA2CD00E6C241 /* PersonalDetailsInterface.swift */; };
 		AA722C1420B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */; };
 		AA722C1520B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */; };
 		AA722C1920B4BBA900262A5F /* AssetAddressRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */; };
@@ -2798,8 +2809,10 @@
 		AA6911A020D18B6E00DDB541 /* MockWalletService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWalletService.swift; sourceTree = "<group>"; };
 		AA69F6582086A2720054EFCE /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchainSettings.swift; sourceTree = "<group>"; };
-		AA7133B421220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCCountrySelectorPresenter.swift; sourceTree = "<group>"; };
+		AA7133B421220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCCountrySelectionPresenter.swift; sourceTree = "<group>"; };
 		AA7133B7212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KYCVerifyPhoneNumberPresenterTests.swift; sourceTree = "<group>"; };
+		AA7133BF21222A7300CB2AA9 /* KYCCountrySelectionPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCCountrySelectionPresenterTests.swift; sourceTree = "<group>"; };
+		AA7133CA21222AFC00CB2AA9 /* MockKYCCountrySelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKYCCountrySelectionView.swift; sourceTree = "<group>"; };
 		AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwipeAddressDelegate.swift; sourceTree = "<group>"; };
 		AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressRepository.swift; sourceTree = "<group>"; };
 		AA748358211129DF008F2768 /* MockKYCEnterPhoneNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKYCEnterPhoneNumberView.swift; sourceTree = "<group>"; };
@@ -3347,6 +3360,7 @@
 			isa = PBXGroup;
 			children = (
 				5159C3202109156400955BD6 /* KYCCountrySelectionControllerTests.swift */,
+				AA7133BF21222A7300CB2AA9 /* KYCCountrySelectionPresenterTests.swift */,
 				AA7133B7212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift */,
 				AA74835421111849008F2768 /* Mock */,
 			);
@@ -3534,7 +3548,7 @@
 			children = (
 				60B10D432118EC84003F945F /* CountryDataProvider.swift */,
 				602B9CB82118E15200BD3D60 /* KYCCountrySelectionController.swift */,
-				AA7133B421220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift */,
+				AA7133B421220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift */,
 			);
 			path = CountrySelector;
 			sourceTree = "<group>";
@@ -5901,6 +5915,7 @@
 			children = (
 				AA748358211129DF008F2768 /* MockKYCEnterPhoneNumberView.swift */,
 				AA74835A21112A18008F2768 /* MockKYCVerifyPhoneNumberInteractor.swift */,
+				AA7133CA21222AFC00CB2AA9 /* MockKYCCountrySelectionView.swift */,
 			);
 			path = Mock;
 			sourceTree = "<group>";
@@ -6819,6 +6834,7 @@
 				AACE32012093FA1A00B7B806 /* ReminderPresenter.swift in Sources */,
 				3AFD18AD21221D40007145EA /* KYCBaseViewController.swift in Sources */,
 				AA63F87B20A3A198002B719B /* AppFeatureConfigurator.swift in Sources */,
+				AA7133D421222D3000CB2AA9 /* PersonalDetailsInterface.swift in Sources */,
 				AACE31DA2092A99B00B7B806 /* Application+Helpers.swift in Sources */,
 				602B9D252118E27100BD3D60 /* KYCVerifyPhoneNumberPresenter.swift in Sources */,
 				3A3D5D8E211B454000E6C241 /* ValidationDateField.swift in Sources */,
@@ -6829,6 +6845,7 @@
 				AA3CA9B92107F66E00C2AD46 /* ConsoleLogDestination.swift in Sources */,
 				602B9D0E2118E23A00BD3D60 /* KYCVerifyIdentityController.swift in Sources */,
 				604598AE2118BAD000AE08C8 /* Settings+Table.swift in Sources */,
+				AA7133D221222D2C00CB2AA9 /* PersonalDetails.swift in Sources */,
 				AAE94DCA20C25124005A3595 /* WalletServiceTests.swift in Sources */,
 				AA69118520D0967300DDB541 /* NetworkError.swift in Sources */,
 				51578AEB20B448BF00B0080A /* WalletKeyImportDelegate.swift in Sources */,
@@ -6840,6 +6857,7 @@
 				602B9D142118E24F00BD3D60 /* LocationSuggestionCoordinator.swift in Sources */,
 				AA5B3B8120C9FC9C0026029D /* PEPinEntryController+PinView.swift in Sources */,
 				C77217EE20AFCF940087836A /* WalletRecoveryDelegate.swift in Sources */,
+				AA7133CF21222D2400CB2AA9 /* PersonalDetailsCoordinator.swift in Sources */,
 				AAE94F6C20C75C67005A3595 /* MockPinInteractor.swift in Sources */,
 				51B7682221065D52003CCD46 /* Environment.swift in Sources */,
 				AACE31D92092A99B00B7B806 /* Reachability.swift in Sources */,
@@ -6850,6 +6868,7 @@
 				51135708209CF69C00056D65 /* BackupWordsViewController.swift in Sources */,
 				AACE31C42092A99B00B7B806 /* Constants.swift in Sources */,
 				AACE31382091220300B7B806 /* HTTPCookieStorage.swift in Sources */,
+				AA7133CE21222D2400CB2AA9 /* KYCPersonalDetailsController.swift in Sources */,
 				604598AD2118BA9700AE08C8 /* Settings+Helpers.swift in Sources */,
 				C72B851B210FC098002EBDB9 /* ExchangeCreateView.swift in Sources */,
 				C74E866220B3272B00F7263D /* TransferAllCoordinator.swift in Sources */,
@@ -6875,6 +6894,7 @@
 				602B9D242118E27100BD3D60 /* KYCConfirmPhoneNumberController.swift in Sources */,
 				C74E865320B3043E00F7263D /* WalletHistoryDelegate.swift in Sources */,
 				AACE31D62092A99B00B7B806 /* Bundle.swift in Sources */,
+				AA7133CD21222D0D00CB2AA9 /* PrimaryButtonContainer.swift in Sources */,
 				AACE31DC2092A99B00B7B806 /* UIViewController.swift in Sources */,
 				3AC4F97B21234940003AA207 /* KYCPageType.swift in Sources */,
 				51A862DF20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift in Sources */,
@@ -6896,16 +6916,18 @@
 				3AC9755B210FBD10006A9263 /* NSAttributedString+Conveniences.swift in Sources */,
 				AA63F86820A27AC6002B719B /* PostAuthenticationRoute.swift in Sources */,
 				60B6A5EC2121C12400CEBFA2 /* PrimaryButtonContainer.swift in Sources */,
+				AA7133C021222A7300CB2AA9 /* KYCCountrySelectionPresenterTests.swift in Sources */,
 				AAE9113220A51C900093A431 /* ReminderType.swift in Sources */,
 				3AC4F97F21234998003AA207 /* PersonalDetailsDelegate.swift in Sources */,
 				AA7E7740210BA48B009DFB4C /* AuthenticationCoordinator+Biometrics.swift in Sources */,
 				AACE31DB2092A99B00B7B806 /* UIDevice.swift in Sources */,
 				3AC4F982212349BF003AA207 /* PersonalDetailsService.swift in Sources */,
 				C79DD06F20B3B74A00DF3684 /* WalletWatchOnlyDelegate.swift in Sources */,
-				AA7133B621220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift in Sources */,
+				AA7133B621220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift in Sources */,
 				AAFA97AF2115110000D19ED3 /* SettingsTwoStepVC.swift in Sources */,
 				51135703209CF5D000056D65 /* AuthenticationTwoFactorType.swift in Sources */,
 				51DC2F5D20B72F4900E03AF2 /* AddressValidator.swift in Sources */,
+				AA7133D321222D3000CB2AA9 /* PersonalDetailsAPI.swift in Sources */,
 				AA56423B20DDBDBB0092A022 /* String+EscapeJSTests.swift in Sources */,
 				AAFA97B12115110000D19ED3 /* SettingsViewController.swift in Sources */,
 				602B9D162118E25A00BD3D60 /* LocationSuggestionService.swift in Sources */,
@@ -6991,6 +7013,7 @@
 				3AC4F97E2123497B003AA207 /* KYCPersonalDetailsController.swift in Sources */,
 				602B9D192118E25F00BD3D60 /* LocationDataProvider.swift in Sources */,
 				AABB74C920D44B0600C0F7C5 /* AboutUsViewController.swift in Sources */,
+				AA7133CC21222D0400CB2AA9 /* LocationUpdateAPI.swift in Sources */,
 				511356BF209B7F6E00056D65 /* BlockchainAPI+Payload.swift in Sources */,
 				602B9D272118E28E00BD3D60 /* ValidationTextField.swift in Sources */,
 				AAE94F2F20C644DE005A3595 /* PinPresenter.swift in Sources */,
@@ -7008,14 +7031,17 @@
 				5185E12B208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */,
 				AACE31CB2092A99B00B7B806 /* AssetType.swift in Sources */,
 				51C2ADD720BDECE700D66108 /* String+EscapeJS.swift in Sources */,
+				AA7133CB21222AFC00CB2AA9 /* MockKYCCountrySelectionView.swift in Sources */,
 				5114EA2020CB2BA90098E26E /* TabControllerManager+Nib.swift in Sources */,
 				AAD27A31209D22FD00C0EAFC /* AVCaptureDeviceInput.swift in Sources */,
 				AA56423C20DDBDBB0092A022 /* NumberFormatter+AssetsTests.swift in Sources */,
+				AA7133D121222D2900CB2AA9 /* PersonalDetailsService.swift in Sources */,
 				51135706209CF64900056D65 /* BackupNavigationViewController.swift in Sources */,
 				C7E1A2E9210A45B30072DDA0 /* ExchangeCoordinator.swift in Sources */,
 				AA1E52342097CC2C0099BD10 /* AuthenticationCoordinator.swift in Sources */,
 				3AC4F983212349CB003AA207 /* PersonalDetailsAPI.swift in Sources */,
 				3A258C0E210A486F00C023F5 /* ReusableView.swift in Sources */,
+				AA7133D021222D2400CB2AA9 /* PersonalDetailsDelegate.swift in Sources */,
 				602B9D102118E23F00BD3D60 /* KYCWelcomeController.swift in Sources */,
 				C78893EF20A4D690003C0A8F /* WalletSendBitcoinDelegate.swift in Sources */,
 				AACE31C62092A99B00B7B806 /* LoadingViewPresenter.swift in Sources */,
@@ -7167,7 +7193,7 @@
 				9F765F3D14BC7C4F00048EFB /* Transaction.m in Sources */,
 				C79DD06E20B3B74A00DF3684 /* WalletWatchOnlyDelegate.swift in Sources */,
 				5185E124208F6E5E00A26B64 /* Enum+RawValued.swift in Sources */,
-				AA7133B521220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift in Sources */,
+				AA7133B521220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift in Sources */,
 				84B601C7197ACD6300DA1829 /* UITextField+Blocks.m in Sources */,
 				602B9CE42118E15300BD3D60 /* KYCVerifyPhoneNumberInteractor.swift in Sources */,
 				9F765F4714BC8AEF00048EFB /* MultiAddressResponse.m in Sources */,

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -446,6 +446,9 @@
 		AA6911A120D18B6E00DDB541 /* MockWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6911A020D18B6E00DDB541 /* MockWalletService.swift */; };
 		AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F6582086A2720054EFCE /* AppCoordinator.swift */; };
 		AA69F65F2086A7500054EFCE /* BlockchainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */; };
+		AA7133B521220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133B421220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift */; };
+		AA7133B621220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133B421220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift */; };
+		AA7133B8212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7133B7212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift */; };
 		AA722C1420B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */; };
 		AA722C1520B4B9F300262A5F /* WalletSwipeAddressDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */; };
 		AA722C1920B4BBA900262A5F /* AssetAddressRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */; };
@@ -2795,6 +2798,8 @@
 		AA6911A020D18B6E00DDB541 /* MockWalletService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWalletService.swift; sourceTree = "<group>"; };
 		AA69F6582086A2720054EFCE /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		AA69F65E2086A7500054EFCE /* BlockchainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchainSettings.swift; sourceTree = "<group>"; };
+		AA7133B421220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCCountrySelectorPresenter.swift; sourceTree = "<group>"; };
+		AA7133B7212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KYCVerifyPhoneNumberPresenterTests.swift; sourceTree = "<group>"; };
 		AA722C1320B4B9F300262A5F /* WalletSwipeAddressDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwipeAddressDelegate.swift; sourceTree = "<group>"; };
 		AA722C1820B4BBA900262A5F /* AssetAddressRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAddressRepository.swift; sourceTree = "<group>"; };
 		AA748358211129DF008F2768 /* MockKYCEnterPhoneNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKYCEnterPhoneNumberView.swift; sourceTree = "<group>"; };
@@ -3341,8 +3346,9 @@
 		5159C3052109153600955BD6 /* KYC */ = {
 			isa = PBXGroup;
 			children = (
-				AA74835421111849008F2768 /* Mock */,
 				5159C3202109156400955BD6 /* KYCCountrySelectionControllerTests.swift */,
+				AA7133B7212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift */,
+				AA74835421111849008F2768 /* Mock */,
 			);
 			path = KYC;
 			sourceTree = "<group>";
@@ -3488,6 +3494,7 @@
 				602B9CB72118E15200BD3D60 /* CountrySelector */,
 				602B9CB22118E15200BD3D60 /* Mobile Number */,
 				602B9CBA2118E15200BD3D60 /* Models */,
+				3A3D5DBA211C98DE00E6C241 /* Personal */,
 				602B9CBC2118E15200BD3D60 /* Search */,
 				602B9CA72118E15200BD3D60 /* Storyboards */,
 				602B9CD32118E15200BD3D60 /* Views */,
@@ -3527,6 +3534,7 @@
 			children = (
 				60B10D432118EC84003F945F /* CountryDataProvider.swift */,
 				602B9CB82118E15200BD3D60 /* KYCCountrySelectionController.swift */,
+				AA7133B421220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift */,
 			);
 			path = CountrySelector;
 			sourceTree = "<group>";
@@ -6894,6 +6902,7 @@
 				AACE31DB2092A99B00B7B806 /* UIDevice.swift in Sources */,
 				3AC4F982212349BF003AA207 /* PersonalDetailsService.swift in Sources */,
 				C79DD06F20B3B74A00DF3684 /* WalletWatchOnlyDelegate.swift in Sources */,
+				AA7133B621220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift in Sources */,
 				AAFA97AF2115110000D19ED3 /* SettingsTwoStepVC.swift in Sources */,
 				51135703209CF5D000056D65 /* AuthenticationTwoFactorType.swift in Sources */,
 				51DC2F5D20B72F4900E03AF2 /* AddressValidator.swift in Sources */,
@@ -6970,6 +6979,7 @@
 				AA1E52352097CC2E0099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */,
 				C761439A211A7FD70041411E /* SocketManager.swift in Sources */,
 				602B9D0C2118E23400BD3D60 /* KYCCoordinator.swift in Sources */,
+				AA7133B8212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift in Sources */,
 				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
 				C76143AC211A80D30041411E /* Codable+Coding.swift in Sources */,
 				AA748359211129DF008F2768 /* MockKYCEnterPhoneNumberView.swift in Sources */,
@@ -7157,6 +7167,7 @@
 				9F765F3D14BC7C4F00048EFB /* Transaction.m in Sources */,
 				C79DD06E20B3B74A00DF3684 /* WalletWatchOnlyDelegate.swift in Sources */,
 				5185E124208F6E5E00A26B64 /* Enum+RawValued.swift in Sources */,
+				AA7133B521220B7100CB2AA9 /* KYCCountrySelectorPresenter.swift in Sources */,
 				84B601C7197ACD6300DA1829 /* UITextField+Blocks.m in Sources */,
 				602B9CE42118E15300BD3D60 /* KYCVerifyPhoneNumberInteractor.swift in Sources */,
 				9F765F4714BC8AEF00048EFB /* MultiAddressResponse.m in Sources */,

--- a/Blockchain/Arrays.swift
+++ b/Blockchain/Arrays.swift
@@ -1,0 +1,23 @@
+//
+//  Arrays.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/13/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+extension Array where Element : Equatable {
+
+    /// Returns an array of unique values in the array
+    var unique: [Element] {
+        var uniques = [Element]()
+        for value in self {
+            if !uniques.contains(value) {
+                uniques.append(value)
+            }
+        }
+        return uniques
+    }
+}

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -34,8 +34,8 @@ final class KYCCountrySelectionController: KYCBaseViewController, ProgressableVi
 
     private var selectedCountry: KYCCountry?
 
-    private lazy var presenter: KYCCountrySelectorPresenter = {
-        return KYCCountrySelectorPresenter(view: self)
+    private lazy var presenter: KYCCountrySelectionPresenter = {
+        return KYCCountrySelectionPresenter(view: self)
     }()
 
     // MARK: Factory
@@ -109,7 +109,7 @@ extension KYCCountrySelectionController: UITableViewDataSource, UITableViewDeleg
     }
 }
 
-extension KYCCountrySelectionController: KYCCountrySelectorView {
+extension KYCCountrySelectionController: KYCCountrySelectionView {
     func continueKycFlow(country: KYCCountry) {
         // TICKET: IOS-1142 - move to coordinator
         performSegue(withIdentifier: "promptForPersonalDetails", sender: self)

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 typealias Countries = [KYCCountry]
 
-fileprivate class CountriesMap {
+private class CountriesMap {
     private var allCountries: Countries?
     private var backingMap = [String: Countries]()
 
@@ -23,11 +23,11 @@ fileprivate class CountriesMap {
                 return
             }
             guard let searchText = searchText?.lowercased() else {
-                set(countries: countries)
+                updateMap(with: countries)
                 return
             }
             let filteredCountries = countries.filter { $0.name.lowercased().starts(with: searchText) }
-            set(countries: filteredCountries)
+            updateMap(with: filteredCountries)
         }
     }
 
@@ -46,7 +46,7 @@ fileprivate class CountriesMap {
     func setAllCountries(_ countries: Countries) {
         allCountries = countries
         allCountries?.sort(by: { $0.name < $1.name })
-        set(countries: countries)
+        updateMap(with: countries)
     }
 
     func country(at indexPath: IndexPath) -> KYCCountry? {
@@ -57,7 +57,7 @@ fileprivate class CountriesMap {
         return countriesInSection[indexPath.row]
     }
 
-    private func set(countries: Countries) {
+    private func updateMap(with countries: Countries) {
         backingMap.removeAll()
 
         let countrySectionHeaders = countries.compactMap({ country -> String? in
@@ -67,12 +67,11 @@ fileprivate class CountriesMap {
             return String(firstChar).uppercased()
         }).unique
 
-        for firstLetter in countrySectionHeaders {
-            let countriesInHeader = countries.filter {
+        countrySectionHeaders.forEach { firstLetter in
+            backingMap[firstLetter] = countries.filter {
                 guard let firstChar = $0.name.first else { return false }
                 return String(firstChar).uppercased() == firstLetter
             }
-            backingMap[firstLetter] = countriesInHeader
         }
     }
 }

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -186,6 +186,10 @@ extension KYCCountrySelectionController: UITableViewDataSource, UITableViewDeleg
         return countriesMap.keys.count
     }
 
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        searchBar.resignFirstResponder()
+    }
+
     // MARK: - UITableViewDelegate
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionPresenter.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionPresenter.swift
@@ -1,5 +1,5 @@
 //
-//  KYCCountrySelectorPresenter.swift
+//  KYCCountrySelectionPresenter.swift
 //  Blockchain
 //
 //  Created by Chris Arriola on 8/13/18.
@@ -9,7 +9,7 @@
 import RxSwift
 
 /// Protocol definition for the country selection view during the KYC flow
-protocol KYCCountrySelectorView: class {
+protocol KYCCountrySelectionView: class {
 
     /// Method invoked once the user selects a native KYC-supported country
     func continueKycFlow(country: KYCCountry)
@@ -24,17 +24,17 @@ protocol KYCCountrySelectorView: class {
     func showExchangeNotAvailable(country: KYCCountry)
 }
 
-class KYCCountrySelectorPresenter {
+class KYCCountrySelectionPresenter {
 
     // MARK: - Private Properties
 
     private let walletService: WalletService
-    private weak var view: KYCCountrySelectorView?
+    private weak var view: KYCCountrySelectionView?
     private var disposable: Disposable?
 
     // MARK: - Initializer
 
-    init(view: KYCCountrySelectorView, walletService: WalletService = WalletService.shared) {
+    init(view: KYCCountrySelectionView, walletService: WalletService = WalletService.shared) {
         self.view = view
         self.walletService = walletService
     }

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectorPresenter.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectorPresenter.swift
@@ -1,0 +1,77 @@
+//
+//  KYCCountrySelectorPresenter.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/13/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import RxSwift
+
+/// Protocol definition for the country selection view during the KYC flow
+protocol KYCCountrySelectorView: class {
+
+    /// Method invoked once the user selects a native KYC-supported country
+    func continueKycFlow(country: KYCCountry)
+
+    /// Method invoked when the user selects a country that isn't supported by
+    /// Blockchain's native KYC. Instead, the user falls back to exchanging
+    /// crypto-to-crypto using a partner (i.e. shapeshift)
+    func startPartnerExchangeFlow(country: KYCCountry)
+
+    /// Method invoked when the user selects a country that is not supported
+    /// for exchanging crypto-to-crypto
+    func showExchangeNotAvailable(country: KYCCountry)
+}
+
+class KYCCountrySelectorPresenter {
+
+    // MARK: - Private Properties
+
+    private let walletService: WalletService
+    private weak var view: KYCCountrySelectorView?
+    private var disposable: Disposable?
+
+    // MARK: - Initializer
+
+    init(view: KYCCountrySelectorView, walletService: WalletService = WalletService.shared) {
+        self.view = view
+        self.walletService = walletService
+    }
+
+    deinit {
+        disposable?.dispose()
+        disposable = nil
+    }
+
+    // MARK: - Public Methods
+
+    func selected(country: KYCCountry) {
+        // There are 3 scenarios once a user picks a country:
+
+        // 1. if the country is supported by our native KYC, proceed
+        if country.isKycSupported {
+            Logger.shared.info("Selected country is supported by our native KYC.")
+            view?.continueKycFlow(country: country)
+            return
+        }
+
+        // TODO: make sure to dispose disposable when moving to coordinator
+        disposable = walletService.walletOptions
+            .observeOn(MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] walletOptions in
+                let shapeshiftBlacklistedCountries = walletOptions.shapeshift?.countriesBlacklist ?? []
+
+                // TODO: check for state if selection is in the states
+                if !shapeshiftBlacklistedCountries.contains(country.code) {
+                    // 2. if the country is supported by shapeshift, use shapeshift
+                    Logger.shared.info("Selected country can use shapeshift.")
+                    self?.view?.startPartnerExchangeFlow(country: country)
+                } else {
+                    // 3. otherwise, tell the user crypto-crypto exchange is not available yet
+                    Logger.shared.info("Country cannot perform crypto-crypto exchange.")
+                    self?.view?.showExchangeNotAvailable(country: country)
+                }
+            })
+    }
+}

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -49,11 +49,10 @@ final class KYCNetworkRequest {
                 case .credentials,
                      .credentialsForProvider,
                      .healthCheck,
+                     .listOfCountries,
                      .nextKYCMethod,
                      .users:
                     return nil
-                case .listOfCountries:
-                    return ["filter": "eea"]
                 }
             }
         }
@@ -141,7 +140,7 @@ final class KYCNetworkRequest {
             encoder.dateEncodingStrategy = .formatted(DateFormatter.birthday)
             let body = try encoder.encode(parameters)
             request.httpBody = body
-            request.allHTTPHeaderFields = ["Content-Type":"application/json",
+            request.allHTTPHeaderFields = ["Content-Type": "application/json",
                                            "Accept": "application/json"]
             send(taskSuccess: taskSuccess, taskFailure: taskFailure)
         } catch let error {

--- a/Blockchain/KYC/Models/KYCCountry.swift
+++ b/Blockchain/KYC/Models/KYCCountry.swift
@@ -12,13 +12,13 @@ struct KYCCountry: Codable {
     let code: String
     let name: String
     let regions: [String]
-    let scopes: [String]
+    let scopes: [String]?
 }
 
 extension KYCCountry {
 
     /// Returns a boolean indicating if this country is supported by Blockchain's native KYC
     var isKycSupported: Bool {
-        return scopes.contains(where: { $0.lowercased() == "kyc" })
+        return scopes?.contains(where: { $0.lowercased() == "kyc" }) ?? false
     }
 }

--- a/Blockchain/KYC/Models/KYCCountry.swift
+++ b/Blockchain/KYC/Models/KYCCountry.swift
@@ -12,4 +12,13 @@ struct KYCCountry: Codable {
     let code: String
     let name: String
     let regions: [String]
+    let scopes: [String]
+}
+
+extension KYCCountry {
+
+    /// Returns a boolean indicating if this country is supported by Blockchain's native KYC
+    var isKycSupported: Bool {
+        return scopes.contains(where: { $0.lowercased() == "kyc" })
+    }
 }

--- a/Blockchain/KYC/Storyboards/KYCAddressController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCAddressController.storyboard
@@ -257,10 +257,10 @@
             </objects>
             <point key="canvasLocation" x="84.375" y="151.05633802816902"/>
         </scene>
-        <!--KYCPersonalDetails-->
+        <!--KYCPersonalDetailsController-->
         <scene sceneID="Mum-mC-SLc">
             <objects>
-                <viewControllerPlaceholder storyboardName="KYCPersonalDetails" id="QUH-Ks-fjK" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="KYCPersonalDetailsController" id="QUH-Ks-fjK" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ezJ-5L-utg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="810" y="115"/>

--- a/Blockchain/KYC/Storyboards/KYCConfirmPhoneNumberController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCConfirmPhoneNumberController.storyboard
@@ -123,10 +123,10 @@
             </objects>
             <point key="canvasLocation" x="125.59999999999999" y="111.57635467980296"/>
         </scene>
-        <!--KYCAddress-->
+        <!--KYCAddressController-->
         <scene sceneID="Yd6-4J-UeZ">
             <objects>
-                <viewControllerPlaceholder storyboardName="KYCAddress" id="Kem-jm-UpZ" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="KYCAddressController" id="Kem-jm-UpZ" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aSg-zE-QFB" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="672" y="33"/>

--- a/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
@@ -55,12 +55,12 @@
                                         <color key="textColor" red="0.30588235289999999" green="0.30588235289999999" blue="0.30588235289999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <searchBar contentMode="redraw" verticalHuggingPriority="751" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="UXv-PD-jDX">
+                                    <searchBar contentMode="redraw" verticalHuggingPriority="751" searchBarStyle="minimal" placeholder="Search" translatesAutoresizingMaskIntoConstraints="NO" id="UXv-PD-jDX">
                                         <rect key="frame" x="0.0" y="78.333333333333343" width="375" height="56"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="ES9-uO-pYD"/>
                                         </constraints>
-                                        <textInputTraits key="textInputTraits"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="words" returnKeyType="done"/>
                                     </searchBar>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
@@ -1,81 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lzQ-iT-CIj">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="maQ-p3-MjV">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="Montserrat-Medium.ttf">
+            <string>Montserrat-Medium</string>
+        </array>
+        <array key="Montserrat-SemiBold.ttf">
+            <string>Montserrat-SemiBold</string>
+        </array>
+    </customFonts>
     <scenes>
-        <!--KYCPersonalDetails-->
+        <!--KYCPersonalDetailsController-->
         <scene sceneID="uPe-kt-Szi">
             <objects>
-                <viewControllerPlaceholder storyboardName="KYCPersonalDetails" id="p5l-MX-35I" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="KYCPersonalDetailsController" id="p5l-MX-35I" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HKM-cD-64E" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="709" y="146"/>
         </scene>
         <!--Country Selection Controller-->
-        <scene sceneID="rXn-im-jZz">
+        <scene sceneID="UvY-Qd-gbg">
             <objects>
-                <tableViewController storyboardIdentifier="CountrySelection" title="Country Selection Controller" useStoryboardIdentifierAsRestorationIdentifier="YES" id="lzQ-iT-CIj" customClass="KYCCountrySelectionController" customModule="Blockchain" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="vGe-6j-xwG">
+                <viewController title="Country Selection Controller" useStoryboardIdentifierAsRestorationIdentifier="YES" id="maQ-p3-MjV" customClass="KYCCountrySelectionController" customModule="Blockchain" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="aMz-CM-PzM">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <searchBar key="tableHeaderView" contentMode="redraw" searchBarStyle="minimal" placeholder="Search" id="fW9-CK-PzN">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                            <textInputTraits key="textInputTraits" autocapitalizationType="words" returnKeyType="search" textContentType="country-name"/>
-                            <connections>
-                                <outlet property="delegate" destination="lzQ-iT-CIj" id="sBk-xN-TNf"/>
-                            </connections>
-                        </searchBar>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CountryCell" textLabel="hxI-sm-sTC" style="IBUITableViewCellStyleDefault" id="5lM-54-JtF" userLabel="Country Cell">
-                                <rect key="frame" x="0.0" y="84" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5lM-54-JtF" id="5FL-PB-5cU">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hxI-sm-sTC">
-                                            <rect key="frame" x="16" y="0.0" width="343" height="43.666666666666664"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HiL-Ft-99J">
+                                <rect key="frame" x="0.0" y="88.000000000000014" width="375" height="134.33333333333337"/>
+                                <subviews>
+                                    <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="DD7-KN-SsY">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="8"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="8" id="ix6-or-VDv"/>
+                                        </constraints>
+                                    </progressView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Why do you need this?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2ON-l9-pXa">
+                                        <rect key="frame" x="16" y="23" width="343" height="14"/>
+                                        <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="12"/>
+                                        <color key="textColor" red="0.30588235289999999" green="0.30588235289999999" blue="0.30588235289999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Right now, digital crypto currency conversions on Blockchain are only available in select countries." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wZm-cR-Ltr">
+                                        <rect key="frame" x="16" y="39" width="343" height="29.333333333333329"/>
+                                        <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="12"/>
+                                        <color key="textColor" red="0.30588235289999999" green="0.30588235289999999" blue="0.30588235289999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <searchBar contentMode="redraw" verticalHuggingPriority="751" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="UXv-PD-jDX">
+                                        <rect key="frame" x="0.0" y="78.333333333333343" width="375" height="56"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="56" id="ES9-uO-pYD"/>
+                                        </constraints>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </searchBar>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="wZm-cR-Ltr" firstAttribute="top" secondItem="2ON-l9-pXa" secondAttribute="bottom" constant="2" id="BAR-vO-UvC"/>
+                                    <constraint firstAttribute="trailing" secondItem="DD7-KN-SsY" secondAttribute="trailing" id="DzG-vR-IPC"/>
+                                    <constraint firstItem="DD7-KN-SsY" firstAttribute="top" secondItem="HiL-Ft-99J" secondAttribute="top" id="Gna-hq-pCf"/>
+                                    <constraint firstItem="UXv-PD-jDX" firstAttribute="top" secondItem="wZm-cR-Ltr" secondAttribute="bottom" constant="10" id="HlC-oJ-eeG"/>
+                                    <constraint firstItem="2ON-l9-pXa" firstAttribute="leading" secondItem="HiL-Ft-99J" secondAttribute="leading" constant="16" id="M7e-ti-eph"/>
+                                    <constraint firstAttribute="trailing" secondItem="2ON-l9-pXa" secondAttribute="trailing" constant="16" id="OOU-46-L3Y"/>
+                                    <constraint firstItem="UXv-PD-jDX" firstAttribute="leading" secondItem="HiL-Ft-99J" secondAttribute="leading" id="SC2-W4-0Yh"/>
+                                    <constraint firstAttribute="trailing" secondItem="UXv-PD-jDX" secondAttribute="trailing" id="YcR-LM-NMY"/>
+                                    <constraint firstAttribute="bottom" secondItem="UXv-PD-jDX" secondAttribute="bottom" id="f0U-7s-C4y"/>
+                                    <constraint firstAttribute="trailing" secondItem="wZm-cR-Ltr" secondAttribute="trailing" constant="16" id="nmc-WL-sK7"/>
+                                    <constraint firstItem="wZm-cR-Ltr" firstAttribute="leading" secondItem="HiL-Ft-99J" secondAttribute="leading" constant="16" id="p1n-O3-tkK"/>
+                                    <constraint firstItem="2ON-l9-pXa" firstAttribute="top" secondItem="DD7-KN-SsY" secondAttribute="bottom" constant="15" id="vUl-q4-FZS"/>
+                                    <constraint firstItem="DD7-KN-SsY" firstAttribute="leading" secondItem="HiL-Ft-99J" secondAttribute="leading" id="wpv-xO-hR3"/>
+                                </constraints>
+                            </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="vGe-6j-xwG">
+                                <rect key="frame" x="0.0" y="222" width="375" height="590"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CountryCell" textLabel="hxI-sm-sTC" style="IBUITableViewCellStyleDefault" id="5lM-54-JtF" userLabel="Country Cell">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5lM-54-JtF" id="5FL-PB-5cU">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="lzQ-iT-CIj" id="iWc-Q7-MMZ"/>
-                            <outlet property="delegate" destination="lzQ-iT-CIj" id="dmZ-8u-hkk"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" title="Select Your Country" id="Jew-Xs-w6G"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hxI-sm-sTC">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.666666666666664"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="vGe-6j-xwG" firstAttribute="top" secondItem="HiL-Ft-99J" secondAttribute="bottom" id="1Ez-eQ-rcg"/>
+                            <constraint firstItem="vGe-6j-xwG" firstAttribute="leading" secondItem="Z4F-OY-daj" secondAttribute="leading" id="31s-jS-z3q"/>
+                            <constraint firstAttribute="bottom" secondItem="vGe-6j-xwG" secondAttribute="bottom" id="BEo-x0-oka"/>
+                            <constraint firstItem="vGe-6j-xwG" firstAttribute="trailing" secondItem="Z4F-OY-daj" secondAttribute="trailing" id="Krc-ek-R5q"/>
+                            <constraint firstItem="HiL-Ft-99J" firstAttribute="leading" secondItem="Z4F-OY-daj" secondAttribute="leading" id="vMY-fK-dLq"/>
+                            <constraint firstItem="Z4F-OY-daj" firstAttribute="top" secondItem="HiL-Ft-99J" secondAttribute="top" id="vW5-Pt-CNJ"/>
+                            <constraint firstItem="HiL-Ft-99J" firstAttribute="trailing" secondItem="Z4F-OY-daj" secondAttribute="trailing" id="ywk-GH-XJn"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Z4F-OY-daj"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Select Your Country" id="lqm-oI-6In"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
-                        <outlet property="searchDisplayController" destination="nau-4k-vuu" id="6qX-WV-PTp"/>
-                        <segue destination="p5l-MX-35I" kind="show" identifier="promptForPersonalDetails" id="ONx-9e-1Zp"/>
+                        <outlet property="progressView" destination="DD7-KN-SsY" id="48v-s6-3Ce"/>
+                        <outlet property="searchBar" destination="UXv-PD-jDX" id="gf9-8J-U61"/>
+                        <outlet property="searchDisplayController" destination="hXY-z4-wfj" id="Bf7-I5-xOW"/>
+                        <outlet property="tableView" destination="vGe-6j-xwG" id="FK8-Rv-9FL"/>
+                        <segue destination="p5l-MX-35I" kind="show" identifier="promptForPersonalDetails" id="c27-ro-Ao3"/>
                     </connections>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="R19-3d-fIi" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <searchDisplayController id="nau-4k-vuu">
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6Wa-Ab-JKR" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <searchDisplayController id="hXY-z4-wfj">
                     <connections>
-                        <outlet property="delegate" destination="lzQ-iT-CIj" id="qeS-Iz-8s2"/>
-                        <outlet property="searchBar" destination="fW9-CK-PzN" id="a5T-H3-jIx"/>
-                        <outlet property="searchContentsController" destination="lzQ-iT-CIj" id="cqK-oS-XHb"/>
-                        <outlet property="searchResultsDataSource" destination="lzQ-iT-CIj" id="ocS-yt-hM3"/>
-                        <outlet property="searchResultsDelegate" destination="lzQ-iT-CIj" id="hOX-7h-ftT"/>
+                        <outlet property="delegate" destination="maQ-p3-MjV" id="Qjh-4Q-afK"/>
+                        <outlet property="searchContentsController" destination="maQ-p3-MjV" id="GQq-Hk-51T"/>
+                        <outlet property="searchResultsDataSource" destination="maQ-p3-MjV" id="26Q-c5-npN"/>
+                        <outlet property="searchResultsDelegate" destination="maQ-p3-MjV" id="tCA-mg-RYd"/>
                     </connections>
                 </searchDisplayController>
             </objects>
-            <point key="canvasLocation" x="14" y="256"/>
+            <point key="canvasLocation" x="100" y="248"/>
         </scene>
     </scenes>
 </document>

--- a/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
@@ -121,20 +121,11 @@
                     <connections>
                         <outlet property="progressView" destination="DD7-KN-SsY" id="48v-s6-3Ce"/>
                         <outlet property="searchBar" destination="UXv-PD-jDX" id="gf9-8J-U61"/>
-                        <outlet property="searchDisplayController" destination="hXY-z4-wfj" id="Bf7-I5-xOW"/>
                         <outlet property="tableView" destination="vGe-6j-xwG" id="FK8-Rv-9FL"/>
                         <segue destination="p5l-MX-35I" kind="show" identifier="promptForPersonalDetails" id="c27-ro-Ao3"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6Wa-Ab-JKR" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <searchDisplayController id="hXY-z4-wfj">
-                    <connections>
-                        <outlet property="delegate" destination="maQ-p3-MjV" id="Qjh-4Q-afK"/>
-                        <outlet property="searchContentsController" destination="maQ-p3-MjV" id="GQq-Hk-51T"/>
-                        <outlet property="searchResultsDataSource" destination="maQ-p3-MjV" id="26Q-c5-npN"/>
-                        <outlet property="searchResultsDelegate" destination="maQ-p3-MjV" id="tCA-mg-RYd"/>
-                    </connections>
-                </searchDisplayController>
             </objects>
             <point key="canvasLocation" x="100" y="248"/>
         </scene>

--- a/Blockchain/KYC/Storyboards/KYCEnterPhoneNumberController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCEnterPhoneNumberController.storyboard
@@ -115,10 +115,10 @@
             </objects>
             <point key="canvasLocation" x="-73" y="218"/>
         </scene>
-        <!--KYCConfirmPhoneNumber-->
+        <!--KYCConfirmPhoneNumberController-->
         <scene sceneID="fw5-HU-1bR">
             <objects>
-                <viewControllerPlaceholder storyboardName="KYCConfirmPhoneNumber" id="xVk-FG-HTS" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="KYCConfirmPhoneNumberController" id="xVk-FG-HTS" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dHo-TW-UGO" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="546" y="152"/>

--- a/Blockchain/KYC/Storyboards/KYCPersonalDetailsController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCPersonalDetailsController.storyboard
@@ -162,10 +162,10 @@
             </objects>
             <point key="canvasLocation" x="-47.200000000000003" y="193.5960591133005"/>
         </scene>
-        <!--KYCEnterPhoneNumber-->
+        <!--KYCEnterPhoneNumberController-->
         <scene sceneID="i1U-r4-6wf">
             <objects>
-                <viewControllerPlaceholder storyboardName="KYCEnterPhoneNumber" id="ikb-aY-GZn" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="KYCEnterPhoneNumberController" id="ikb-aY-GZn" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="BDp-2Y-wKI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="754" y="81"/>

--- a/Blockchain/Network/API/WalletService.swift
+++ b/Blockchain/Network/API/WalletService.swift
@@ -48,16 +48,10 @@ import RxSwift
     /// If WalletOptions has already been fetched, this property will return the cached value
     var walletOptions: Single<WalletOptions> {
         return Single.deferred { [unowned self] in
-            let startEmission: Observable<WalletOptions>
-            if let cachedValue = self.cachedWalletOptions.value {
-                startEmission = Observable.just(cachedValue)
-            } else {
-                startEmission = Observable.empty()
+            guard let cachedValue = self.cachedWalletOptions.value else {
+                return self.networkFetchedWalletOptions
             }
-
-            return startEmission.concat(self.networkFetchedWalletOptions.asObservable())
-                .elementAt(0)
-                .asSingle()
+            return Single.just(cachedValue)
         }
     }
 

--- a/Blockchain/Network/API/WalletService.swift
+++ b/Blockchain/Network/API/WalletService.swift
@@ -21,10 +21,11 @@ import RxSwift
         self.networkManager = networkManager
     }
 
-    // MARK: - Public
+    // MARK: - Private Properties
 
-    /// A Single returning the WalletOptions which contains dynamic flags for configuring the app.
-    var walletOptions: Single<WalletOptions> {
+    private var cachedWalletOptions = Variable<WalletOptions?>(nil)
+
+    private var networkFetchedWalletOptions: Single<WalletOptions> {
         return networkManager.requestJsonOrString(
             BlockchainAPI.shared.walletOptionsUrl,
             method: .get
@@ -36,6 +37,27 @@ import RxSwift
                 throw NetworkError.jsonParseError
             }
             return WalletOptions(json: json)
+        }.do(onSuccess: { [weak self] in
+            self?.cachedWalletOptions.value = $0
+        })
+    }
+
+    // MARK: - Public
+
+    /// A Single returning the WalletOptions which contains dynamic flags for configuring the app.
+    /// If WalletOptions has already been fetched, this property will return the cached value
+    var walletOptions: Single<WalletOptions> {
+        return Single.deferred { [unowned self] in
+            let startEmission: Observable<WalletOptions>
+            if let cachedValue = self.cachedWalletOptions.value {
+                startEmission = Observable.just(cachedValue)
+            } else {
+                startEmission = Observable.empty()
+            }
+
+            return startEmission.concat(self.networkFetchedWalletOptions.asObservable())
+                .elementAt(0)
+                .asSingle()
         }
     }
 

--- a/Blockchain/Network/Models/WalletOptions.swift
+++ b/Blockchain/Network/Models/WalletOptions.swift
@@ -30,8 +30,8 @@ struct WalletOptions {
     }
 
     struct Shapeshift {
-        let countriesBlacklist: [String]
-        let statesWhitelist: [String]
+        let countriesBlacklist: [String]?
+        let statesWhitelist: [String]?
     }
 
     // MARK: - Properties
@@ -76,8 +76,8 @@ extension WalletOptions.Shapeshift {
             self.statesWhitelist = []
             return
         }
-        self.countriesBlacklist = shapeshiftJson["countriesBlacklist"] as? [String] ?? []
-        self.statesWhitelist = shapeshiftJson["statesWhitelist"] as? [String] ?? []
+        self.countriesBlacklist = shapeshiftJson["countriesBlacklist"] as? [String]
+        self.statesWhitelist = shapeshiftJson["statesWhitelist"] as? [String]
     }
 }
 

--- a/Blockchain/Network/Models/WalletOptions.swift
+++ b/Blockchain/Network/Models/WalletOptions.swift
@@ -13,8 +13,10 @@ private struct Keys {
     static let walletRoot = "walletRoot"
     static let maintenance = "maintenance"
     static let mobileInfo = "mobileInfo"
+    static let shapeshift = "shapeshift"
 }
 
+// TODO: Conform to Decodable
 struct WalletOptions {
 
     // MARK: - Internal Structs
@@ -27,6 +29,11 @@ struct WalletOptions {
         let message: String?
     }
 
+    struct Shapeshift {
+        let countriesBlacklist: [String]
+        let statesWhitelist: [String]
+    }
+
     // MARK: - Properties
 
     let downForMaintenance: Bool
@@ -34,6 +41,8 @@ struct WalletOptions {
     let mobileInfo: MobileInfo?
 
     let mobile: Mobile?
+
+    let shapeshift: Shapeshift?
 }
 
 extension WalletOptions.Mobile {
@@ -60,10 +69,23 @@ extension WalletOptions.MobileInfo {
     }
 }
 
+extension WalletOptions.Shapeshift {
+    init(json: JSON) {
+        guard let shapeshiftJson = json[Keys.shapeshift] as? JSON else {
+            self.countriesBlacklist = []
+            self.statesWhitelist = []
+            return
+        }
+        self.countriesBlacklist = shapeshiftJson["countriesBlacklist"] as? [String] ?? []
+        self.statesWhitelist = shapeshiftJson["statesWhitelist"] as? [String] ?? []
+    }
+}
+
 extension WalletOptions {
     init(json: JSON) {
         self.downForMaintenance = json[Keys.maintenance] as? Bool ?? false
         self.mobile = WalletOptions.Mobile(json: json)
         self.mobileInfo = WalletOptions.MobileInfo(json: json)
+        self.shapeshift = WalletOptions.Shapeshift(json: json)
     }
 }

--- a/BlockchainTests/KYC/KYCCountrySelectionControllerTests.swift
+++ b/BlockchainTests/KYC/KYCCountrySelectionControllerTests.swift
@@ -16,12 +16,14 @@ class KYCCountrySelectionControllerTests: XCTestCase {
             {
                 "code": "ASC",
                 "name": "Ascension Island",
-                "regions": []
+                "regions": [],
+                "scopes": []
             },
             {
                 "code": "AND",
                 "name": "Andorra",
-                "regions": []
+                "regions": [],
+                "scopes": []
             }
         ]
     """
@@ -51,16 +53,17 @@ class KYCCountrySelectionControllerTests: XCTestCase {
         XCTAssertNotNil(data, "Expected data not to be nil")
     }
 
-    func testDecodeJSONFileFromDisk() {
-        guard let jsonFile = Bundle.main.url(forResource: "countries", withExtension: "json"),
-            let jsonData = try? Data(contentsOf: jsonFile) else {
-                XCTFail("Failed to load the JSON file containing the sample countries")
-                return
-        }
-        let data = try? JSONDecoder().decode([KYCCountry].self, from: jsonData)
-        XCTAssertNoThrow(data, "Expected data not to throw")
-        XCTAssertNotNil(data, "Expected data not to be nil")
-    }
+//    func testDecodeJSONFileFromDisk() {
+//        // TODO: update countries payload
+//        guard let jsonFile = Bundle.main.url(forResource: "countries", withExtension: "json"),
+//            let jsonData = try? Data(contentsOf: jsonFile) else {
+//                XCTFail("Failed to load the JSON file containing the sample countries")
+//                return
+//        }
+//        let data = try? JSONDecoder().decode([KYCCountry].self, from: jsonData)
+//        XCTAssertNoThrow(data, "Expected data not to throw")
+//        XCTAssertNotNil(data, "Expected data not to be nil")
+//    }
 
     func testDecodeBadResponse() {
         let responseData = badResponse.data(using: .utf8)!

--- a/BlockchainTests/KYC/KYCCountrySelectionControllerTests.swift
+++ b/BlockchainTests/KYC/KYCCountrySelectionControllerTests.swift
@@ -53,17 +53,16 @@ class KYCCountrySelectionControllerTests: XCTestCase {
         XCTAssertNotNil(data, "Expected data not to be nil")
     }
 
-//    func testDecodeJSONFileFromDisk() {
-//        // TODO: update countries payload
-//        guard let jsonFile = Bundle.main.url(forResource: "countries", withExtension: "json"),
-//            let jsonData = try? Data(contentsOf: jsonFile) else {
-//                XCTFail("Failed to load the JSON file containing the sample countries")
-//                return
-//        }
-//        let data = try? JSONDecoder().decode([KYCCountry].self, from: jsonData)
-//        XCTAssertNoThrow(data, "Expected data not to throw")
-//        XCTAssertNotNil(data, "Expected data not to be nil")
-//    }
+    func testDecodeJSONFileFromDisk() {
+        guard let jsonFile = Bundle.main.url(forResource: "countries", withExtension: "json"),
+            let jsonData = try? Data(contentsOf: jsonFile) else {
+                XCTFail("Failed to load the JSON file containing the sample countries")
+                return
+        }
+        let data = try? JSONDecoder().decode([KYCCountry].self, from: jsonData)
+        XCTAssertNoThrow(data, "Expected data not to throw")
+        XCTAssertNotNil(data, "Expected data not to be nil")
+    }
 
     func testDecodeBadResponse() {
         let responseData = badResponse.data(using: .utf8)!

--- a/BlockchainTests/KYC/KYCCountrySelectionPresenterTests.swift
+++ b/BlockchainTests/KYC/KYCCountrySelectionPresenterTests.swift
@@ -1,0 +1,63 @@
+//
+//  KYCCountrySelectionPresenterTests.swift
+//  BlockchainTests
+//
+//  Created by Chris Arriola on 8/13/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import XCTest
+@testable import Blockchain
+
+class KYCCountrySelectionPresenterTests: XCTestCase {
+
+    private var view: MockKYCCountrySelectionView!
+    private var walletService: MockWalletService!
+    private var presenter: KYCCountrySelectionPresenter!
+
+    override func setUp() {
+        super.setUp()
+        view = MockKYCCountrySelectionView()
+        walletService = MockWalletService()
+        presenter = KYCCountrySelectionPresenter(view: view, walletService: walletService)
+    }
+
+    func testSelectedSupportedKycCountry() {
+        view.didCallContinueKycFlow = expectation(description: "Continue KYC flow when user selects valid KYC country.")
+        let country = KYCCountry(code: "TEST", name: "Test Country", regions: [], scopes: ["KYC"])
+        presenter.selected(country: country)
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testSelectedPartnerSupportedCountry() {
+        view.didCallStartPartnerExchangeFlow = expectation(
+            description: "Partner exchange flow starts when user selects country not supported by homebrew."
+        )
+        walletService.mockWalletOptions = WalletOptions(
+            json: [
+                "shapeshift": [
+                    "countriesBlacklist": ["US"]
+                ]
+            ]
+        )
+        let country = KYCCountry(code: "TEST", name: "Test Country", regions: [], scopes: [])
+        presenter.selected(country: country)
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testSelectedUnsupportedCountry() {
+        view.didCallShowExchangeNotAvailable = expectation(
+            description: "KYC flow stops when user selects blacklisted country"
+        )
+        walletService.mockWalletOptions = WalletOptions(
+            json: [
+                "shapeshift": [
+                    "countriesBlacklist": ["US"]
+                ]
+            ]
+        )
+        let country = KYCCountry(code: "US", name: "Test Country", regions: [], scopes: [])
+        presenter.selected(country: country)
+        waitForExpectations(timeout: 0.1)
+    }
+}

--- a/BlockchainTests/KYC/Mock/MockKYCCountrySelectionView.swift
+++ b/BlockchainTests/KYC/Mock/MockKYCCountrySelectionView.swift
@@ -1,0 +1,27 @@
+//
+//  MockKYCCountrySelectionView.swift
+//  BlockchainTests
+//
+//  Created by Chris Arriola on 8/13/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import XCTest
+
+class MockKYCCountrySelectionView: KYCCountrySelectionView {
+    var didCallContinueKycFlow: XCTestExpectation?
+    var didCallStartPartnerExchangeFlow: XCTestExpectation?
+    var didCallShowExchangeNotAvailable: XCTestExpectation?
+
+    func continueKycFlow(country: KYCCountry) {
+        didCallContinueKycFlow?.fulfill()
+    }
+
+    func startPartnerExchangeFlow(country: KYCCountry) {
+        didCallStartPartnerExchangeFlow?.fulfill()
+    }
+
+    func showExchangeNotAvailable(country: KYCCountry) {
+        didCallShowExchangeNotAvailable?.fulfill()
+    }
+}

--- a/BlockchainTests/Mock Data/countries.json
+++ b/BlockchainTests/Mock Data/countries.json
@@ -1,1 +1,1333 @@
-[{"code":"AUT","name":"Austria","regions":["EEA"]},{"code":"PRT","name":"Portugal","regions":["EEA"]},{"code":"BEL","name":"Belgium","regions":["EEA"]},{"code":"BGR","name":"Bulgaria","regions":["EEA"]},{"code":"ESP","name":"Spain","regions":["EEA"]},{"code":"HRV","name":"Croatia","regions":["EEA"]},{"code":"CYP","name":"Cyprus","regions":["EEA"]},{"code":"CZE","name":"Czech Republic","regions":["EEA"]},{"code":"DNK","name":"Denmark","regions":["EEA"]},{"code":"EST","name":"Estonia","regions":["EEA"]},{"code":"FRA","name":"France","regions":["EEA"]},{"code":"GUF","name":"French Guiana","regions":["EEA"]},{"code":"DEU","name":"Germany","regions":["EEA"]},{"code":"GIB","name":"Gibraltar","regions":["EEA"]},{"code":"GRC","name":"Greece","regions":["EEA"]},{"code":"GLP","name":"Guadeloupe","regions":["EEA"]},{"code":"GGY","name":"Guernsey","regions":["EEA"]},{"code":"HUN","name":"Hungary","regions":["EEA"]},{"code":"ISL","name":"Iceland","regions":["EEA"]},{"code":"IRL","name":"Ireland","regions":["EEA"]},{"code":"IMN","name":"Isle of Man","regions":["EEA"]},{"code":"ITA","name":"Italy","regions":["EEA"]},{"code":"JEY","name":"Jersey","regions":["EEA"]},{"code":"LVA","name":"Latvia","regions":["EEA"]},{"code":"LIE","name":"Liechtenstein","regions":["EEA"]},{"code":"LTU","name":"Lithuania","regions":["EEA"]},{"code":"LUX","name":"Luxembourg","regions":["EEA"]},{"code":"MLT","name":"Malta","regions":["EEA"]},{"code":"MTQ","name":"Martinique","regions":["EEA"]},{"code":"MYT","name":"Mayotte","regions":["EEA"]},{"code":"NLD","name":"Netherlands","regions":["EEA"]},{"code":"NOR","name":"Norway","regions":["EEA"]},{"code":"POL","name":"Poland","regions":["EEA"]},{"code":"REU","name":"Réunion","regions":["EEA"]},{"code":"ROU","name":"Romania","regions":["EEA"]},{"code":"BLM","name":"Saint Barthélemy","regions":["EEA"]},{"code":"MAF","name":"Saint Martin (French part)","regions":["EEA"]},{"code":"SPM","name":"Saint Pierre and Miquelon","regions":["EEA"]},{"code":"SVK","name":"Slovakia","regions":["EEA"]},{"code":"SVN","name":"Slovenia","regions":["EEA"]},{"code":"SWE","name":"Sweden","regions":["EEA"]},{"code":"GBR","name":"United Kingdom","regions":["EEA"]},{"code":"FIN","name":"Finland","regions":["EEA"]}]
+ [
+  {
+  "code": "AD",
+  "name": "Andorra",
+  "regions": []
+  },
+  {
+  "code": "AE",
+  "name": "United Arab Emirates",
+  "regions": []
+  },
+  {
+  "code": "AF",
+  "name": "Afghanistan",
+  "regions": []
+  },
+  {
+  "code": "AG",
+  "name": "Antigua and Barbuda",
+  "regions": []
+  },
+  {
+  "code": "AI",
+  "name": "Anguilla",
+  "regions": []
+  },
+  {
+  "code": "AL",
+  "name": "Albania",
+  "regions": []
+  },
+  {
+  "code": "AM",
+  "name": "Armenia",
+  "regions": []
+  },
+  {
+  "code": "AO",
+  "name": "Angola",
+  "regions": []
+  },
+  {
+  "code": "AQ",
+  "name": "Antarctica",
+  "regions": []
+  },
+  {
+  "code": "AR",
+  "name": "Argentina",
+  "regions": []
+  },
+  {
+  "code": "AS",
+  "name": "American Samoa",
+  "regions": []
+  },
+  {
+  "code": "AT",
+  "name": "Austria",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "AU",
+  "name": "Australia",
+  "regions": []
+  },
+  {
+  "code": "AW",
+  "name": "Aruba",
+  "regions": []
+  },
+  {
+  "code": "AX",
+  "name": "Åland Islands",
+  "regions": []
+  },
+  {
+  "code": "AZ",
+  "name": "Azerbaijan",
+  "regions": []
+  },
+  {
+  "code": "BA",
+  "name": "Bosnia and Herzegovina",
+  "regions": []
+  },
+  {
+  "code": "BB",
+  "name": "Barbados",
+  "regions": []
+  },
+  {
+  "code": "BD",
+  "name": "Bangladesh",
+  "regions": []
+  },
+  {
+  "code": "BE",
+  "name": "Belgium",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "BF",
+  "name": "Burkina Faso",
+  "regions": []
+  },
+  {
+  "code": "BG",
+  "name": "Bulgaria",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "BH",
+  "name": "Bahrain",
+  "regions": []
+  },
+  {
+  "code": "BI",
+  "name": "Burundi",
+  "regions": []
+  },
+  {
+  "code": "BJ",
+  "name": "Benin",
+  "regions": []
+  },
+  {
+  "code": "BL",
+  "name": "Saint Barthélemy",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "BM",
+  "name": "Bermuda",
+  "regions": []
+  },
+  {
+  "code": "BN",
+  "name": "Brunei Darussalam",
+  "regions": []
+  },
+  {
+  "code": "BO",
+  "name": "Bolivia, Plurinational State of",
+  "regions": []
+  },
+  {
+  "code": "BQ",
+  "name": "Bonaire, Sint Eustatius and Saba",
+  "regions": []
+  },
+  {
+  "code": "BR",
+  "name": "Brazil",
+  "regions": []
+  },
+  {
+  "code": "BS",
+  "name": "Bahamas",
+  "regions": []
+  },
+  {
+  "code": "BT",
+  "name": "Bhutan",
+  "regions": []
+  },
+  {
+  "code": "BV",
+  "name": "Bouvet Island",
+  "regions": []
+  },
+  {
+  "code": "BW",
+  "name": "Botswana",
+  "regions": []
+  },
+  {
+  "code": "BY",
+  "name": "Belarus",
+  "regions": []
+  },
+  {
+  "code": "BZ",
+  "name": "Belize",
+  "regions": []
+  },
+  {
+  "code": "CA",
+  "name": "Canada",
+  "regions": []
+  },
+  {
+  "code": "CC",
+  "name": "Cocos (Keeling) Islands",
+  "regions": []
+  },
+  {
+  "code": "CD",
+  "name": "Congo, the Democratic Republic of the",
+  "regions": []
+  },
+  {
+  "code": "CF",
+  "name": "Central African Republic",
+  "regions": []
+  },
+  {
+  "code": "CG",
+  "name": "Congo",
+  "regions": []
+  },
+  {
+  "code": "CH",
+  "name": "Switzerland",
+  "regions": []
+  },
+  {
+  "code": "CI",
+  "name": "Côte d'Ivoire",
+  "regions": []
+  },
+  {
+  "code": "CK",
+  "name": "Cook Islands",
+  "regions": []
+  },
+  {
+  "code": "CL",
+  "name": "Chile",
+  "regions": []
+  },
+  {
+  "code": "CM",
+  "name": "Cameroon",
+  "regions": []
+  },
+  {
+  "code": "CN",
+  "name": "China",
+  "regions": []
+  },
+  {
+  "code": "CO",
+  "name": "Colombia",
+  "regions": []
+  },
+  {
+  "code": "CR",
+  "name": "Costa Rica",
+  "regions": []
+  },
+  {
+  "code": "CU",
+  "name": "Cuba",
+  "regions": []
+  },
+  {
+  "code": "CV",
+  "name": "Cape Verde",
+  "regions": []
+  },
+  {
+  "code": "CW",
+  "name": "Curaçao",
+  "regions": []
+  },
+  {
+  "code": "CX",
+  "name": "Christmas Island",
+  "regions": []
+  },
+  {
+  "code": "CY",
+  "name": "Cyprus",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "CZ",
+  "name": "Czech Republic",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "DE",
+  "name": "Germany",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "DJ",
+  "name": "Djibouti",
+  "regions": []
+  },
+  {
+  "code": "DK",
+  "name": "Denmark",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "DM",
+  "name": "Dominica",
+  "regions": []
+  },
+  {
+  "code": "DO",
+  "name": "Dominican Republic",
+  "regions": []
+  },
+  {
+  "code": "DZ",
+  "name": "Algeria",
+  "regions": []
+  },
+  {
+  "code": "EC",
+  "name": "Ecuador",
+  "regions": []
+  },
+  {
+  "code": "EE",
+  "name": "Estonia",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "EG",
+  "name": "Egypt",
+  "regions": []
+  },
+  {
+  "code": "EH",
+  "name": "Western Sahara",
+  "regions": []
+  },
+  {
+  "code": "ER",
+  "name": "Eritrea",
+  "regions": []
+  },
+  {
+  "code": "ES",
+  "name": "Spain",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "ET",
+  "name": "Ethiopia",
+  "regions": []
+  },
+  {
+  "code": "FI",
+  "name": "Finland",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "FJ",
+  "name": "Fiji",
+  "regions": []
+  },
+  {
+  "code": "FK",
+  "name": "Falkland Islands (Malvinas)",
+  "regions": []
+  },
+  {
+  "code": "FM",
+  "name": "Micronesia, Federated States of",
+  "regions": []
+  },
+  {
+  "code": "FO",
+  "name": "Faroe Islands",
+  "regions": []
+  },
+  {
+  "code": "FR",
+  "name": "France",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "GA",
+  "name": "Gabon",
+  "regions": []
+  },
+  {
+  "code": "GB",
+  "name": "United Kingdom",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "GD",
+  "name": "Grenada",
+  "regions": []
+  },
+  {
+  "code": "GE",
+  "name": "Georgia",
+  "regions": []
+  },
+  {
+  "code": "GF",
+  "name": "French Guiana",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "GG",
+  "name": "Guernsey",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "GH",
+  "name": "Ghana",
+  "regions": []
+  },
+  {
+  "code": "GI",
+  "name": "Gibraltar",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "GL",
+  "name": "Greenland",
+  "regions": []
+  },
+  {
+  "code": "GM",
+  "name": "Gambia",
+  "regions": []
+  },
+  {
+  "code": "GN",
+  "name": "Guinea",
+  "regions": []
+  },
+  {
+  "code": "GP",
+  "name": "Guadeloupe",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "GQ",
+  "name": "Equatorial Guinea",
+  "regions": []
+  },
+  {
+  "code": "GR",
+  "name": "Greece",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "GS",
+  "name": "South Georgia and the South Sandwich Islands",
+  "regions": []
+  },
+  {
+  "code": "GT",
+  "name": "Guatemala",
+  "regions": []
+  },
+  {
+  "code": "GU",
+  "name": "Guam",
+  "regions": []
+  },
+  {
+  "code": "GW",
+  "name": "Guinea-Bissau",
+  "regions": []
+  },
+  {
+  "code": "GY",
+  "name": "Guyana",
+  "regions": []
+  },
+  {
+  "code": "HK",
+  "name": "Hong Kong",
+  "regions": []
+  },
+  {
+  "code": "HM",
+  "name": "Heard Island and McDonald Islands",
+  "regions": []
+  },
+  {
+  "code": "HN",
+  "name": "Honduras",
+  "regions": []
+  },
+  {
+  "code": "HR",
+  "name": "Croatia",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "HT",
+  "name": "Haiti",
+  "regions": []
+  },
+  {
+  "code": "HU",
+  "name": "Hungary",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "ID",
+  "name": "Indonesia",
+  "regions": []
+  },
+  {
+  "code": "IE",
+  "name": "Ireland",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "IL",
+  "name": "Israel",
+  "regions": []
+  },
+  {
+  "code": "IM",
+  "name": "Isle of Man",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "IN",
+  "name": "India",
+  "regions": []
+  },
+  {
+  "code": "IO",
+  "name": "British Indian Ocean Territory",
+  "regions": []
+  },
+  {
+  "code": "IQ",
+  "name": "Iraq",
+  "regions": []
+  },
+  {
+  "code": "IR",
+  "name": "Iran, Islamic Republic of",
+  "regions": []
+  },
+  {
+  "code": "IS",
+  "name": "Iceland",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "IT",
+  "name": "Italy",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "JE",
+  "name": "Jersey",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "JM",
+  "name": "Jamaica",
+  "regions": []
+  },
+  {
+  "code": "JO",
+  "name": "Jordan",
+  "regions": []
+  },
+  {
+  "code": "JP",
+  "name": "Japan",
+  "regions": []
+  },
+  {
+  "code": "KE",
+  "name": "Kenya",
+  "regions": []
+  },
+  {
+  "code": "KG",
+  "name": "Kyrgyzstan",
+  "regions": []
+  },
+  {
+  "code": "KH",
+  "name": "Cambodia",
+  "regions": []
+  },
+  {
+  "code": "KI",
+  "name": "Kiribati",
+  "regions": []
+  },
+  {
+  "code": "KM",
+  "name": "Comoros",
+  "regions": []
+  },
+  {
+  "code": "KN",
+  "name": "Saint Kitts and Nevis",
+  "regions": []
+  },
+  {
+  "code": "KP",
+  "name": "Korea, Democratic People's Republic of",
+  "regions": []
+  },
+  {
+  "code": "KR",
+  "name": "Korea, Republic of",
+  "regions": []
+  },
+  {
+  "code": "KW",
+  "name": "Kuwait",
+  "regions": []
+  },
+  {
+  "code": "KY",
+  "name": "Cayman Islands",
+  "regions": []
+  },
+  {
+  "code": "KZ",
+  "name": "Kazakhstan",
+  "regions": []
+  },
+  {
+  "code": "LA",
+  "name": "Lao People's Democratic Republic",
+  "regions": []
+  },
+  {
+  "code": "LB",
+  "name": "Lebanon",
+  "regions": []
+  },
+  {
+  "code": "LC",
+  "name": "Saint Lucia",
+  "regions": []
+  },
+  {
+  "code": "LI",
+  "name": "Liechtenstein",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "LK",
+  "name": "Sri Lanka",
+  "regions": []
+  },
+  {
+  "code": "LR",
+  "name": "Liberia",
+  "regions": []
+  },
+  {
+  "code": "LS",
+  "name": "Lesotho",
+  "regions": []
+  },
+  {
+  "code": "LT",
+  "name": "Lithuania",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "LU",
+  "name": "Luxembourg",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "LV",
+  "name": "Latvia",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "LY",
+  "name": "Libya",
+  "regions": []
+  },
+  {
+  "code": "MA",
+  "name": "Morocco",
+  "regions": []
+  },
+  {
+  "code": "MC",
+  "name": "Monaco",
+  "regions": []
+  },
+  {
+  "code": "MD",
+  "name": "Moldova, Republic of",
+  "regions": []
+  },
+  {
+  "code": "ME",
+  "name": "Montenegro",
+  "regions": []
+  },
+  {
+  "code": "MF",
+  "name": "Saint Martin (French part)",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "MG",
+  "name": "Madagascar",
+  "regions": []
+  },
+  {
+  "code": "MH",
+  "name": "Marshall Islands",
+  "regions": []
+  },
+  {
+  "code": "MK",
+  "name": "Macedonia, the former Yugoslav Republic of",
+  "regions": []
+  },
+  {
+  "code": "ML",
+  "name": "Mali",
+  "regions": []
+  },
+  {
+  "code": "MM",
+  "name": "Myanmar",
+  "regions": []
+  },
+  {
+  "code": "MN",
+  "name": "Mongolia",
+  "regions": []
+  },
+  {
+  "code": "MO",
+  "name": "Macao",
+  "regions": []
+  },
+  {
+  "code": "MP",
+  "name": "Northern Mariana Islands",
+  "regions": []
+  },
+  {
+  "code": "MQ",
+  "name": "Martinique",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "MR",
+  "name": "Mauritania",
+  "regions": []
+  },
+  {
+  "code": "MS",
+  "name": "Montserrat",
+  "regions": []
+  },
+  {
+  "code": "MT",
+  "name": "Malta",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "MU",
+  "name": "Mauritius",
+  "regions": []
+  },
+  {
+  "code": "MV",
+  "name": "Maldives",
+  "regions": []
+  },
+  {
+  "code": "MW",
+  "name": "Malawi",
+  "regions": []
+  },
+  {
+  "code": "MX",
+  "name": "Mexico",
+  "regions": []
+  },
+  {
+  "code": "MY",
+  "name": "Malaysia",
+  "regions": []
+  },
+  {
+  "code": "MZ",
+  "name": "Mozambique",
+  "regions": []
+  },
+  {
+  "code": "NA",
+  "name": "Namibia",
+  "regions": []
+  },
+  {
+  "code": "NC",
+  "name": "New Caledonia",
+  "regions": []
+  },
+  {
+  "code": "NE",
+  "name": "Niger",
+  "regions": []
+  },
+  {
+  "code": "NF",
+  "name": "Norfolk Island",
+  "regions": []
+  },
+  {
+  "code": "NG",
+  "name": "Nigeria",
+  "regions": []
+  },
+  {
+  "code": "NI",
+  "name": "Nicaragua",
+  "regions": []
+  },
+  {
+  "code": "NL",
+  "name": "Netherlands",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "NO",
+  "name": "Norway",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "NP",
+  "name": "Nepal",
+  "regions": []
+  },
+  {
+  "code": "NR",
+  "name": "Nauru",
+  "regions": []
+  },
+  {
+  "code": "NU",
+  "name": "Niue",
+  "regions": []
+  },
+  {
+  "code": "NZ",
+  "name": "New Zealand",
+  "regions": []
+  },
+  {
+  "code": "OM",
+  "name": "Oman",
+  "regions": []
+  },
+  {
+  "code": "PA",
+  "name": "Panama",
+  "regions": []
+  },
+  {
+  "code": "PE",
+  "name": "Peru",
+  "regions": []
+  },
+  {
+  "code": "PF",
+  "name": "French Polynesia",
+  "regions": []
+  },
+  {
+  "code": "PG",
+  "name": "Papua New Guinea",
+  "regions": []
+  },
+  {
+  "code": "PH",
+  "name": "Philippines",
+  "regions": []
+  },
+  {
+  "code": "PK",
+  "name": "Pakistan",
+  "regions": []
+  },
+  {
+  "code": "PL",
+  "name": "Poland",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "PM",
+  "name": "Saint Pierre and Miquelon",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "PN",
+  "name": "Pitcairn",
+  "regions": []
+  },
+  {
+  "code": "PR",
+  "name": "Puerto Rico",
+  "regions": []
+  },
+  {
+  "code": "PS",
+  "name": "Palestine, State of",
+  "regions": []
+  },
+  {
+  "code": "PT",
+  "name": "Portugal",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "PW",
+  "name": "Palau",
+  "regions": []
+  },
+  {
+  "code": "PY",
+  "name": "Paraguay",
+  "regions": []
+  },
+  {
+  "code": "QA",
+  "name": "Qatar",
+  "regions": []
+  },
+  {
+  "code": "RE",
+  "name": "Réunion",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "RO",
+  "name": "Romania",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "RS",
+  "name": "Serbia",
+  "regions": []
+  },
+  {
+  "code": "RU",
+  "name": "Russian Federation",
+  "regions": []
+  },
+  {
+  "code": "RW",
+  "name": "Rwanda",
+  "regions": []
+  },
+  {
+  "code": "SA",
+  "name": "Saudi Arabia",
+  "regions": []
+  },
+  {
+  "code": "SB",
+  "name": "Solomon Islands",
+  "regions": []
+  },
+  {
+  "code": "SC",
+  "name": "Seychelles",
+  "regions": []
+  },
+  {
+  "code": "SD",
+  "name": "Sudan",
+  "regions": []
+  },
+  {
+  "code": "SE",
+  "name": "Sweden",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "SG",
+  "name": "Singapore",
+  "regions": []
+  },
+  {
+  "code": "SH",
+  "name": "Saint Helena, Ascension and Tristan da Cunha",
+  "regions": []
+  },
+  {
+  "code": "SI",
+  "name": "Slovenia",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "SJ",
+  "name": "Svalbard and Jan Mayen",
+  "regions": []
+  },
+  {
+  "code": "SK",
+  "name": "Slovakia",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "SL",
+  "name": "Sierra Leone",
+  "regions": []
+  },
+  {
+  "code": "SM",
+  "name": "San Marino",
+  "regions": []
+  },
+  {
+  "code": "SN",
+  "name": "Senegal",
+  "regions": []
+  },
+  {
+  "code": "SO",
+  "name": "Somalia",
+  "regions": []
+  },
+  {
+  "code": "SR",
+  "name": "Suriname",
+  "regions": []
+  },
+  {
+  "code": "SS",
+  "name": "South Sudan",
+  "regions": []
+  },
+  {
+  "code": "ST",
+  "name": "Sao Tome and Principe",
+  "regions": []
+  },
+  {
+  "code": "SV",
+  "name": "El Salvador",
+  "regions": []
+  },
+  {
+  "code": "SX",
+  "name": "Sint Maarten (Dutch part)",
+  "regions": []
+  },
+  {
+  "code": "SY",
+  "name": "Syrian Arab Republic",
+  "regions": []
+  },
+  {
+  "code": "SZ",
+  "name": "Swaziland",
+  "regions": []
+  },
+  {
+  "code": "TC",
+  "name": "Turks and Caicos Islands",
+  "regions": []
+  },
+  {
+  "code": "TD",
+  "name": "Chad",
+  "regions": []
+  },
+  {
+  "code": "TF",
+  "name": "French Southern Territories",
+  "regions": []
+  },
+  {
+  "code": "TG",
+  "name": "Togo",
+  "regions": []
+  },
+  {
+  "code": "TH",
+  "name": "Thailand",
+  "regions": []
+  },
+  {
+  "code": "TJ",
+  "name": "Tajikistan",
+  "regions": []
+  },
+  {
+  "code": "TK",
+  "name": "Tokelau",
+  "regions": []
+  },
+  {
+  "code": "TL",
+  "name": "Timor-Leste",
+  "regions": []
+  },
+  {
+  "code": "TM",
+  "name": "Turkmenistan",
+  "regions": []
+  },
+  {
+  "code": "TN",
+  "name": "Tunisia",
+  "regions": []
+  },
+  {
+  "code": "TO",
+  "name": "Tonga",
+  "regions": []
+  },
+  {
+  "code": "TR",
+  "name": "Turkey",
+  "regions": []
+  },
+  {
+  "code": "TT",
+  "name": "Trinidad and Tobago",
+  "regions": []
+  },
+  {
+  "code": "TV",
+  "name": "Tuvalu",
+  "regions": []
+  },
+  {
+  "code": "TW",
+  "name": "Taiwan, Province of China",
+  "regions": []
+  },
+  {
+  "code": "TZ",
+  "name": "Tanzania, United Republic of",
+  "regions": []
+  },
+  {
+  "code": "UA",
+  "name": "Ukraine",
+  "regions": []
+  },
+  {
+  "code": "UG",
+  "name": "Uganda",
+  "regions": []
+  },
+  {
+  "code": "UM",
+  "name": "United States Minor Outlying Islands",
+  "regions": []
+  },
+  {
+  "code": "US",
+  "name": "United States",
+  "regions": []
+  },
+  {
+  "code": "UY",
+  "name": "Uruguay",
+  "regions": []
+  },
+  {
+  "code": "UZ",
+  "name": "Uzbekistan",
+  "regions": []
+  },
+  {
+  "code": "VA",
+  "name": "Holy See (Vatican City State)",
+  "regions": []
+  },
+  {
+  "code": "VC",
+  "name": "Saint Vincent and the Grenadines",
+  "regions": []
+  },
+  {
+  "code": "VE",
+  "name": "Venezuela, Bolivarian Republic of",
+  "regions": []
+  },
+  {
+  "code": "VG",
+  "name": "Virgin Islands, British",
+  "regions": []
+  },
+  {
+  "code": "VI",
+  "name": "Virgin Islands, U.S.",
+  "regions": []
+  },
+  {
+  "code": "VN",
+  "name": "Viet Nam",
+  "regions": []
+  },
+  {
+  "code": "VU",
+  "name": "Vanuatu",
+  "regions": []
+  },
+  {
+  "code": "WF",
+  "name": "Wallis and Futuna",
+  "regions": []
+  },
+  {
+  "code": "WS",
+  "name": "Samoa",
+  "regions": []
+  },
+  {
+  "code": "YE",
+  "name": "Yemen",
+  "regions": []
+  },
+  {
+  "code": "YT",
+  "name": "Mayotte",
+  "regions": [
+              "EEA"
+              ]
+  },
+  {
+  "code": "ZA",
+  "name": "South Africa",
+  "regions": []
+  },
+  {
+  "code": "ZM",
+  "name": "Zambia",
+  "regions": []
+  },
+  {
+  "code": "ZW",
+  "name": "Zimbabwe",
+  "regions": []
+  }
+  ]


### PR DESCRIPTION
## Objective

Polishing country selection screen.

## Description

Summary:
* Polishing country selection screen by implementing the search field, adding right hand side jump to section view
* Handling logic for what should happen when the user taps on a country and the country either is: (1) supported by our native KYC, (2) supported by Shapeshift or (3) is not supported at all.
* Added unit tests for logic mentioned above and fixed unit tests (had to add Swift files to BlockchainTests)

Note: some of this will change (i.e. `KYCCountrySelectionController` needs to be updated to integrate w/ `KYCCoordinator`) once #393 gets merged

## How to Test

Pull this branch and "Launch KYC" from the debug view

## Screenshot

![simulator screen shot - iphone 5s - 2018-08-13 at 16 56 25](https://user-images.githubusercontent.com/38220701/44064447-d3682fd8-9f19-11e8-938a-63856c50e65d.png)
![simulator screen shot - iphone 5s - 2018-08-13 at 16 48 05](https://user-images.githubusercontent.com/38220701/44064448-d38a0888-9f19-11e8-8f4c-e28b7f08bf05.png)


## Related Information

* Ticket Number: IOS-1045

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [X] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
