### PR TITLE
feat(KYC Authentication): IOS-1104 caching authentication session token

### DIFF
--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -216,6 +216,8 @@ import RxSwift
 
         WalletManager.shared.close()
 
+        BlockchainDataRepository.shared.clearCache()
+
         let appCoordinator = AppCoordinator.shared
         appCoordinator.tabControllerManager.clearSendToAddressAndAmountFields()
         appCoordinator.closeSideMenu()

--- a/Blockchain/Data/BlockchainDataRepository.swift
+++ b/Blockchain/Data/BlockchainDataRepository.swift
@@ -18,7 +18,7 @@ import RxSwift
 
     private let authenticationService: KYCAuthenticationService
 
-    init(authenticationService: KYCAuthenticationService = KYCAuthenticationService.shared) {
+    init(authenticationService: KYCAuthenticationService = KYCAuthenticationService()) {
         self.authenticationService = authenticationService
     }
 

--- a/Blockchain/Data/BlockchainDataRepository.swift
+++ b/Blockchain/Data/BlockchainDataRepository.swift
@@ -47,6 +47,14 @@ import RxSwift
 
     private var cachedUser = BehaviorRelay<KYCUser?>(value: nil)
 
+    // MARK: - Public Methods
+
+    /// Clears cached data in this repository
+    func clearCache() {
+        cachedUser = BehaviorRelay<KYCUser?>(value: nil)
+        cachedCountries = BehaviorRelay<Countries?>(value: nil)
+    }
+
     // MARK: - Private Methods
 
     private func fetchData<ResponseType: Decodable>(

--- a/Blockchain/Extensions/DateFormatter+Conveniences.swift
+++ b/Blockchain/Extensions/DateFormatter+Conveniences.swift
@@ -16,6 +16,13 @@ extension DateFormatter {
         return formatter
     }()
 
+    /// The format that the server sends down the expiration date for session tokens
+    static let sessionDateFormat: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        return formatter
+    }()
+
     /// The API expects the user's DOB to be formatted
     /// this way.
     static let birthday: DateFormatter = {

--- a/Blockchain/KYC/KYCAuthenticationService.swift
+++ b/Blockchain/KYC/KYCAuthenticationService.swift
@@ -17,8 +17,6 @@ final class KYCAuthenticationService {
         static let userId = "userId"
     }
 
-    static let shared = KYCAuthenticationService()
-
     private let wallet: Wallet
 
     // MARK: - Initialization
@@ -35,13 +33,12 @@ final class KYCAuthenticationService {
     /// - Returns: a Single returning the sesion token
     func getKycSessionToken() -> Single<KYCSessionTokenResponse> {
         // TODO: cache this
-        // TODO: pass in valid device ID
         return getOrCreateApiTokenResponse().flatMap { [unowned self] apiToken in
             let headers: [String: String] = [
                 HttpHeaderField.authorization: apiToken.token,
                 HttpHeaderField.appVersion: Bundle.applicationVersion ?? "",
                 HttpHeaderField.clientType: HttpHeaderValue.clientTypeIos,
-                HttpHeaderField.deviceId: "ID GOES HERE",
+                HttpHeaderField.deviceId: UIDevice.current.identifierForVendor?.uuidString ?? "",
                 HttpHeaderField.walletGuid: self.wallet.guid,
                 HttpHeaderField.walletEmail: self.wallet.getEmail()
             ]

--- a/Blockchain/KYC/KYCAuthenticationService.swift
+++ b/Blockchain/KYC/KYCAuthenticationService.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
 //
 
+import RxCocoa
 import RxSwift
 
 /// Component in charge of authenticating the KYC user.
@@ -17,6 +18,7 @@ final class KYCAuthenticationService {
         static let userId = "userId"
     }
 
+    private var cachedSessionToken = BehaviorRelay<KYCSessionTokenResponse?>(value: nil)
     private let wallet: Wallet
 
     // MARK: - Initialization
@@ -32,26 +34,36 @@ final class KYCAuthenticationService {
     ///
     /// - Returns: a Single returning the sesion token
     func getKycSessionToken() -> Single<KYCSessionTokenResponse> {
-        // TODO: cache this
         return getOrCreateApiTokenResponse().flatMap { [unowned self] apiToken in
-            let headers: [String: String] = [
-                HttpHeaderField.authorization: apiToken.token,
-                HttpHeaderField.appVersion: Bundle.applicationVersion ?? "",
-                HttpHeaderField.clientType: HttpHeaderValue.clientTypeIos,
-                HttpHeaderField.deviceId: UIDevice.current.identifierForVendor?.uuidString ?? "",
-                HttpHeaderField.walletGuid: self.wallet.guid,
-                HttpHeaderField.walletEmail: self.wallet.getEmail()
-            ]
-            return KYCNetworkRequest.request(
-                post: .sessionToken(userId: apiToken.userId),
-                parameters: [:],
-                headers: headers,
-                type: KYCSessionTokenResponse.self
-            )
+            self.getKycSessionTokenIfNeeded(from: apiToken)
         }
     }
 
     // MARK: - Private Methods
+
+    private func getKycSessionTokenIfNeeded(from apiToken: KYCApiTokenResponse) -> Single<KYCSessionTokenResponse> {
+        // Use cached session token if not expired, otherwise, request a new one
+        guard let sessionToken = cachedSessionToken.value,
+            let expiresAt = sessionToken.expiresAt, Date() < expiresAt else {
+                let headers: [String: String] = [
+                    HttpHeaderField.authorization: apiToken.token,
+                    HttpHeaderField.appVersion: Bundle.applicationVersion ?? "",
+                    HttpHeaderField.clientType: HttpHeaderValue.clientTypeIos,
+                    HttpHeaderField.deviceId: UIDevice.current.identifierForVendor?.uuidString ?? "",
+                    HttpHeaderField.walletGuid: self.wallet.guid,
+                    HttpHeaderField.walletEmail: self.wallet.getEmail()
+                ]
+                return KYCNetworkRequest.request(
+                    post: .sessionToken(userId: apiToken.userId),
+                    parameters: [:],
+                    headers: headers,
+                    type: KYCSessionTokenResponse.self
+                ).do(onSuccess: { [unowned self] in
+                    self.cachedSessionToken.accept($0)
+                })
+        }
+        return Single.just(sessionToken)
+    }
 
     /// Retrieves the user's KYC user ID and API token from the wallet metadata if the KYC user ID
     /// and api token had already been created. Otherwise, this method will create a new KYC user ID

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -146,7 +146,9 @@ final class KYCNetworkRequest {
         guard let endpoint = URL.endpoint(base, pathComponents: nil, queryParameters: url.queryParameters) else { return nil }
         self.init(url: endpoint, httpMethod: "POST")
         do {
-            let body = try JSONSerialization.data(withJSONObject: parameters, options: .prettyPrinted)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let body = try encoder.encode(parameters)
             request.httpBody = body
 
             var allHeaders = [HttpHeaderField.contentType: HttpHeaderValue.json]

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -146,9 +146,7 @@ final class KYCNetworkRequest {
         guard let endpoint = URL.endpoint(base, pathComponents: nil, queryParameters: url.queryParameters) else { return nil }
         self.init(url: endpoint, httpMethod: "POST")
         do {
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            let body = try encoder.encode(parameters)
+            let body = try JSONSerialization.data(withJSONObject: parameters, options: .prettyPrinted)
             request.httpBody = body
 
             var allHeaders = [HttpHeaderField.contentType: HttpHeaderValue.json]

--- a/Blockchain/KYC/Models/Network/KYCSessionTokenResponse.swift
+++ b/Blockchain/KYC/Models/Network/KYCSessionTokenResponse.swift
@@ -16,12 +16,18 @@ struct KYCSessionTokenResponse: Decodable {
         case userId = "userId"
         case token = "token"
         case isActive = "isActive"
+        case expiresAt = "expiresAt"
+        case insertedAt = "insertedAt"
+        case updatedAt = "updatedAt"
     }
 
     let identifier: String
     let userId: String
     let token: String
     let isActive: Bool
+    let expiresAt: Date
+    let insertedAt: Date
+    let updatedAt: Date
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)

--- a/Blockchain/KYC/Models/Network/KYCSessionTokenResponse.swift
+++ b/Blockchain/KYC/Models/Network/KYCSessionTokenResponse.swift
@@ -17,17 +17,13 @@ struct KYCSessionTokenResponse: Decodable {
         case token = "token"
         case isActive = "isActive"
         case expiresAt = "expiresAt"
-        case insertedAt = "insertedAt"
-        case updatedAt = "updatedAt"
     }
 
     let identifier: String
     let userId: String
     let token: String
     let isActive: Bool
-    let expiresAt: Date
-    let insertedAt: Date
-    let updatedAt: Date
+    let expiresAt: Date?
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
@@ -35,6 +31,7 @@ struct KYCSessionTokenResponse: Decodable {
         userId = try values.decode(String.self, forKey: .userId)
         token = try values.decode(String.self, forKey: .token)
         isActive = try values.decode(Bool.self, forKey: .isActive)
-        // TODO: Parse expiresAt, insertedAt, updatedAt
+        let expiresAtString = try values.decode(String.self, forKey: .expiresAt)
+        expiresAt = DateFormatter.sessionDateFormat.date(from: expiresAtString)
     }
 }


### PR DESCRIPTION
## Objective

Cache the KYC authentication session token in KYCAuthenticationService.

## Description

Previously, a new session token for authentication is requested each time when invoking `getKycSessionToken()`. With this change, we are now caching the previously fetched `KYCSessionTokenResponse` and so subsequent calls will now use that cached response. However, if the cached session token is expired, we'll fetch another one.

Writing tests for this is a bit involved—`KYCNetworkRequest` cannot be easily mocked and creating the changes to make it mock-able involves refactoring the network layer a bit. I can make that change in another PR, but since @jstxx & @achtenhagen are working on refactoring the network layer, I figured it would be good to hold off until that's in a good place (something to consider in the new arch).

Other changes:
* clearing the `BlockchainDataRepository` when logging out. Looking for suggestions as well on how we can genericize the cache.
* `KYCAuthenticationService` is no longer a singleton. I'm thinking `BlockchainDataRepository` should also not be a singleton and instead the lifecycle should live within `KYCCoordinator`. Looking for input/thoughts here.

## How to Test

* Add `|| host == "api.dev.blockchain.info"` in line 108 in NetworkManager to get around the cert pinning issue
* Comment out line 70 in `BlockchainDataRepository` so that a `KYCUser` is always fetched over the network
* Put a breakpoint on line 65 in `KYCAuthenticationService`, go in, out, and back in KYC and verify that the breakpoint is reached

## Screenshot

N/A

## Related Information

* Ticket Number: IOS-1104

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
