### PR TITLE
refactor(Exchange): IOS-1159 rename methods and combine protocols

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -591,6 +591,11 @@
 		AAFE9E9221016132002E4E1E /* PinError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFE9E9121016132002E4E1E /* PinError.swift */; };
 		AAFE9E9321016132002E4E1E /* PinError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFE9E9121016132002E4E1E /* PinError.swift */; };
 		C6FFCE3372082DAB9DA7021E /* Pods_BlockchainTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5185A3368C92DCF1134710A /* Pods_BlockchainTests.framework */; };
+		C7057660212B4DD70027C6AA /* FromToButtonDelegateIntermediate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AEB1CF2125CF4900320A32 /* FromToButtonDelegateIntermediate.swift */; };
+		C705766A212B4DE00027C6AA /* HomebrewExchangeCreateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75F65002124BEDF00396B65 /* HomebrewExchangeCreateViewController.swift */; };
+		C705766B212B4E010027C6AA /* ExchangeTradeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75F65072124DDB900396B65 /* ExchangeTradeDelegate.swift */; };
+		C705766C212B4E060027C6AA /* ExchangeTradeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75F65022124CE1B00396B65 /* ExchangeTradeCoordinator.swift */; };
+		C705766D212B4E1C0027C6AA /* ExchangeTradeInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75F65042124D95600396B65 /* ExchangeTradeInterface.swift */; };
 		C70FF55E1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = C70FF55D1E76D5C600AC7F8B /* BuyBitcoinNavigationController.m */; };
 		C70FF5661E7B051C00AC7F8B /* ContactTransactionTableCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C70FF5651E7B051C00AC7F8B /* ContactTransactionTableCell.xib */; };
 		C71859471F3E227D00745A87 /* BCDescriptionView.m in Sources */ = {isa = PBXBuildFile; fileRef = C71859461F3E227C00745A87 /* BCDescriptionView.m */; };
@@ -7001,6 +7006,7 @@
 				AA722C1A20B4BBA900262A5F /* AssetAddressRepository.swift in Sources */,
 				511356E4209CAFC600056D65 /* NetworkManager+PushNotifications.swift in Sources */,
 				AAD27A29209CFE2100C0EAFC /* PasswordConfirmView.swift in Sources */,
+				C7057660212B4DD70027C6AA /* FromToButtonDelegateIntermediate.swift in Sources */,
 				C740FA8A210BAF740060292F /* WalletExchangeIntermediateDelegate.swift in Sources */,
 				602B9D1C2118E26300BD3D60 /* PostalAddress.swift in Sources */,
 				AACE31CD2092A99B00B7B806 /* BitcoinCashAddress.swift in Sources */,
@@ -7071,6 +7077,7 @@
 				602B9D172118E25A00BD3D60 /* LocationSuggestionInterface.swift in Sources */,
 				AA56423820DDBDAA0092A022 /* PinTests.swift in Sources */,
 				AA1E523E2097E6AC0099BD10 /* PinStoreResponse.swift in Sources */,
+				C705766D212B4E1C0027C6AA /* ExchangeTradeInterface.swift in Sources */,
 				AACE31C92092A99B00B7B806 /* AlertViewPresenter.swift in Sources */,
 				3AE92BDE2110DF33008D7BDC /* NotificationCenter+Conveniences.swift in Sources */,
 				51979169210BA7AC0096E50B /* HTTPRequestError.swift in Sources */,
@@ -7126,6 +7133,7 @@
 				602B9D0C2118E23400BD3D60 /* KYCCoordinator.swift in Sources */,
 				AA7133B8212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift in Sources */,
 				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
+				C705766C212B4E060027C6AA /* ExchangeTradeCoordinator.swift in Sources */,
 				C76143AC211A80D30041411E /* Codable+Coding.swift in Sources */,
 				AA748359211129DF008F2768 /* MockKYCEnterPhoneNumberView.swift in Sources */,
 				AA9B30D220F6D85000A7F809 /* WalletUpgradeDelegate.swift in Sources */,
@@ -7148,6 +7156,7 @@
 				602B9D1B2118E26300BD3D60 /* LocationSuggestionPageModel.swift in Sources */,
 				AA74835B21112A18008F2768 /* MockKYCVerifyPhoneNumberInteractor.swift in Sources */,
 				602B9D1A2118E26300BD3D60 /* LocationSuggestion.swift in Sources */,
+				C705766B212B4E010027C6AA /* ExchangeTradeDelegate.swift in Sources */,
 				51A862D620921A6E00B338E0 /* BlockchainAPI+URLSuffix.swift in Sources */,
 				5185E12B208F7ACA00A26B64 /* BlockchainAPI+URI.swift in Sources */,
 				AACE31CB2092A99B00B7B806 /* AssetType.swift in Sources */,
@@ -7184,6 +7193,7 @@
 				600E18BB2118D46B003C1846 /* KeyboardPayload.swift in Sources */,
 				C764372A20ED199500CA7CA4 /* BalanceChartModel.swift in Sources */,
 				AADB023A20C0A871000FFFEC /* HttpMethod.swift in Sources */,
+				C705766A212B4DE00027C6AA /* HomebrewExchangeCreateViewController.swift in Sources */,
 				519435AC208E6279001EF882 /* CertificatePinnerTests.swift in Sources */,
 				3AC4F97A2123493A003AA207 /* KYCUser.swift in Sources */,
 				AAF2AEC02123797300687E30 /* PersonalDetails.swift in Sources */,

--- a/Blockchain/Homebrew/Exchange/ExchangeTradeCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeTradeCoordinator.swift
@@ -22,7 +22,7 @@ class ExchangeTradeCoordinator: NSObject {
 }
 
 extension ExchangeTradeCoordinator: ExchangeTradeDelegate {
-    func onContinueButtonClicked() {
+    func onContinueButtonTapped() {
         
     }
 }

--- a/Blockchain/Homebrew/Exchange/ExchangeTradeDelegate.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeTradeDelegate.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 protocol ExchangeTradeDelegate: class {
-    func onContinueButtonClicked()
+    func onContinueButtonTapped()
 }

--- a/Blockchain/Homebrew/Exchange/HomebrewExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/HomebrewExchangeCreateViewController.swift
@@ -28,16 +28,9 @@ class HomebrewExchangeCreateViewController: UIViewController {
         let exchangeCreateView = ExchangeCreateView(frame: view.bounds)
         view.addSubview(exchangeCreateView)
 
-        let fromToButtonCoordinator = FromToButtonDelegateIntermediate(
-            wallet: WalletManager.shared.wallet,
-            navigationController: self.navigationController as! BCNavigationController,
-            addressSelectionDelegate: self
-        )
         exchangeCreateView.setup(
-            createViewDelegate: self,
-            fromToButtonDelegate: fromToButtonCoordinator,
-            continueButtonInputAccessoryDelegate: self,
-            textFieldDelegate: self
+            delegate: self,
+            navigationController: self.navigationController as! BCNavigationController
         )
     }
 }
@@ -74,9 +67,21 @@ extension HomebrewExchangeCreateViewController: ContinueButtonInputAccessoryView
 }
 
 extension HomebrewExchangeCreateViewController: UITextFieldDelegate {
-
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        return true
+    }
 }
 
 extension HomebrewExchangeCreateViewController: AddressSelectionDelegate {
+    func getAssetType() -> LegacyAssetType {
+        return LegacyAssetType(rawValue: -1)!
+    }
 
+    func didSelect(fromAccount account: Int32, assetType asset: LegacyAssetType) {
+
+    }
+
+    func didSelect(toAccount account: Int32, assetType asset: LegacyAssetType) {
+
+    }
 }

--- a/Blockchain/Homebrew/Exchange/HomebrewExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/HomebrewExchangeCreateViewController.swift
@@ -53,22 +53,22 @@ extension HomebrewExchangeCreateViewController: ExchangeTradeInterface {
 }
 
 extension HomebrewExchangeCreateViewController: ExchangeCreateViewDelegate {
-    func assetToggleButtonClicked() {
+    func assetToggleButtonTapped() {
     }
 
-    func useMinButtonClicked() {
+    func useMinButtonTapped() {
     }
 
-    func useMaxButtonClicked() {
+    func useMaxButtonTapped() {
     }
 
-    func continueButtonClicked() {
-        delegate?.onContinueButtonClicked()
+    func continueButtonTapped() {
+        delegate?.onContinueButtonTapped()
     }
 }
 
 extension HomebrewExchangeCreateViewController: ContinueButtonInputAccessoryViewDelegate {
-    func closeButtonClicked() {
+    func closeButtonTapped() {
         exchangeCreateView.hideKeyboard()
     }
 }

--- a/Blockchain/Homebrew/Exchange/Views/ExchangeCreateView.swift
+++ b/Blockchain/Homebrew/Exchange/Views/ExchangeCreateView.swift
@@ -8,8 +8,7 @@
 
 import Foundation
 
-// TICKET: 1159 Combine this protocol with other delegates in setup method and rename 'clicked' to 'tapped'
-@objc protocol ExchangeCreateViewDelegate {
+@objc protocol ExchangeCreateViewDelegate: AddressSelectionDelegate, UITextFieldDelegate, ContinueButtonInputAccessoryViewDelegate {
     func assetToggleButtonTapped()
     func useMinButtonTapped()
     func useMaxButtonTapped()
@@ -48,25 +47,24 @@ To use it, create an instance using init(frame:), add it as a subview, and call 
 
     @objc var errorTextView: UITextView?
 
-    private weak var createViewDelegate: ExchangeCreateViewDelegate?
-    private weak var fromToButtonDelegate: FromToButtonDelegate?
-    private weak var continueButtonInputAccessoryDelegate: ContinueButtonInputAccessoryViewDelegate?
-    private weak var textFieldDelegate: UITextFieldDelegate?
+    private weak var delegate: ExchangeCreateViewDelegate?
+    private var fromToButtonDelegate: FromToButtonDelegateIntermediate?
 }
 
 // MARK: - Setup
 
 extension ExchangeCreateView {
     @objc func setup(
-        createViewDelegate: ExchangeCreateViewDelegate,
-        fromToButtonDelegate: FromToButtonDelegate,
-        continueButtonInputAccessoryDelegate: ContinueButtonInputAccessoryViewDelegate,
-        textFieldDelegate: UITextFieldDelegate
+        delegate: ExchangeCreateViewDelegate,
+        navigationController: BCNavigationController
     ) {
-        self.createViewDelegate = createViewDelegate
-        self.fromToButtonDelegate = fromToButtonDelegate
-        self.continueButtonInputAccessoryDelegate = continueButtonInputAccessoryDelegate
-        self.textFieldDelegate = textFieldDelegate
+        self.delegate = delegate
+
+        fromToButtonDelegate = FromToButtonDelegateIntermediate(
+            wallet: WalletManager.shared.wallet,
+            navigationController: navigationController,
+            addressSelectionDelegate: self
+        )
 
         backgroundColor = UIColor.lightGray
         setupSubviews()
@@ -160,7 +158,7 @@ private extension ExchangeCreateView {
 
     func setupInputAccessoryView() {
         let inputAccessoryView = ContinueButtonInputAccessoryView()
-        inputAccessoryView.delegate = continueButtonInputAccessoryDelegate
+        inputAccessoryView.delegate = self
         continuePaymentAccessoryView = inputAccessoryView
     }
 
@@ -307,19 +305,19 @@ private extension ExchangeCreateView {
 
 @objc private extension ExchangeCreateView {
     func assetToggleButtonTapped() {
-        createViewDelegate?.assetToggleButtonTapped()
+        delegate?.assetToggleButtonTapped()
     }
 
     func useMinButtonTapped() {
-        createViewDelegate?.useMinButtonTapped()
+        delegate?.useMinButtonTapped()
     }
 
     func useMaxButtonTapped() {
-        createViewDelegate?.useMaxButtonTapped()
+        delegate?.useMaxButtonTapped()
     }
 
-    func continueButtonTapped() {
-        createViewDelegate?.continueButtonTapped()
+    internal func continueButtonTapped() {
+        delegate?.continueButtonTapped()
     }
 }
 
@@ -348,7 +346,7 @@ private extension ExchangeCreateView {
         textField.keyboardType = .decimalPad
         textField.font = UIFont(name: Constants.FontNames.montserratLight, size: Constants.FontSizes.Small)
         textField.textColor = UIColor.gray5
-        textField.delegate = textFieldDelegate
+        textField.delegate = delegate
         textField.inputAccessoryView = continuePaymentAccessoryView
         return textField
     }
@@ -445,5 +443,39 @@ private extension ExchangeCreateView {
         } else {
             clearRightFields()
         }
+    }
+}
+
+extension ExchangeCreateView: ContinueButtonInputAccessoryViewDelegate {
+    func closeButtonTapped() {
+        delegate?.closeButtonTapped()
+    }
+}
+
+extension ExchangeCreateView: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let delegate = delegate else {
+            Logger.shared.debug("No delegate, do not allow changing of characters")
+            return false
+        }
+        return delegate.textField!(textField, shouldChangeCharactersIn: range, replacementString: string)
+    }
+}
+
+extension ExchangeCreateView: AddressSelectionDelegate {
+    func getAssetType() -> LegacyAssetType {
+        guard let delegate = delegate else {
+            Logger.shared.debug("Delegate is nil - allowing selection of all asset types by default.")
+            return LegacyAssetType(rawValue: -1)!
+        }
+        return delegate.getAssetType!()
+    }
+
+    func didSelect(fromAccount account: Int32, assetType asset: LegacyAssetType) {
+        delegate?.didSelect?(fromAccount: account, assetType: asset)
+    }
+
+    func didSelect(toAccount account: Int32, assetType asset: LegacyAssetType) {
+        delegate?.didSelect?(toAccount: account, assetType: asset)
     }
 }

--- a/Blockchain/Homebrew/Exchange/Views/ExchangeCreateView.swift
+++ b/Blockchain/Homebrew/Exchange/Views/ExchangeCreateView.swift
@@ -10,10 +10,10 @@ import Foundation
 
 // TICKET: 1159 Combine this protocol with other delegates in setup method and rename 'clicked' to 'tapped'
 @objc protocol ExchangeCreateViewDelegate {
-    func assetToggleButtonClicked()
-    func useMinButtonClicked()
-    func useMaxButtonClicked()
-    func continueButtonClicked()
+    func assetToggleButtonTapped()
+    func useMinButtonTapped()
+    func useMaxButtonTapped()
+    func continueButtonTapped()
 }
 
 /*
@@ -128,7 +128,7 @@ private extension ExchangeCreateView {
     func setupToggleButtonWithSpinner(amountView: UIView) {
         let assetToggleButton = UIButton(frame: toggleButtonFrame)
         assetToggleButton.center = CGPoint(x: windowWidth / 2, y: assetToggleButton.center.y)
-        assetToggleButton.addTarget(self, action: #selector(self.assetToggleButtonClicked), for: .touchUpInside)
+        assetToggleButton.addTarget(self, action: #selector(self.assetToggleButtonTapped), for: .touchUpInside)
         assetToggleButton.setImage(#imageLiteral(resourceName: "switch_currencies"), for: .normal)
         assetToggleButton.imageView?.transform = CGAffineTransform(rotationAngle: .pi / 2)
         assetToggleButton.center = CGPoint(x: assetToggleButton.center.x, y: FromToView.self.rowHeight() / 2)
@@ -252,7 +252,7 @@ private extension ExchangeCreateView {
         useMinButton.backgroundColor = UIColor.white
         useMinButton.setTitleColor(UIColor.brandSecondary, for: .normal)
         useMinButton.setTitle(LocalizationConstants.Exchange.useMinimum, for: .normal)
-        useMinButton.addTarget(self, action: #selector(self.useMinButtonClicked), for: .touchUpInside)
+        useMinButton.addTarget(self, action: #selector(self.useMinButtonTapped), for: .touchUpInside)
         buttonsView.addSubview(useMinButton)
 
         let useMaxButtonOriginX: CGFloat = buttonsView.frame.size.width / 2 + dividerLineWidth / 2
@@ -266,7 +266,7 @@ private extension ExchangeCreateView {
         useMaxButton.backgroundColor = UIColor.white
         useMaxButton.setTitleColor(UIColor.brandSecondary, for: .normal)
         useMaxButton.setTitle(LocalizationConstants.Exchange.useMaximum, for: .normal)
-        useMaxButton.addTarget(self, action: #selector(self.useMaxButtonClicked), for: .touchUpInside)
+        useMaxButton.addTarget(self, action: #selector(self.useMaxButtonTapped), for: .touchUpInside)
         buttonsView.addSubview(useMaxButton)
     }
 
@@ -299,27 +299,27 @@ private extension ExchangeCreateView {
             - safeAreaInsetTop - ConstantsObjcBridge.defaultNavigationBarHeight()
         continueButton?.center = CGPoint(x: center.x, y: continueButtonCenterY)
         addSubview(continueButton!)
-        continueButton?.addTarget(self, action: #selector(self.continueButtonClicked), for: .touchUpInside)
+        continueButton?.addTarget(self, action: #selector(self.continueButtonTapped), for: .touchUpInside)
     }
 }
 
 // MARK: - Button actions
 
 @objc private extension ExchangeCreateView {
-    func assetToggleButtonClicked() {
-        createViewDelegate?.assetToggleButtonClicked()
+    func assetToggleButtonTapped() {
+        createViewDelegate?.assetToggleButtonTapped()
     }
 
-    func useMinButtonClicked() {
-        createViewDelegate?.useMinButtonClicked()
+    func useMinButtonTapped() {
+        createViewDelegate?.useMinButtonTapped()
     }
 
-    func useMaxButtonClicked() {
-        createViewDelegate?.useMaxButtonClicked()
+    func useMaxButtonTapped() {
+        createViewDelegate?.useMaxButtonTapped()
     }
 
-    func continueButtonClicked() {
-        createViewDelegate?.continueButtonClicked()
+    func continueButtonTapped() {
+        createViewDelegate?.continueButtonTapped()
     }
 }
 

--- a/Blockchain/View Controllers/ExchangeCreateViewController.m
+++ b/Blockchain/View Controllers/ExchangeCreateViewController.m
@@ -62,7 +62,7 @@
 
     self.fromToButtonDelegateIntermediate = [[FromToButtonDelegateIntermediate alloc] initWithWallet:WalletManager.sharedInstance.wallet navigationController:(BCNavigationController *)self.navigationController addressSelectionDelegate:self];
 
-    [self.exchangeView setupWithCreateViewDelegate:self fromToButtonDelegate:self.fromToButtonDelegateIntermediate continueButtonInputAccessoryDelegate:self textFieldDelegate:self];
+    [self.exchangeView setupWithDelegate:self navigationController:(BCNavigationController *)self.navigationController];
 
     self.btcAccount = [WalletManager.sharedInstance.wallet getDefaultAccountIndexForAssetType:LegacyAssetTypeBitcoin];
     

--- a/Blockchain/View Controllers/ExchangeCreateViewController.m
+++ b/Blockchain/View Controllers/ExchangeCreateViewController.m
@@ -1003,7 +1003,7 @@
 
 #pragma mark - Continue Button Input Accessory View Delegate
 
-- (void)continueButtonClicked
+- (void)continueButtonTapped
 {
     [self.exchangeView hideKeyboard];
     
@@ -1012,14 +1012,14 @@
     [self performSelector:@selector(buildTrade) withObject:nil afterDelay:DELAY_KEYBOARD_DISMISSAL];
 }
 
-- (void)closeButtonClicked
+- (void)closeButtonTapped
 {
     [self.exchangeView hideKeyboard];
 }
 
 #pragma mark - Exchange Create View Delegate
 
-- (void)assetToggleButtonClicked
+- (void)assetToggleButtonTapped
 {
     [self clearFieldOfSymbol:self.fromSymbol];
     
@@ -1033,12 +1033,12 @@
     }
 }
 
-- (void)useMinButtonClicked
+- (void)useMinButtonTapped
 {
     [self autoFillFromAmount:self.minimum];
 }
 
-- (void)useMaxButtonClicked
+- (void)useMaxButtonTapped
 {
     id maximum = [self.maximum compare:self.maximumHardLimit] == NSOrderedAscending ? self.maximum : self.maximumHardLimit;
     

--- a/Blockchain/Views/ContinueButtonInputAccessoryView.h
+++ b/Blockchain/Views/ContinueButtonInputAccessoryView.h
@@ -8,8 +8,8 @@
 
 #import <UIKit/UIKit.h>
 @protocol ContinueButtonInputAccessoryViewDelegate
-- (void)continueButtonClicked;
-- (void)closeButtonClicked;
+- (void)continueButtonTapped;
+- (void)closeButtonTapped;
 @end
 @interface ContinueButtonInputAccessoryView : UIView
 @property (nonatomic, weak) id <ContinueButtonInputAccessoryViewDelegate> delegate;

--- a/Blockchain/Views/ContinueButtonInputAccessoryView.m
+++ b/Blockchain/Views/ContinueButtonInputAccessoryView.m
@@ -22,7 +22,7 @@
         UIButton *continueButton = [[UIButton alloc] initWithFrame:self.bounds];
         [continueButton setTitle:BC_STRING_CONTINUE forState:UIControlStateNormal];
         continueButton.titleLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:FONT_SIZE_LARGE];
-        [continueButton addTarget:self action:@selector(continueButtonClicked) forControlEvents:UIControlEventTouchUpInside];
+        [continueButton addTarget:self action:@selector(continueButtonTapped) forControlEvents:UIControlEventTouchUpInside];
         continueButton.backgroundColor = UIColor.brandSecondary;
         [self addSubview:continueButton];
         self.continueButton = continueButton;
@@ -30,7 +30,7 @@
         CGFloat closeButtonWidth = 50;
         UIButton *closeButton = [[UIButton alloc] initWithFrame:CGRectMake(self.bounds.size.width - closeButtonWidth, 0, closeButtonWidth, BUTTON_HEIGHT)];
         [closeButton setImage:[UIImage imageNamed:@"close"] forState:UIControlStateNormal];
-        [closeButton addTarget:self action:@selector(closeButtonClicked) forControlEvents:UIControlEventTouchUpInside];
+        [closeButton addTarget:self action:@selector(closeButtonTapped) forControlEvents:UIControlEventTouchUpInside];
         closeButton.backgroundColor = UIColor.gray4;
         [self addSubview:closeButton];
         self.closeButton = closeButton;
@@ -38,14 +38,14 @@
     return self;
 }
 
-- (void)continueButtonClicked
+- (void)continueButtonTapped
 {
-    [self.delegate continueButtonClicked];
+    [self.delegate continueButtonTapped];
 }
 
-- (void)closeButtonClicked
+- (void)closeButtonTapped
 {
-    [self.delegate closeButtonClicked];
+    [self.delegate closeButtonTapped];
 }
 
 - (void)enableContinueButton


### PR DESCRIPTION
## Objective

Use `tapped` instead of `clicked` in method names and combine protocols into `ExchangeCreateViewDelegate`.

Looking for feedback on the usage of `LegacyAssetType(rawValue: -1)!`, which is intended to mean "any asset type" so that the Address Selection View can show all asset types.

## How to Test
- Whitelist the dev url in `NetworkManager` (add `|| host == "dev.blockchain.com"` to `if` statement)

Homebrew:
- Replace `exchangeViewController` with `HomebrewExchangeCreateViewController` here: https://github.com/blockchain/My-Wallet-V3-iOS/blob/kevin/IOS-1159/clean_exchange/Blockchain/Coordinators/ExchangeCoordinator.swift#L104
- Add `LoadingViewPresenter.shared.hideBusyView()` here: https://github.com/blockchain/My-Wallet-V3-iOS/compare/kevin/IOS-1159/clean_exchange?expand=1#diff-ec90cea558c853745b93a95b07a80d56R34
- Go to Exchange, tap on buttons/fields, things shouldn't crash.

Shapeshift:
- If testing on `dev` env, change this `if` requirement to `if (YES)`https://github.com/blockchain/My-Wallet-V3-iOS/blob/kevin/IOS-1159/clean_exchange/Blockchain/View%20Controllers/ConfirmStateViewController.m#L71
- Shapeshift should work normally as expected.

## Screenshot

N/A

## Related Information

* Ticket Number: IOS-1159

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
