### PR TITLE
feat(KYC): Creating BlockchainDataRepository.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 		AACE32012093FA1A00B7B806 /* ReminderPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE31FF2093FA1A00B7B806 /* ReminderPresenter.swift */; };
 		AACE32082097835F00B7B806 /* AuthenticationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE32072097835F00B7B806 /* AuthenticationManagerTests.swift */; };
 		AACE320B20978EB100B7B806 /* MockWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE320A20978EB100B7B806 /* MockWallet.swift */; };
-		AAD158DE2123740C0058B3C8 /* KYCDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD158DD2123740C0058B3C8 /* KYCDataRepository.swift */; };
+		AAD158DE2123740C0058B3C8 /* BlockchainDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD158DD2123740C0058B3C8 /* BlockchainDataRepository.swift */; };
 		AAD279B0209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD279AF209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift */; };
 		AAD279E0209A99DA00C0EAFC /* AVCaptureDeviceInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD279DF209A99D900C0EAFC /* AVCaptureDeviceInput.swift */; };
 		AAD27A28209CFE2100C0EAFC /* PasswordConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD27A27209CFE2100C0EAFC /* PasswordConfirmView.swift */; };
@@ -566,7 +566,7 @@
 		AAF2AEC4212379D800687E30 /* PersonalDetailsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8B224B211CA7990091E706 /* PersonalDetailsDelegate.swift */; };
 		AAF2AEC521237A1A00687E30 /* PersonalDetailsInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCF211CA2CD00E6C241 /* PersonalDetailsInterface.swift */; };
 		AAF2AEC621237A1F00687E30 /* PersonalDetailsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCC211C9C6500E6C241 /* PersonalDetailsService.swift */; };
-		AAF2AEE52123863200687E30 /* KYCDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD158DD2123740C0058B3C8 /* KYCDataRepository.swift */; };
+		AAF2AEE52123863200687E30 /* BlockchainDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD158DD2123740C0058B3C8 /* BlockchainDataRepository.swift */; };
 		AAFA97AE2115110000D19ED3 /* SettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FBE083211258F300AD514A /* SettingsCell.swift */; };
 		AAFA97AF2115110000D19ED3 /* SettingsTwoStepVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FBE084211258F300AD514A /* SettingsTwoStepVC.swift */; };
 		AAFA97B02115110000D19ED3 /* SettingsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FBE085211258F300AD514A /* SettingsProtocols.swift */; };
@@ -2841,7 +2841,7 @@
 		AACE31FF2093FA1A00B7B806 /* ReminderPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderPresenter.swift; sourceTree = "<group>"; };
 		AACE32072097835F00B7B806 /* AuthenticationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManagerTests.swift; sourceTree = "<group>"; };
 		AACE320A20978EB100B7B806 /* MockWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWallet.swift; sourceTree = "<group>"; };
-		AAD158DD2123740C0058B3C8 /* KYCDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCDataRepository.swift; sourceTree = "<group>"; };
+		AAD158DD2123740C0058B3C8 /* BlockchainDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchainDataRepository.swift; sourceTree = "<group>"; };
 		AAD279AF209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTwoFactorType.swift; sourceTree = "<group>"; };
 		AAD279DF209A99D900C0EAFC /* AVCaptureDeviceInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVCaptureDeviceInput.swift; sourceTree = "<group>"; };
 		AAD27A27209CFE2100C0EAFC /* PasswordConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordConfirmView.swift; sourceTree = "<group>"; };
@@ -3495,7 +3495,6 @@
 				602B9CCD2118E15200BD3D60 /* KYCAccountStatusController.swift */,
 				3A8B229E2122117A0091E706 /* KYCBaseViewController.swift */,
 				602B9CCE2118E15200BD3D60 /* KYCCoordinator.swift */,
-				AAD158DD2123740C0058B3C8 /* KYCDataRepository.swift */,
 				602B9CB12118E15200BD3D60 /* KYCNetworkRequest.swift */,
 				602B9CD12118E15200BD3D60 /* KYCOnboardingNavigationController.swift */,
 				602B9CD22118E15200BD3D60 /* KYCVerifyIdentityController.swift */,
@@ -5687,6 +5686,7 @@
 				AAD279DE209A99CA00C0EAFC /* AV */,
 				9F1831F315176F2200FB3D52 /* Categories */,
 				AAA33338208811460019AD55 /* Coordinators */,
+				AAF2AF0B2124946F00687E30 /* Data */,
 				510EA19620811FF100A63AB8 /* Extensions */,
 				AA63F87220A39D4E002B719B /* Feature Configuration */,
 				9F0CBAAB15135DF200CD945D /* JavaScript */,
@@ -6099,6 +6099,14 @@
 				AAE94F6720C75B8D005A3595 /* PinPresenterTests.swift */,
 			);
 			path = Pin;
+			sourceTree = "<group>";
+		};
+		AAF2AF0B2124946F00687E30 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				AAD158DD2123740C0058B3C8 /* BlockchainDataRepository.swift */,
+			);
+			path = Data;
 			sourceTree = "<group>";
 		};
 		C790E0F91E5205620063D141 /* Fonts */ = {
@@ -7035,7 +7043,7 @@
 				AAE9113620A520D40093A431 /* WalletAccountInfoDelegate.swift in Sources */,
 				AAF2AEC22123799800687E30 /* KYCPersonalDetailsController.swift in Sources */,
 				AA47709D211B7BC3006356B1 /* BottomButtonContainerView.swift in Sources */,
-				AAF2AEE52123863200687E30 /* KYCDataRepository.swift in Sources */,
+				AAF2AEE52123863200687E30 /* BlockchainDataRepository.swift in Sources */,
 				AACE31D22092A99B00B7B806 /* UINavigationController+PopToRootWithCompletion.swift in Sources */,
 				513C828720EBF30C00ECDE52 /* UIDevice+Biometrics.swift in Sources */,
 				AAF2AEC12123798C00687E30 /* PersonalDetailsAPI.swift in Sources */,
@@ -7447,7 +7455,7 @@
 				AA7E773F210BA48B009DFB4C /* AuthenticationCoordinator+Biometrics.swift in Sources */,
 				A269E92E1B32D51F0052F953 /* SecondPasswordViewController.swift in Sources */,
 				C76D732C20B2F5CD00040B57 /* WalletFiatAtTimeDelegate.swift in Sources */,
-				AAD158DE2123740C0058B3C8 /* KYCDataRepository.swift in Sources */,
+				AAD158DE2123740C0058B3C8 /* BlockchainDataRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -523,6 +523,7 @@
 		AACE32012093FA1A00B7B806 /* ReminderPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE31FF2093FA1A00B7B806 /* ReminderPresenter.swift */; };
 		AACE32082097835F00B7B806 /* AuthenticationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE32072097835F00B7B806 /* AuthenticationManagerTests.swift */; };
 		AACE320B20978EB100B7B806 /* MockWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACE320A20978EB100B7B806 /* MockWallet.swift */; };
+		AAD158DE2123740C0058B3C8 /* KYCDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD158DD2123740C0058B3C8 /* KYCDataRepository.swift */; };
 		AAD279B0209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD279AF209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift */; };
 		AAD279E0209A99DA00C0EAFC /* AVCaptureDeviceInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD279DF209A99D900C0EAFC /* AVCaptureDeviceInput.swift */; };
 		AAD27A28209CFE2100C0EAFC /* PasswordConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD27A27209CFE2100C0EAFC /* PasswordConfirmView.swift */; };
@@ -565,6 +566,7 @@
 		AAF2AEC4212379D800687E30 /* PersonalDetailsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8B224B211CA7990091E706 /* PersonalDetailsDelegate.swift */; };
 		AAF2AEC521237A1A00687E30 /* PersonalDetailsInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCF211CA2CD00E6C241 /* PersonalDetailsInterface.swift */; };
 		AAF2AEC621237A1F00687E30 /* PersonalDetailsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCC211C9C6500E6C241 /* PersonalDetailsService.swift */; };
+		AAF2AEE52123863200687E30 /* KYCDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD158DD2123740C0058B3C8 /* KYCDataRepository.swift */; };
 		AAFA97AE2115110000D19ED3 /* SettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FBE083211258F300AD514A /* SettingsCell.swift */; };
 		AAFA97AF2115110000D19ED3 /* SettingsTwoStepVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FBE084211258F300AD514A /* SettingsTwoStepVC.swift */; };
 		AAFA97B02115110000D19ED3 /* SettingsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FBE085211258F300AD514A /* SettingsProtocols.swift */; };
@@ -2839,6 +2841,7 @@
 		AACE31FF2093FA1A00B7B806 /* ReminderPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderPresenter.swift; sourceTree = "<group>"; };
 		AACE32072097835F00B7B806 /* AuthenticationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManagerTests.swift; sourceTree = "<group>"; };
 		AACE320A20978EB100B7B806 /* MockWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWallet.swift; sourceTree = "<group>"; };
+		AAD158DD2123740C0058B3C8 /* KYCDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCDataRepository.swift; sourceTree = "<group>"; };
 		AAD279AF209A5E7C00C0EAFC /* AuthenticationTwoFactorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTwoFactorType.swift; sourceTree = "<group>"; };
 		AAD279DF209A99D900C0EAFC /* AVCaptureDeviceInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVCaptureDeviceInput.swift; sourceTree = "<group>"; };
 		AAD27A27209CFE2100C0EAFC /* PasswordConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordConfirmView.swift; sourceTree = "<group>"; };
@@ -3489,9 +3492,10 @@
 		602B9CA62118E15200BD3D60 /* KYC */ = {
 			isa = PBXGroup;
 			children = (
-				3A8B229E2122117A0091E706 /* KYCBaseViewController.swift */,
 				602B9CCD2118E15200BD3D60 /* KYCAccountStatusController.swift */,
+				3A8B229E2122117A0091E706 /* KYCBaseViewController.swift */,
 				602B9CCE2118E15200BD3D60 /* KYCCoordinator.swift */,
+				AAD158DD2123740C0058B3C8 /* KYCDataRepository.swift */,
 				602B9CB12118E15200BD3D60 /* KYCNetworkRequest.swift */,
 				602B9CD12118E15200BD3D60 /* KYCOnboardingNavigationController.swift */,
 				602B9CD22118E15200BD3D60 /* KYCVerifyIdentityController.swift */,
@@ -7031,6 +7035,7 @@
 				AAE9113620A520D40093A431 /* WalletAccountInfoDelegate.swift in Sources */,
 				AAF2AEC22123799800687E30 /* KYCPersonalDetailsController.swift in Sources */,
 				AA47709D211B7BC3006356B1 /* BottomButtonContainerView.swift in Sources */,
+				AAF2AEE52123863200687E30 /* KYCDataRepository.swift in Sources */,
 				AACE31D22092A99B00B7B806 /* UINavigationController+PopToRootWithCompletion.swift in Sources */,
 				513C828720EBF30C00ECDE52 /* UIDevice+Biometrics.swift in Sources */,
 				AAF2AEC12123798C00687E30 /* PersonalDetailsAPI.swift in Sources */,
@@ -7442,6 +7447,7 @@
 				AA7E773F210BA48B009DFB4C /* AuthenticationCoordinator+Biometrics.swift in Sources */,
 				A269E92E1B32D51F0052F953 /* SecondPasswordViewController.swift in Sources */,
 				C76D732C20B2F5CD00040B57 /* WalletFiatAtTimeDelegate.swift in Sources */,
+				AAD158DE2123740C0058B3C8 /* KYCDataRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Blockchain/Data/BlockchainDataRepository.swift
+++ b/Blockchain/Data/BlockchainDataRepository.swift
@@ -1,5 +1,5 @@
 //
-//  KYCDataRepository.swift
+//  BlockchainDataRepository.swift
 //  Blockchain
 //
 //  Created by Chris Arriola on 8/14/18.
@@ -8,16 +8,16 @@
 
 import RxSwift
 
-/// Repository for KYC related data. Accessing properties in this repository
+/// Repository for fetching Blockchain data. Accessing properties in this repository
 /// will be fetched from the cache (if available), otherwise, data will be fetched over
 /// the network and subsequently cached for faster access.
-@objc class KYCDataRepository: NSObject {
+@objc class BlockchainDataRepository: NSObject {
 
-    static let shared = KYCDataRepository()
+    static let shared = BlockchainDataRepository()
 
     // MARK: - Public Properties
 
-    var user: Single<KYCUser> {
+    var kycUser: Single<KYCUser> {
         // TODO: need to fetch userID from wallet metadata
         // TICKET: IOS-1104
         return fetchData(

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -137,7 +137,7 @@ final class KYCCountrySelectionController: KYCBaseViewController, ProgressableVi
     // MARK: - Private Methods
 
     private func fetchListOfCountries() {
-        disposable = KYCDataRepository.shared.countries
+        disposable = BlockchainDataRepository.shared.countries
             .subscribeOn(MainScheduler.asyncInstance)
             .observeOn(MainScheduler.instance)
             .subscribe(onSuccess: { [weak self] countries in

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
 //
 
+import RxSwift
 import UIKit
 
 typealias Countries = [KYCCountry]
@@ -100,13 +101,22 @@ final class KYCCountrySelectionController: KYCBaseViewController, ProgressableVi
         return KYCCountrySelectionPresenter(view: self)
     }()
 
-    // MARK: Factory
+    private var disposable: Disposable?
+
+    // MARK: - Factory
 
     override class func make(with coordinator: KYCCoordinator) -> KYCCountrySelectionController {
         let controller = makeFromStoryboard()
         controller.coordinator = coordinator
         controller.pageType = .country
         return controller
+    }
+
+    // MARK: - View Controller Lifecycle
+
+    deinit {
+        disposable?.dispose()
+        disposable = nil
     }
 
     override func viewDidLoad() {
@@ -127,17 +137,15 @@ final class KYCCountrySelectionController: KYCBaseViewController, ProgressableVi
     // MARK: - Private Methods
 
     private func fetchListOfCountries() {
-        KYCNetworkRequest(get: .listOfCountries, taskSuccess: { [weak self] responseData in
-            do {
-                let allCountries = try JSONDecoder().decode(Countries.self, from: responseData)
-                self?.countriesMap.setAllCountries(allCountries)
+        disposable = KYCDataRepository.shared.countries
+            .subscribeOn(MainScheduler.asyncInstance)
+            .observeOn(MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] countries in
+                self?.countriesMap.setAllCountries(countries)
                 self?.tableView.reloadData()
-            } catch {
-                Logger.shared.error("Failed to parse countries list.")
-            }
-        }, taskFailure: { error in
-            Logger.shared.error(error.debugDescription)
-        })
+            }, onError: { error in
+                Logger.shared.error("Failed to fetch countries. Error: \(error.localizedDescription)")
+            })
     }
 }
 
@@ -204,8 +212,7 @@ extension KYCCountrySelectionController: UITableViewDataSource, UITableViewDeleg
 
 extension KYCCountrySelectionController: KYCCountrySelectionView {
     func continueKycFlow(country: KYCCountry) {
-        // TICKET: IOS-1142 - move to coordinator
-        performSegue(withIdentifier: "promptForPersonalDetails", sender: self)
+        coordinator.handle(event: .nextPageFromPageType(pageType))
     }
 
     func startPartnerExchangeFlow(country: KYCCountry) {

--- a/Blockchain/KYC/KYCDataRepository.swift
+++ b/Blockchain/KYC/KYCDataRepository.swift
@@ -1,0 +1,75 @@
+//
+//  KYCDataRepository.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/14/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import RxSwift
+
+/// Repository for KYC related data. Accessing properties in this repository
+/// will be fetched from the cache (if available), otherwise, data will be fetched over
+/// the network and subsequently cached for faster access.
+@objc class KYCDataRepository: NSObject {
+
+    static let shared = KYCDataRepository()
+
+    // MARK: - Public Properties
+
+    var user: Single<KYCUser> {
+        // TODO: need to fetch userID from wallet metadata
+        // TICKET: IOS-1104
+        return fetchData(
+            cachedValue: cachedUser,
+            networkValue: networkRequest(get: .users(userID: "userID"), type: KYCUser.self)
+        )
+    }
+
+    var countries: Single<Countries> {
+        return fetchData(
+            cachedValue: cachedCountries,
+            networkValue: networkRequest(get: .listOfCountries, type: Countries.self)
+        )
+    }
+
+    // MARK: - Private Properties
+
+    private var cachedCountries = Variable<Countries?>(nil)
+    private var cachedUser = Variable<KYCUser?>(nil)
+
+    // MARK: - Private Methods
+
+    private func fetchData<ResponseType: Decodable>(
+        cachedValue: Variable<ResponseType?>,
+        networkValue: Single<ResponseType>
+    ) -> Single<ResponseType> {
+        return Single.deferred {
+            guard let cachedValue = cachedValue.value else {
+                return networkValue
+            }
+            return Single.just(cachedValue)
+        }.do(onSuccess: { response in
+            cachedValue.value = response
+        })
+    }
+
+    private func networkRequest<ResponseType: Decodable>(
+        get url: KYCNetworkRequest.KYCEndpoints.GET,
+        type: ResponseType.Type
+    ) -> Single<ResponseType> {
+        return Single.create(subscribe: { observer -> Disposable in
+            KYCNetworkRequest(get: url, taskSuccess: { responseData in
+                do {
+                    let response = try JSONDecoder().decode(type.self, from: responseData)
+                    observer(.success(response))
+                } catch {
+                    observer(.error(error))
+                }
+            }, taskFailure: { error in
+                observer(.error(error))
+            })
+            return Disposables.create()
+        })
+    }
+}


### PR DESCRIPTION
## Objective

Creating KYCDataRepository. A component that handles fetching KYC-related models (user, countries, etc.)

## Description

`KYCDataRepository` is a component wherein layers can retrieve KYC-related data, such as the current `KYCUser`, while being agnostic as to where data is being fetched from. The 1st time a property in `KYCDataRepository` is accessed, it will be retrieved over the network followed by caching in memory. Callers are all provided a `Single<KYCData: Decodable>` type regardless if data is coming from memory or over the network.

Open to feedback if you guys think something like this is a good idea for other components to use (e.g. we can update `KYCCoordinator` to use this as well as the settings view for accessing a `KYCUser`)

## How to Test

Pull in these changes and launch the KYC feature. At the moment, only `KYCCountrySelectionController` is using this component. To verify that it's accessing cached data, enter/exit a couple times from the `KYCWelcomeController` to `KYCCountrySelectionController`.

## Screenshot

N/A

## Related Information

* Ticket Number: N/A

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [X] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
