### PR TITLE
feat(KYC): set badge color depending on account status

### DIFF
--- a/Blockchain/Colors.swift
+++ b/Blockchain/Colors.swift
@@ -63,6 +63,10 @@ extension UIColor {
     static let keyPadButton = #colorLiteral(red: 0.831372549, green: 0.8509803922, blue: 0.8666666667, alpha: 1)
 
     static let lightGray = #colorLiteral(red: 0.9607843137, green: 0.9647058824, blue: 0.9725490196, alpha: 1)
-    
-    static let unverified = #colorLiteral(red: 0.86, green: 0.16, blue: 0.16, alpha: 1.0)
+
+    static let pending = #colorLiteral(red: 0.9490196078, green: 0.5450980392, blue: 0.1882352941, alpha: 1)
+
+    static let verified = #colorLiteral(red: 0.01176470588, green: 0.662745098, blue: 0.4470588235, alpha: 1)
+
+    static let unverified = #colorLiteral(red: 0.86, green: 0.16, blue: 0.16, alpha: 1)
 }

--- a/Blockchain/KYC/Models/KYCAccountStatus.swift
+++ b/Blockchain/KYC/Models/KYCAccountStatus.swift
@@ -15,5 +15,3 @@ enum KYCAccountStatus: String {
     case failed = "REJECTED"
     case pending = "PENDING"
 }
-
-

--- a/Blockchain/Settings/Settings+Helpers.swift
+++ b/Blockchain/Settings/Settings+Helpers.swift
@@ -142,12 +142,19 @@ extension AppSettingsController {
     func createBadge(_ cell: UITableViewCell, color: UIColor? = nil, _ using: KYCUser? = nil) {
         cell.detailTextLabel?.layer.cornerRadius = 4
         cell.detailTextLabel?.layer.masksToBounds = true
-        cell.detailTextLabel?.backgroundColor = color
+        if let status = using?.status {
+            switch status {
+            case .approved: cell.detailTextLabel?.backgroundColor = .verified
+            case .expired, .failed, .none: cell.detailTextLabel?.backgroundColor = .unverified
+            case .pending: cell.detailTextLabel?.backgroundColor = .pending
+            }
+        } else {
+            cell.detailTextLabel?.backgroundColor = color
+        }
         cell.detailTextLabel?.textColor = .white
         cell.detailTextLabel?.font = UIFont(name: Constants.FontNames.montserratSemiBold, size: Constants.FontSizes.Tiny)
         cell.detailTextLabel?.sizeToFit()
         cell.detailTextLabel?.layoutIfNeeded()
-
     }
     
     /// MARK: -isMobileVerified

--- a/Blockchain/Settings/Settings+Table.swift
+++ b/Blockchain/Settings/Settings+Table.swift
@@ -144,8 +144,8 @@ extension SettingsTableViewController {
                     cell.detailTextLabel?.text = userModel.badge
                 }
             } else {
-                self.createBadge(cell, status)
-                cell.detailTextLabel?.text = "Unknown"
+                self.createBadge(cell, color: .unverified)
+                cell.detailTextLabel?.text = LocalizationConstants.KYC.accountUnverifiedBadge
             }
         }
     }


### PR DESCRIPTION
## Objective

Set the badge color of the `Identity Verification` row in the settings controller.

## Related Information

* Ticket Number: [IOS-1158](https://blockchain.atlassian.net/browse/IOS-1158)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
