### PR TITLE
fix(KYC Authentication): using owned self vs. weak.

### DIFF
--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -62,8 +62,8 @@ protocol KYCCoordinatorDelegate: class {
             disposable = BlockchainDataRepository.shared.kycUser
                 .subscribeOn(MainScheduler.asyncInstance)
                 .observeOn(MainScheduler.instance)
-                .subscribe(onSuccess: { [weak self] in
-                    self?.user = $0
+                .subscribe(onSuccess: { [unowned self] in
+                    self.user = $0
                     Logger.shared.debug("Got user with ID: \($0.personalDetails?.identifier ?? "")")
                 }, onError: { error in
                     Logger.shared.error("Failed to get user: \(error.localizedDescription)")

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -191,7 +191,6 @@ final class KYCNetworkRequest {
     // MARK: - Private Methods
 
     private func send(taskSuccess: @escaping TaskSuccess, taskFailure: @escaping TaskFailure) {
-        // Use URLSession.shared instead of NetworkManager.shared.session for debugging on dev
         let task = NetworkManager.shared.session.dataTask(with: request, completionHandler: { data, response, error in
             DispatchQueue.main.async {
                 if let error = error {


### PR DESCRIPTION
## Objective

Fix issue where URLSession prematurely deallocs.

## Description

Using `weak self` caused the URLSession to prematurely deinit which results in the following error:

```
Error Domain=NSURLErrorDomain Code=-999 "cancelled" UserInfo={NSErrorFailingURLStringKey=https://url.com?userId=<user_id>, NSLocalizedDescription=cancelled, NSErrorFailingURLKey=https://url.com?userId=<user_id>}
```

Updating the closure to use `unowned self` will fix this issue. With this change, you no longer need to use `URLSession.shared` in KYCNetworkRequest as I've commented before.

## How to Test

Launch KYC and verify that you get a valid `KYCUser`.

## Screenshot

N/A

## Related Information

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
