### PR TITLE
prototype(Networking): Stubbing out basic networking layer.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -103,9 +103,9 @@
 		3AC4F982212349BF003AA207 /* PersonalDetailsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCC211C9C6500E6C241 /* PersonalDetailsService.swift */; };
 		3AC4F983212349CB003AA207 /* PersonalDetailsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DC5211C992B00E6C241 /* PersonalDetailsAPI.swift */; };
 		3AC4F9A42124B4BA003AA207 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC4F9A32124B4BA003AA207 /* AsyncOperation.swift */; };
-		3AC4F9A62124B77D003AA207 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC4F9A52124B77D003AA207 /* Result.swift */; };
 		3AC4F9A92124B893003AA207 /* NetworkOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC4F9A82124B893003AA207 /* NetworkOperation.swift */; };
 		3AC4F9AC2124B8CE003AA207 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC4F9AB2124B8CE003AA207 /* NetworkRequest.swift */; };
+		3AC4F9C52124CCC5003AA207 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC4F9C42124CCC5003AA207 /* Result.swift */; };
 		3AC9755A210FBD10006A9263 /* NSAttributedString+Conveniences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */; };
 		3AC9755B210FBD10006A9263 /* NSAttributedString+Conveniences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */; };
 		3AD7EE7621124F0C006B924F /* ValidationTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD7EE7521124F0C006B924F /* ValidationTextField.swift */; };
@@ -1107,9 +1107,9 @@
 		3A8B229E2122117A0091E706 /* KYCBaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCBaseViewController.swift; sourceTree = "<group>"; };
 		3AC4F97721234040003AA207 /* Storyboardable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storyboardable.swift; sourceTree = "<group>"; };
 		3AC4F9A32124B4BA003AA207 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
-		3AC4F9A52124B77D003AA207 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		3AC4F9A82124B893003AA207 /* NetworkOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkOperation.swift; sourceTree = "<group>"; };
 		3AC4F9AB2124B8CE003AA207 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
+		3AC4F9C42124CCC5003AA207 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Conveniences.swift"; sourceTree = "<group>"; };
 		3AD7EE7521124F0C006B924F /* ValidationTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationTextField.swift; sourceTree = "<group>"; };
 		3AD7EE9F21125156006B924F /* ValidationTextField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ValidationTextField.xib; sourceTree = "<group>"; };
@@ -3267,7 +3267,7 @@
 		3AC4F9AA2124B8B5003AA207 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				3AC4F9A52124B77D003AA207 /* Result.swift */,
+				3AC4F9C42124CCC5003AA207 /* Result.swift */,
 				3AC4F9AB2124B8CE003AA207 /* NetworkRequest.swift */,
 			);
 			path = Models;
@@ -7199,7 +7199,6 @@
 				51A7349320891EB3009727D5 /* NetworkManager.swift in Sources */,
 				606399EA2110FC2D005B6DF5 /* SRDelegateController.m in Sources */,
 				3AE92BDB2110DB3C008D7BDC /* KeyboardPayload.swift in Sources */,
-				3AC4F9A62124B77D003AA207 /* Result.swift in Sources */,
 				C7559CB21F56FE09005B2375 /* TransactionsEtherViewController.m in Sources */,
 				AA1E522B2097CA360099BD10 /* AuthenticationCoordinator.swift in Sources */,
 				23FDEFAC1D6F669100FC80D6 /* NSURLSession+SendSynchronousRequest.m in Sources */,
@@ -7347,6 +7346,7 @@
 				C7559CBA1F573763005B2375 /* EtherTransaction.m in Sources */,
 				511356BE209B7F6E00056D65 /* BlockchainAPI+Payload.swift in Sources */,
 				C76135641F9E55DF0029E159 /* ExchangeCreateViewController.m in Sources */,
+				3AC4F9C52124CCC5003AA207 /* Result.swift in Sources */,
 				606399E42110FC2D005B6DF5 /* SRProxyConnect.m in Sources */,
 				67EE1DCD19E3325900DBBFC9 /* ECSlidingSegue.m in Sources */,
 				AAA3316120895A9C00BBD292 /* LoadingViewPresenter.swift in Sources */,

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -102,6 +102,10 @@
 		3AC4F981212349AE003AA207 /* PersonalDetailsInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCF211CA2CD00E6C241 /* PersonalDetailsInterface.swift */; };
 		3AC4F982212349BF003AA207 /* PersonalDetailsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DCC211C9C6500E6C241 /* PersonalDetailsService.swift */; };
 		3AC4F983212349CB003AA207 /* PersonalDetailsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DC5211C992B00E6C241 /* PersonalDetailsAPI.swift */; };
+		3AC4F9A42124B4BA003AA207 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC4F9A32124B4BA003AA207 /* AsyncOperation.swift */; };
+		3AC4F9A62124B77D003AA207 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC4F9A52124B77D003AA207 /* Result.swift */; };
+		3AC4F9A92124B893003AA207 /* NetworkOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC4F9A82124B893003AA207 /* NetworkOperation.swift */; };
+		3AC4F9AC2124B8CE003AA207 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC4F9AB2124B8CE003AA207 /* NetworkRequest.swift */; };
 		3AC9755A210FBD10006A9263 /* NSAttributedString+Conveniences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */; };
 		3AC9755B210FBD10006A9263 /* NSAttributedString+Conveniences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */; };
 		3AD7EE7621124F0C006B924F /* ValidationTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD7EE7521124F0C006B924F /* ValidationTextField.swift */; };
@@ -1102,6 +1106,10 @@
 		3A8B229C211E2A960091E706 /* KYCUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCUser.swift; sourceTree = "<group>"; };
 		3A8B229E2122117A0091E706 /* KYCBaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCBaseViewController.swift; sourceTree = "<group>"; };
 		3AC4F97721234040003AA207 /* Storyboardable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storyboardable.swift; sourceTree = "<group>"; };
+		3AC4F9A32124B4BA003AA207 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
+		3AC4F9A52124B77D003AA207 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		3AC4F9A82124B893003AA207 /* NetworkOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkOperation.swift; sourceTree = "<group>"; };
+		3AC4F9AB2124B8CE003AA207 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
 		3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Conveniences.swift"; sourceTree = "<group>"; };
 		3AD7EE7521124F0C006B924F /* ValidationTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationTextField.swift; sourceTree = "<group>"; };
 		3AD7EE9F21125156006B924F /* ValidationTextField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ValidationTextField.xib; sourceTree = "<group>"; };
@@ -3238,6 +3246,33 @@
 			path = "Primary Button";
 			sourceTree = "<group>";
 		};
+		3AC4F9992124B436003AA207 /* Operations */ = {
+			isa = PBXGroup;
+			children = (
+				3AC4F9A32124B4BA003AA207 /* AsyncOperation.swift */,
+				3AC4F9A72124B883003AA207 /* NetworkOperation */,
+			);
+			path = Operations;
+			sourceTree = "<group>";
+		};
+		3AC4F9A72124B883003AA207 /* NetworkOperation */ = {
+			isa = PBXGroup;
+			children = (
+				3AC4F9A82124B893003AA207 /* NetworkOperation.swift */,
+				3AC4F9AA2124B8B5003AA207 /* Models */,
+			);
+			path = NetworkOperation;
+			sourceTree = "<group>";
+		};
+		3AC4F9AA2124B8B5003AA207 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				3AC4F9A52124B77D003AA207 /* Result.swift */,
+				3AC4F9AB2124B8CE003AA207 /* NetworkRequest.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		3AD7EE7421124D56006B924F /* ValidationTextField */ = {
 			isa = PBXGroup;
 			children = (
@@ -3497,7 +3532,6 @@
 			isa = PBXGroup;
 			children = (
 				3A8B229E2122117A0091E706 /* KYCBaseViewController.swift */,
-				3A3D5DBA211C98DE00E6C241 /* Personal */,
 				602B9CCD2118E15200BD3D60 /* KYCAccountStatusController.swift */,
 				602B9CCE2118E15200BD3D60 /* KYCCoordinator.swift */,
 				602B9CB12118E15200BD3D60 /* KYCNetworkRequest.swift */,
@@ -5666,6 +5700,7 @@
 		9FB3637B14B60128004BEA02 /* Blockchain */ = {
 			isa = PBXGroup;
 			children = (
+				3AC4F9992124B436003AA207 /* Operations */,
 				C790E0F21E4913F00063D141 /* Blockchain.entitlements */,
 				A2599B9D1B0B5FC700C2EA81 /* Blockchain-Bridging-Header.h */,
 				67470A0519D438E000757D46 /* LocalizationConstants.h */,
@@ -7098,6 +7133,7 @@
 				9F45F82C1514E53C00018AED /* UIButtonPressAndHold.m in Sources */,
 				9F7480E315140EF200BC4292 /* TabViewController.m in Sources */,
 				3A8B229F2122117A0091E706 /* KYCBaseViewController.swift in Sources */,
+				3AC4F9A92124B893003AA207 /* NetworkOperation.swift in Sources */,
 				AAA3314E20893CE100BBD292 /* PairingInstructionsView.swift in Sources */,
 				AAA3316B2089650B00BBD292 /* AlertViewPresenter.swift in Sources */,
 				51E5C73320741A130000A7FD /* LocalizationConstants.swift in Sources */,
@@ -7163,6 +7199,7 @@
 				51A7349320891EB3009727D5 /* NetworkManager.swift in Sources */,
 				606399EA2110FC2D005B6DF5 /* SRDelegateController.m in Sources */,
 				3AE92BDB2110DB3C008D7BDC /* KeyboardPayload.swift in Sources */,
+				3AC4F9A62124B77D003AA207 /* Result.swift in Sources */,
 				C7559CB21F56FE09005B2375 /* TransactionsEtherViewController.m in Sources */,
 				AA1E522B2097CA360099BD10 /* AuthenticationCoordinator.swift in Sources */,
 				23FDEFAC1D6F669100FC80D6 /* NSURLSession+SendSynchronousRequest.m in Sources */,
@@ -7261,6 +7298,7 @@
 				AA3CA9AF2107F18C00C2AD46 /* Logger.swift in Sources */,
 				AA69F6592086A2720054EFCE /* AppCoordinator.swift in Sources */,
 				C7614399211A7FD70041411E /* SocketManager.swift in Sources */,
+				3AC4F9A42124B4BA003AA207 /* AsyncOperation.swift in Sources */,
 				67D95A261B3DD86B0012EBB1 /* BCTextField.swift in Sources */,
 				C77217E820AFCC3C0087836A /* WalletBackupDelegate.swift in Sources */,
 				5171E39020F4F98000E8913E /* Colors.swift in Sources */,
@@ -7344,6 +7382,7 @@
 				C7A0E92E1FA8FFBF004F4267 /* ExchangeConfirmViewController.m in Sources */,
 				C79261B51E8ADF0300C87CED /* BCCardView.m in Sources */,
 				ECD244F719A8B444004B1F40 /* UIImage+Utils.m in Sources */,
+				3AC4F9AC2124B8CE003AA207 /* NetworkRequest.swift in Sources */,
 				511356E3209CAFC600056D65 /* NetworkManager+PushNotifications.swift in Sources */,
 				C740FA89210BAF740060292F /* WalletExchangeIntermediateDelegate.swift in Sources */,
 				23444F961DCD21C600573C8C /* BTCKeychain.m in Sources */,

--- a/Blockchain/Network/Models/Result.swift
+++ b/Blockchain/Network/Models/Result.swift
@@ -1,0 +1,9 @@
+//
+//  Result.swift
+//  Blockchain
+//
+//  Created by AlexM on 8/15/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation

--- a/Blockchain/Operations/AsyncOperation.swift
+++ b/Blockchain/Operations/AsyncOperation.swift
@@ -1,0 +1,130 @@
+//
+//  AsyncOperation.swift
+//  Blockchain
+//
+//  Created by Alex McGregor on 8/15/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+class AsyncOperation: Operation {
+
+    // MARK: Private Properties
+
+    /// The dispatch queue on which the execution method will be invoked.
+    private let executionQueue: DispatchQueue
+
+    /// The completion blocks are called when the operation completes.
+    private var completionHandlers = [() -> Void]()
+
+    /// Synchronizes `completionHandlers`.
+    private var lock = NSLock()
+
+    // MARK: Lifecycle
+
+    override init() {
+        self.executionQueue = DispatchQueue(
+            label: "com.blockchain.AsyncOperation.executionQueue",
+            qos: .background
+        )
+        super.init()
+    }
+
+    // MARK: Public Methods
+
+    /// Adds a completion handler to be invoked when the operation is finished.
+    /// All completion handlers will be called on the main queue. The operation
+    /// will not be marked as finished until all completion handlers have been
+    /// called.
+    func addCompletionHandler(_ handler: @escaping () -> Void) {
+        guard !isCancelled && !isFinished else { return }
+        lock.lock()
+        completionHandlers.append(handler)
+        lock.unlock()
+    }
+
+    // MARK: Required Methods for Subclasses
+
+    /// Begins execution of the asynchronous work. This method will *not* be
+    /// called from the AsyncOperation's operation queue, but rather from a
+    /// private dispatch queue.
+    ///
+    /// - Warning: Subclass implementations must invoke `finish` when done. If
+    /// you do not invoke `finish`, the operation will remain in its executing
+    /// state indefinitely.
+    open func execute(finish: @escaping () -> Void) {
+        assertionFailure("Subclasses must override without calling super.")
+    }
+
+    // MARK: Overrides
+
+    override func start() {
+        guard !isCancelled else { return }
+        markAsExecuting()
+        executionQueue.async { [weak self] in
+            guard let this = self else { return }
+            this.execute { [weak this] in
+                DispatchQueue.main.async {
+                    guard let this = this else { return }
+                    guard !this.isCancelled else { return }
+                    this.lock.lock()
+                    let handlers = this.completionHandlers
+                    this.lock.unlock()
+                    handlers.forEach{ $0() }
+                    this.markAsFinished()
+                }
+            }
+        }
+    }
+
+    override var isAsynchronous: Bool {
+        return true
+    }
+
+    fileprivate var _finished: Bool = false
+    override var isFinished: Bool {
+        get { return _finished }
+        set { _finished = newValue }
+    }
+
+    fileprivate var _executing: Bool = false
+    override var isExecuting: Bool {
+        get { return _executing }
+        set { _executing = newValue }
+    }
+}
+
+
+fileprivate extension AsyncOperation {
+
+    func markAsExecuting() {
+        willChangeValue(for: .isExecuting)
+        _executing = true
+        didChangeValue(for: .isExecuting)
+    }
+
+    func markAsFinished() {
+        willChangeValue(for: .isExecuting)
+        willChangeValue(for: .isFinished)
+        _executing = false
+        _finished = true
+        didChangeValue(for: .isExecuting)
+        didChangeValue(for: .isFinished)
+    }
+
+    // MARK: Private
+
+    private func willChangeValue(for key: OperationChangeKey) {
+        self.willChangeValue(forKey: key.rawValue)
+    }
+
+    private func didChangeValue(for key: OperationChangeKey) {
+        self.didChangeValue(forKey: key.rawValue)
+    }
+
+    private enum OperationChangeKey: String {
+        case isFinished
+        case isExecuting
+    }
+}

--- a/Blockchain/Operations/NetworkOperation/Models/NetworkRequest.swift
+++ b/Blockchain/Operations/NetworkOperation/Models/NetworkRequest.swift
@@ -1,0 +1,63 @@
+//
+//  NetworkRequest.swift
+//  Blockchain
+//
+//  Created by AlexM on 8/15/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+struct NetworkRequest {
+
+    enum NetworkMethod: String {
+        case get = "GET"
+        case post = "POST"
+        case put = "PUT"
+        case delete = "DELETE"
+    }
+
+    let method: NetworkMethod
+    let endpoint: URL
+    let body: Data?
+
+    init(endpoint: URL, method: NetworkMethod, body: Data?) {
+        self.endpoint = endpoint
+        self.method = method
+        self.body = body
+    }
+
+    func URLRequest() -> URLRequest? {
+        let request: NSMutableURLRequest = NSMutableURLRequest(
+            url: endpoint,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 30.0
+        )
+
+        request.httpMethod = method.rawValue
+        request.allHTTPHeaderFields = ["Content-Type":"application/json",
+                                       "Accept": "application/json"]
+
+        if let data = body {
+            request.httpBody = data
+        }
+
+        return request.copy() as? URLRequest
+    }
+
+    static func GET(url: URL, body: Data?) -> NetworkRequest {
+        return self.init(endpoint: url, method: .get, body: body)
+    }
+
+    static func POST(url: URL, body: Data?) -> NetworkRequest {
+        return self.init(endpoint: url, method: .post, body: body)
+    }
+
+    static func PUT(url: URL, body: Data?) -> NetworkRequest {
+        return self.init(endpoint: url, method: .put, body: body)
+    }
+
+    static func DELETE(url: URL) -> NetworkRequest {
+        return self.init(endpoint: url, method: .delete, body: nil)
+    }
+}

--- a/Blockchain/Operations/NetworkOperation/Models/Result.swift
+++ b/Blockchain/Operations/NetworkOperation/Models/Result.swift
@@ -1,0 +1,18 @@
+//
+//  Result.swift
+//  Blockchain
+//
+//  Created by Alex McGregor on 8/15/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// The model you're expecting can be anything.
+/// Some endpoints may not return an error, and
+/// sometimes you may want to return a `error`
+/// result but don't have an error to provide.
+enum Result<A> {
+    case success(A)
+    case error(Error?)
+}

--- a/Blockchain/Operations/NetworkOperation/NetworkOperation.swift
+++ b/Blockchain/Operations/NetworkOperation/NetworkOperation.swift
@@ -1,0 +1,63 @@
+//
+//  NetworkOperation.swift
+//  Blockchain
+//
+//  Created by Alex McGregor on 8/15/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+class NetworkOperation<T: Decodable>: AsyncOperation {
+
+    typealias NetworkCompletion = (_ result: Result<T>, _ statusCode: Int?) -> Void
+
+    var result: Result<T> = .error(nil)
+    fileprivate var request: NetworkRequest
+    fileprivate var responseCode: Int?
+
+    init(with request: NetworkRequest, responseHandler: @escaping NetworkCompletion) {
+        self.request = request
+        super.init()
+
+        addCompletionHandler { [weak self] in
+            guard let this = self else { return }
+            responseHandler(
+                this.result,
+                this.responseCode
+            )
+        }
+    }
+
+    public override func execute(finish: @escaping () -> Void) {
+        guard let urlRequest = request.URLRequest() else { return }
+
+        let task = URLSession.shared.dataTask(with: urlRequest) { [weak self] (data, response, error) in
+            guard let this = self else { return }
+
+            if let httpResponse = response as? HTTPURLResponse {
+                this.responseCode = httpResponse.statusCode
+            }
+
+            if let payload = data, error == nil {
+                do {
+                    let decoder = JSONDecoder()
+                    decoder.dateDecodingStrategy = .secondsSince1970
+                    let final = try decoder.decode(T.self, from: payload)
+
+                    this.result = .success(final)
+                } catch let err {
+                    this.result = .error(err)
+                }
+            }
+
+            if let error = error {
+                this.result = .error(error)
+            }
+
+            finish()
+        }
+
+        task.resume()
+    }
+}


### PR DESCRIPTION
## Objective

This is a basic networking implementation. 

## Description

This uses `Operations`. I've had good results with operations and async tasks (cancelable and chainable). `NetworkOperation` takes an expected model type as a generic parameter. The way I would use this is I would create an operation for whatever API endpoint I needed to hit. That operation would subclass `AsyncOperation`. This is pretty important if you want to be able to chain together network calls an inject the results of one call into another. 

Here's an example:

    class FancyAPIOperation: AsyncOperation {
    
    var result: Result<Widget> = .error(nil)
    
    fileprivate let requirement: String
    fileprivate var networkOperation: NetworkOperation<Widget>!
    
    init(with requirement: String) {
        self.requirement = requirement
        super.init()
    }
    
    override func execute(finish: @escaping () -> Void) {
       let url = URL(string:"endpoint")!
        let request = NetworkRequest.GET(url: url, body: nil)
        
        networkOperation = NetworkOperation<Widget>(with: request, responseHandler: { [weak self] (result, code) in
            guard let this = self else { return }
            
            this.result = result
            finish()
        })
        
        networkOperation.start()
        }
    }


`let operation = FancyAPIOperation(with "requirement")`
```
operation.addCompletionHandler {
guard let this = self else { return }
if case let .success(payload) = this.operation.result {
           // TODO: Success
   }
}
operation.start()
```

## How to Test

N/A

## Screenshot

N/A

## Related Information

* Ticket Number: N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
