### PR TITLE
style(KYC): UI polish for Address input scren

### DIFF
--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -218,6 +218,10 @@ extension KYCAddressController: LocationSuggestionInterface {
         tableView.alpha = visibility.defaultAlpha
     }
 
+    func primaryButton(_ visibility: Visibility) {
+        primaryButtonContainer.alpha = visibility.defaultAlpha
+    }
+
     func searchFieldActive(_ isFirstResponder: Bool) {
         switch isFirstResponder {
         case true:

--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -145,6 +145,7 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
             self?.scrollView.setContentOffset(.zero, animated: true)
             guard let keyboard = self?.keyboard else { return }
             self?.keyboardWillHide(with: keyboard)
+            self?.keyboard = nil
         }
         NotificationCenter.when(.UIKeyboardWillShow) { [weak self] notification in
             let keyboard = KeyboardPayload(notification: notification)

--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -23,7 +23,6 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView {
     @IBOutlet fileprivate var cityTextField: ValidationTextField!
     @IBOutlet fileprivate var stateTextField: ValidationTextField!
     @IBOutlet fileprivate var postalCodeTextField: ValidationTextField!
-    @IBOutlet fileprivate var countryTextField: ValidationTextField!
     @IBOutlet fileprivate var primaryButtonContainer: PrimaryButtonContainer!
 
     // MARK: - Public IBOutlets
@@ -33,8 +32,7 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView {
     // MARK: Factory
 
     override class func make(with coordinator: KYCCoordinator) -> KYCAddressController {
-        let storyboard = UIStoryboard(name: "KYCAddress", bundle: nil)
-        let controller = storyboard.instantiateInitialViewController() as! KYCAddressController
+        let controller = makeFromStoryboard()
         controller.coordinator = coordinator
         controller.pageType = .address
         return controller
@@ -53,8 +51,7 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView {
                     apartmentTextField,
                     cityTextField,
                     stateTextField,
-                    postalCodeTextField,
-                    countryTextField
+                    postalCodeTextField
             ]
         }
     }
@@ -112,11 +109,8 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView {
         stateTextField.returnKeyType = .next
         stateTextField.contentType = .addressState
 
-        postalCodeTextField.returnKeyType = .next
+        postalCodeTextField.returnKeyType = .done
         postalCodeTextField.contentType = .postalCode
-
-        countryTextField.returnKeyType = .done
-        countryTextField.contentType = .countryName
 
         validationFields.enumerated().forEach { (index, field) in
             field.returnTappedBlock = { [weak self] in
@@ -154,7 +148,7 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView {
             postalCode: postalCodeTextField.text ?? "",
             city: cityTextField.text ?? "",
             state: stateTextField.text ?? "",
-            country: countryTextField.text ?? ""
+            country: ""
         )
         searchDelegate?.onSubmission(address, completion: { [weak self] in
             guard let this = self else { return }
@@ -199,7 +193,6 @@ extension KYCAddressController: LocationSuggestionInterface {
         cityTextField.text = address.city
         stateTextField.text = address.state
         postalCodeTextField.text = address.postalCode
-        countryTextField.text = address.country
     }
 
     func updateActivityIndicator(_ visibility: Visibility) {

--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -157,7 +157,9 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
     fileprivate func primaryButtonTapped() {
         guard checkFieldsValidity() else { return }
         validationFields.forEach({$0.resignFocus()})
-        
+
+        // TODO: ⚠️ The address country should be injected
+        // into this screen. 
         let address = UserAddress(
             lineOne: addressTextField.text ?? "",
             lineTwo: apartmentTextField.text ?? "",

--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -8,7 +8,12 @@
 
 import UIKit
 
-class KYCAddressController: KYCBaseViewController, ValidationFormView {
+class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomButtonContainerView {
+
+    // MARK: BottomButtonContainerView
+
+    var originalBottomButtonConstraint: CGFloat!
+    @IBOutlet var layoutConstraintBottomButton: NSLayoutConstraint!
 
     // MARK: - Private IBOutlets
 
@@ -80,13 +85,20 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView {
 
         validationFieldsSetup()
         setupNotifications()
+        setUpBottomButtonContainerView()
 
         primaryButtonContainer.actionBlock = { [weak self] in
             guard let this = self else { return }
             this.primaryButtonTapped()
         }
 
+        originalBottomButtonConstraint = layoutConstraintBottomButton.constant
+
         searchDelegate?.onStart()
+    }
+
+    deinit {
+        cleanUp()
     }
 
     // MARK: Private Functions
@@ -131,9 +143,12 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView {
         NotificationCenter.when(.UIKeyboardWillHide) { [weak self] _ in
             self?.scrollView.contentInset = .zero
             self?.scrollView.setContentOffset(.zero, animated: true)
+            guard let keyboard = self?.keyboard else { return }
+            self?.keyboardWillHide(with: keyboard)
         }
         NotificationCenter.when(.UIKeyboardWillShow) { [weak self] notification in
             let keyboard = KeyboardPayload(notification: notification)
+            self?.keyboardWillShow(with: keyboard)
             self?.keyboard = keyboard
         }
     }

--- a/Blockchain/KYC/Search/API/LocationSuggestionInterface.swift
+++ b/Blockchain/KYC/Search/API/LocationSuggestionInterface.swift
@@ -11,6 +11,7 @@ protocol LocationSuggestionInterface: class {
     func suggestionsList(_ visibility: Visibility)
     func addressEntryView(_ visibility: Visibility)
     func primaryButtonEnabled(_ enabled: Bool)
+    func primaryButton(_ visibility: Visibility)
     func primaryButtonActivityIndicator(_ visibility: Visibility)
     func populateAddressEntryView(_ address: PostalAddress)
     func searchFieldActive(_ isFirstResponder: Bool)

--- a/Blockchain/KYC/Search/LocationSuggestionCoordinator.swift
+++ b/Blockchain/KYC/Search/LocationSuggestionCoordinator.swift
@@ -45,9 +45,11 @@ extension LocationSuggestionCoordinator: SearchControllerDelegate {
         switch model.suggestions.isEmpty {
         case true:
             interface?.searchFieldText(nil)
+            interface?.primaryButton(.visible)
             interface?.suggestionsList(.hidden)
             interface?.addressEntryView(.visible)
         case false:
+            interface?.primaryButton(.hidden)
             interface?.suggestionsList(.visible)
             interface?.addressEntryView(.hidden)
         }
@@ -69,6 +71,7 @@ extension LocationSuggestionCoordinator: SearchControllerDelegate {
         if let input = selection as? LocationSuggestion {
             interface?.searchFieldText("\(input.title) \(input.subtitle)")
             interface?.suggestionsList(.hidden)
+            interface?.primaryButton(.visible)
             interface?.updateActivityIndicator(.visible)
             service.fetchAddress(from: input) { [weak self] (address) in
                 guard let this = self else { return }
@@ -137,6 +140,7 @@ extension LocationSuggestionCoordinator: SearchControllerDelegate {
     func onSearchViewCancel() {
         interface?.searchFieldActive(false)
         interface?.suggestionsList(.hidden)
+        interface?.primaryButton(.visible)
         interface?.addressEntryView(.visible)
         guard service.isExecuting else { return }
         service.cancel()

--- a/Blockchain/KYC/Search/LocationSuggestionCoordinator.swift
+++ b/Blockchain/KYC/Search/LocationSuggestionCoordinator.swift
@@ -36,8 +36,6 @@ class LocationSuggestionCoordinator: NSObject {
         if let controller = delegate as? KYCAddressController {
             controller.searchDelegate = self
         }
-
-        self.interface?.searchFieldActive(true)
     }
 }
 

--- a/Blockchain/KYC/Storyboards/KYCAddressController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCAddressController.storyboard
@@ -221,6 +221,7 @@
                         <outlet property="addressTextField" destination="HnA-P2-2Gj" id="Gl8-tC-Ya0"/>
                         <outlet property="apartmentTextField" destination="5mF-Bq-VW9" id="P4y-WS-nbX"/>
                         <outlet property="cityTextField" destination="j8H-Lr-LlB" id="C3k-xF-5Hp"/>
+                        <outlet property="layoutConstraintBottomButton" destination="mQa-gA-TTY" id="fO2-mo-UgL"/>
                         <outlet property="postalCodeTextField" destination="LF7-ax-XE2" id="1zJ-7Y-SwY"/>
                         <outlet property="primaryButtonContainer" destination="bhb-q7-xBR" id="0UF-pO-SuD"/>
                         <outlet property="progressView" destination="LU7-BL-Zrb" id="0lU-I7-mIU"/>

--- a/Blockchain/KYC/Storyboards/KYCAddressController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCAddressController.storyboard
@@ -19,34 +19,29 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="What is my address used for?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TVk-mv-RzC">
-                                <rect key="frame" x="16" y="80" width="288" height="15"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="LU7-BL-Zrb">
                                 <rect key="frame" x="0.0" y="64" width="320" height="8"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="8" id="Sev-w9-pJR"/>
                                 </constraints>
                             </progressView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="999" text="We may send a verification postcard for added security." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zsH-tV-aX0">
-                                <rect key="frame" x="16" y="97" width="288" height="29"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fkm-6J-r0r">
-                                <rect key="frame" x="0.0" y="190.5" width="320" height="377.5"/>
+                                <rect key="frame" x="0.0" y="136.5" width="320" height="431.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <inset key="scrollIndicatorInsets" minX="18" minY="0.0" maxX="0.0" maxY="0.0"/>
                             </tableView>
+                            <searchBar contentMode="redraw" verticalHuggingPriority="751" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="6g6-gf-4D1">
+                                <rect key="frame" x="8" y="80" width="304" height="56"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="56" id="Wz6-6Z-OCC"/>
+                                </constraints>
+                                <textInputTraits key="textInputTraits"/>
+                            </searchBar>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HTQ-Da-JDA">
-                                <rect key="frame" x="0.0" y="190.5" width="320" height="377.5"/>
+                                <rect key="frame" x="0.0" y="136" width="320" height="340"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HnA-P2-2Gj" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="0.0" width="288" height="56"/>
+                                        <rect key="frame" x="16" y="54" width="288" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="qiA-WP-2m1"/>
@@ -64,7 +59,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5mF-Bq-VW9" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="56" width="288" height="56"/>
+                                        <rect key="frame" x="16" y="110" width="288" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="OZn-hW-Aaj"/>
@@ -81,7 +76,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j8H-Lr-LlB" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="112" width="288" height="56"/>
+                                        <rect key="frame" x="16" y="166" width="288" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="vO7-yX-H6J"/>
@@ -99,7 +94,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MQL-tY-eAz" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="168" width="136" height="56"/>
+                                        <rect key="frame" x="16" y="222" width="136" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="gxq-ds-nCp"/>
@@ -117,7 +112,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LF7-ax-XE2" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="167.5" y="168" width="136.5" height="56"/>
+                                        <rect key="frame" x="167.5" y="222" width="136.5" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="5Kb-Nc-YfN"/>
@@ -134,100 +129,84 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZL2-vY-uhQ" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="224" width="288.5" height="56"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="56" id="elD-gS-93M"/>
-                                        </constraints>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Country"/>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
-                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
-                                                <color key="value" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bhb-q7-xBR" customClass="PrimaryButtonContainer" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="312" width="288.5" height="44"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="7OT-yL-tsy"/>
-                                        </constraints>
-                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="What is my address used for?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TVk-mv-RzC">
+                                        <rect key="frame" x="16" y="0.0" width="288" height="15"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="999" text="We may send a verification postcard for added security." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zsH-tV-aX0">
+                                        <rect key="frame" x="16" y="17" width="288" height="29"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="j8H-Lr-LlB" firstAttribute="leading" secondItem="5mF-Bq-VW9" secondAttribute="leading" id="0RP-bO-K2v"/>
                                     <constraint firstItem="LF7-ax-XE2" firstAttribute="trailing" secondItem="j8H-Lr-LlB" secondAttribute="trailing" id="1l7-Cb-xaE"/>
+                                    <constraint firstItem="TVk-mv-RzC" firstAttribute="top" secondItem="HTQ-Da-JDA" secondAttribute="top" id="8Ra-M9-J1t"/>
                                     <constraint firstItem="j8H-Lr-LlB" firstAttribute="top" secondItem="5mF-Bq-VW9" secondAttribute="bottom" id="9dF-M6-NLJ"/>
                                     <constraint firstItem="j8H-Lr-LlB" firstAttribute="width" secondItem="5mF-Bq-VW9" secondAttribute="width" id="9hf-ex-7fK"/>
-                                    <constraint firstItem="bhb-q7-xBR" firstAttribute="leading" secondItem="HTQ-Da-JDA" secondAttribute="leading" constant="16" id="C8u-Of-jg4"/>
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="top" secondItem="HnA-P2-2Gj" secondAttribute="bottom" id="Db8-K7-5xO"/>
                                     <constraint firstItem="MQL-tY-eAz" firstAttribute="leading" secondItem="j8H-Lr-LlB" secondAttribute="leading" id="Egi-9K-lbW"/>
-                                    <constraint firstItem="ZL2-vY-uhQ" firstAttribute="trailing" secondItem="LF7-ax-XE2" secondAttribute="trailing" id="Epb-FU-gzE"/>
                                     <constraint firstItem="HnA-P2-2Gj" firstAttribute="width" secondItem="HTQ-Da-JDA" secondAttribute="width" constant="-32" id="Jyz-vG-0JH"/>
-                                    <constraint firstItem="HnA-P2-2Gj" firstAttribute="top" secondItem="HTQ-Da-JDA" secondAttribute="top" id="MC2-SN-VnN"/>
+                                    <constraint firstItem="zsH-tV-aX0" firstAttribute="top" secondItem="TVk-mv-RzC" secondAttribute="bottom" constant="2" id="Pwb-jJ-RLZ"/>
                                     <constraint firstItem="MQL-tY-eAz" firstAttribute="trailing" secondItem="j8H-Lr-LlB" secondAttribute="centerX" constant="-8" id="QLk-Yl-ULp"/>
                                     <constraint firstItem="MQL-tY-eAz" firstAttribute="top" secondItem="j8H-Lr-LlB" secondAttribute="bottom" id="aPV-xw-zye"/>
+                                    <constraint firstAttribute="bottom" secondItem="MQL-tY-eAz" secondAttribute="bottom" id="cot-jt-cOH"/>
                                     <constraint firstItem="HnA-P2-2Gj" firstAttribute="leading" secondItem="HTQ-Da-JDA" secondAttribute="leading" constant="16" id="gmy-jw-t42"/>
-                                    <constraint firstAttribute="trailing" secondItem="bhb-q7-xBR" secondAttribute="trailing" constant="16" id="hAo-we-trs"/>
-                                    <constraint firstItem="ZL2-vY-uhQ" firstAttribute="top" secondItem="MQL-tY-eAz" secondAttribute="bottom" id="meY-DE-dYh"/>
                                     <constraint firstItem="LF7-ax-XE2" firstAttribute="top" secondItem="j8H-Lr-LlB" secondAttribute="bottom" id="nLG-mU-QFX"/>
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="leading" secondItem="HnA-P2-2Gj" secondAttribute="leading" id="nT3-YY-MhI"/>
-                                    <constraint firstItem="bhb-q7-xBR" firstAttribute="width" secondItem="ZL2-vY-uhQ" secondAttribute="width" id="phP-U6-Qdw"/>
+                                    <constraint firstItem="HnA-P2-2Gj" firstAttribute="top" secondItem="zsH-tV-aX0" secondAttribute="bottom" constant="8" id="nw1-NY-jhH"/>
+                                    <constraint firstItem="zsH-tV-aX0" firstAttribute="trailing" secondItem="TVk-mv-RzC" secondAttribute="trailing" id="oBT-ma-W1E"/>
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="height" secondItem="HnA-P2-2Gj" secondAttribute="height" id="qJ0-ut-CxM"/>
+                                    <constraint firstAttribute="trailing" secondItem="HnA-P2-2Gj" secondAttribute="trailing" constant="16" id="ro4-4Z-JhY"/>
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="width" secondItem="HnA-P2-2Gj" secondAttribute="width" id="sWF-2c-nZN"/>
+                                    <constraint firstItem="zsH-tV-aX0" firstAttribute="leading" secondItem="TVk-mv-RzC" secondAttribute="leading" id="shJ-4e-F6e"/>
                                     <constraint firstItem="LF7-ax-XE2" firstAttribute="leading" secondItem="j8H-Lr-LlB" secondAttribute="centerX" constant="8" id="uub-Jl-NzC"/>
-                                    <constraint firstAttribute="bottom" secondItem="bhb-q7-xBR" secondAttribute="bottom" constant="30" id="vG7-JH-3YO"/>
-                                    <constraint firstItem="bhb-q7-xBR" firstAttribute="top" secondItem="ZL2-vY-uhQ" secondAttribute="bottom" constant="32" id="wdJ-bf-SZb"/>
-                                    <constraint firstItem="ZL2-vY-uhQ" firstAttribute="leading" secondItem="MQL-tY-eAz" secondAttribute="leading" id="yPr-80-8l4"/>
                                 </constraints>
                                 <connections>
                                     <outlet property="delegate" destination="1m4-Wz-u3W" id="GHu-es-UQT"/>
                                 </connections>
                             </scrollView>
                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="FFX-OX-l36">
-                                <rect key="frame" x="141.5" y="361.5" width="37" height="37"/>
+                                <rect key="frame" x="141.5" y="334" width="37" height="37"/>
                                 <color key="color" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </activityIndicatorView>
-                            <searchBar contentMode="redraw" verticalHuggingPriority="751" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="6g6-gf-4D1">
-                                <rect key="frame" x="8" y="134.5" width="304" height="56"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bhb-q7-xBR" customClass="PrimaryButtonContainer" customModule="Blockchain" customModuleProvider="target">
+                                <rect key="frame" x="16" y="508" width="287.5" height="44"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="56" id="Wz6-6Z-OCC"/>
+                                    <constraint firstAttribute="height" constant="44" id="7OT-yL-tsy"/>
                                 </constraints>
-                                <textInputTraits key="textInputTraits"/>
-                            </searchBar>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="FFX-OX-l36" firstAttribute="centerX" secondItem="fkm-6J-r0r" secondAttribute="centerX" id="0Ut-0l-I7u"/>
-                            <constraint firstItem="AxH-7G-UPE" firstAttribute="bottom" secondItem="HTQ-Da-JDA" secondAttribute="bottom" id="A18-c2-u3I"/>
+                            <constraint firstItem="AxH-7G-UPE" firstAttribute="trailing" secondItem="bhb-q7-xBR" secondAttribute="trailing" constant="16" id="3ol-UA-lS5"/>
+                            <constraint firstItem="AxH-7G-UPE" firstAttribute="bottom" secondItem="HTQ-Da-JDA" secondAttribute="bottom" constant="92" id="6ml-qb-GDk"/>
                             <constraint firstItem="LU7-BL-Zrb" firstAttribute="top" secondItem="AxH-7G-UPE" secondAttribute="top" id="CrN-Ju-eUo"/>
-                            <constraint firstItem="zsH-tV-aX0" firstAttribute="trailing" secondItem="TVk-mv-RzC" secondAttribute="trailing" id="EPc-xP-5Hd"/>
+                            <constraint firstItem="TVk-mv-RzC" firstAttribute="trailing" secondItem="6g6-gf-4D1" secondAttribute="trailing" constant="-8" id="DWW-Xs-MOP"/>
                             <constraint firstItem="HTQ-Da-JDA" firstAttribute="top" secondItem="6g6-gf-4D1" secondAttribute="bottom" id="HmF-fx-8n3"/>
                             <constraint firstItem="AxH-7G-UPE" firstAttribute="trailing" secondItem="fkm-6J-r0r" secondAttribute="trailing" id="IYJ-gN-uYx"/>
                             <constraint firstItem="6g6-gf-4D1" firstAttribute="leading" secondItem="AxH-7G-UPE" secondAttribute="leading" constant="8" id="MDA-LB-MFx"/>
                             <constraint firstItem="HTQ-Da-JDA" firstAttribute="top" secondItem="6g6-gf-4D1" secondAttribute="bottom" id="NAG-lx-eGZ"/>
-                            <constraint firstItem="TVk-mv-RzC" firstAttribute="leading" secondItem="AxH-7G-UPE" secondAttribute="leading" constant="16" id="PTM-4b-NZA"/>
-                            <constraint firstItem="6g6-gf-4D1" firstAttribute="top" secondItem="zsH-tV-aX0" secondAttribute="bottom" constant="8" id="W4a-r2-oKr"/>
+                            <constraint firstItem="6g6-gf-4D1" firstAttribute="top" secondItem="LU7-BL-Zrb" secondAttribute="bottom" constant="8" id="P8D-R4-GLd"/>
                             <constraint firstItem="HTQ-Da-JDA" firstAttribute="top" secondItem="6g6-gf-4D1" secondAttribute="bottom" id="X7I-lC-XMT"/>
-                            <constraint firstItem="zsH-tV-aX0" firstAttribute="leading" secondItem="TVk-mv-RzC" secondAttribute="leading" id="ana-Sh-3ms"/>
                             <constraint firstItem="fkm-6J-r0r" firstAttribute="leading" secondItem="AxH-7G-UPE" secondAttribute="leading" id="bXa-KO-AG8"/>
-                            <constraint firstItem="TVk-mv-RzC" firstAttribute="top" secondItem="LU7-BL-Zrb" secondAttribute="bottom" constant="8" id="cEl-pe-pp2"/>
                             <constraint firstItem="AxH-7G-UPE" firstAttribute="trailing" secondItem="6g6-gf-4D1" secondAttribute="trailing" constant="8" id="eXM-Ti-fr6"/>
                             <constraint firstItem="HTQ-Da-JDA" firstAttribute="width" secondItem="fkm-6J-r0r" secondAttribute="width" id="fGV-2G-FUa"/>
                             <constraint firstAttribute="trailing" secondItem="LU7-BL-Zrb" secondAttribute="trailing" id="fdv-7i-NAs"/>
                             <constraint firstItem="FFX-OX-l36" firstAttribute="centerY" secondItem="fkm-6J-r0r" secondAttribute="centerY" id="gEx-Xs-EYn"/>
-                            <constraint firstItem="zsH-tV-aX0" firstAttribute="top" secondItem="TVk-mv-RzC" secondAttribute="bottom" constant="2" id="gOe-ea-Xx7"/>
                             <constraint firstItem="AxH-7G-UPE" firstAttribute="bottom" secondItem="fkm-6J-r0r" secondAttribute="bottom" id="gZO-b6-sp3"/>
+                            <constraint firstItem="TVk-mv-RzC" firstAttribute="leading" secondItem="6g6-gf-4D1" secondAttribute="leading" constant="8" id="hJZ-Mr-1UM"/>
+                            <constraint firstItem="bhb-q7-xBR" firstAttribute="leading" secondItem="AxH-7G-UPE" secondAttribute="leading" constant="16" id="kXq-zY-apF"/>
+                            <constraint firstItem="AxH-7G-UPE" firstAttribute="bottom" secondItem="bhb-q7-xBR" secondAttribute="bottom" constant="16" id="mQa-gA-TTY"/>
                             <constraint firstItem="fkm-6J-r0r" firstAttribute="top" secondItem="6g6-gf-4D1" secondAttribute="bottom" id="rId-YP-cpw"/>
                             <constraint firstItem="AxH-7G-UPE" firstAttribute="trailing" secondItem="HTQ-Da-JDA" secondAttribute="trailing" id="v5U-T5-WcD"/>
-                            <constraint firstItem="AxH-7G-UPE" firstAttribute="trailing" secondItem="TVk-mv-RzC" secondAttribute="trailing" constant="16" id="w1O-eC-jGk"/>
                             <constraint firstItem="HTQ-Da-JDA" firstAttribute="leading" secondItem="AxH-7G-UPE" secondAttribute="leading" id="wYk-lH-ypQ"/>
                             <constraint firstItem="LU7-BL-Zrb" firstAttribute="leading" secondItem="6kS-bR-6h1" secondAttribute="leading" id="zkI-JF-v6V"/>
                         </constraints>
@@ -242,7 +221,6 @@
                         <outlet property="addressTextField" destination="HnA-P2-2Gj" id="Gl8-tC-Ya0"/>
                         <outlet property="apartmentTextField" destination="5mF-Bq-VW9" id="P4y-WS-nbX"/>
                         <outlet property="cityTextField" destination="j8H-Lr-LlB" id="C3k-xF-5Hp"/>
-                        <outlet property="countryTextField" destination="ZL2-vY-uhQ" id="1MF-yD-Xle"/>
                         <outlet property="postalCodeTextField" destination="LF7-ax-XE2" id="1zJ-7Y-SwY"/>
                         <outlet property="primaryButtonContainer" destination="bhb-q7-xBR" id="0UF-pO-SuD"/>
                         <outlet property="progressView" destination="LU7-BL-Zrb" id="0lU-I7-mIU"/>

--- a/Blockchain/KYC/Views/BottomButtonContainerView.swift
+++ b/Blockchain/KYC/Views/BottomButtonContainerView.swift
@@ -35,7 +35,7 @@ extension BottomButtonContainerView where Self: UIViewController {
         NotificationCenter.default.removeObserver(self)
     }
 
-    private func keyboardWillShow(with payload: KeyboardPayload) {
+    func keyboardWillShow(with payload: KeyboardPayload) {
         UIView.beginAnimations(nil, context: nil)
         UIView.setAnimationDuration(payload.animationDuration)
         UIView.setAnimationCurve(payload.animationCurve)
@@ -44,7 +44,7 @@ extension BottomButtonContainerView where Self: UIViewController {
         UIView.commitAnimations()
     }
 
-    private func keyboardWillHide(with payload: KeyboardPayload) {
+    func keyboardWillHide(with payload: KeyboardPayload) {
         UIView.beginAnimations(nil, context: nil)
         UIView.setAnimationDuration(payload.animationDuration)
         UIView.setAnimationCurve(payload.animationCurve)

--- a/Blockchain/Views/ValidationForm/ValidationFormView.swift
+++ b/Blockchain/Views/ValidationForm/ValidationFormView.swift
@@ -49,21 +49,11 @@ extension ValidationFormView where Self: UIViewController {
                 )
                 this.scrollView.contentInset = insets
 
-                let viewSize = CGSize(
-                    width: this.scrollView.frame.width,
-                    height: this.scrollView.frame.height - height
+                let offset = CGPoint(
+                    x: 0.0,
+                    y: validationField.frame.minY
                 )
-                let viewableFrame = CGRect(
-                    origin: this.scrollView.frame.origin,
-                    size: viewSize
-                )
-
-                if !viewableFrame.contains(validationField.frame.origin) {
-                    this.scrollView.scrollRectToVisible(
-                        validationField.frame,
-                        animated: true
-                    )
-                }
+                this.scrollView.setContentOffset(offset, animated: true)
             }
         }
     }


### PR DESCRIPTION
## Objective

This implements a few polish items for the address input screen.

## Description

* The `primaryButton` is always above the keyboard
* The currently in focus textField is at the top of the `UIScrollView` 
* The description labels are within the `UIScrollView`
* The `UISearchBar` is now above the `UIScrollView`

## How to Test

1. Build and run
2. Go to the debug KYC flow
3. Go to the address screen. (Note: you may need to hardcode this in `screenFor(pageType:)` in the `KYCCoordinator`)
4. Use the `UISearchBar`.
5. Enter values in the fields.
6. Observe the `primaryButton`. Observe the scrolling behavior.

## Screenshot

![screen shot 2018-08-15 at 10 36 03 am](https://user-images.githubusercontent.com/41585563/44157356-ddf25a00-a077-11e8-8de4-ba1a28446c71.png)
![screen shot 2018-08-15 at 10 36 08 am](https://user-images.githubusercontent.com/41585563/44157358-dfbc1d80-a077-11e8-93bc-55f4e76ed21c.png)

## Related Information

* Ticket Number: N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
