### PR TITLE
refactor(KYCCountrySelectionPresenter): use isInPartnerRegionForExchange

### DIFF
--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -207,6 +207,7 @@ extension KYCCountrySelectionController: UITableViewDataSource, UITableViewDeleg
         }
         Logger.shared.info("User selected '\(selectedCountry.name)'")
         presenter.selected(country: selectedCountry)
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 }
 

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -216,7 +216,7 @@ extension KYCCountrySelectionController: KYCCountrySelectionView {
     }
 
     func startPartnerExchangeFlow(country: KYCCountry) {
-        ExchangeCoordinator.shared.start()
+        ExchangeCoordinator.shared.start(rootViewController: self)
     }
 
     func showExchangeNotAvailable(country: KYCCountry) {

--- a/BlockchainTests/KYC/KYCCountrySelectionPresenterTests.swift
+++ b/BlockchainTests/KYC/KYCCountrySelectionPresenterTests.swift
@@ -37,6 +37,9 @@ class KYCCountrySelectionPresenterTests: XCTestCase {
             json: [
                 "shapeshift": [
                     "countriesBlacklist": ["US"]
+                ],
+                "ios": [
+                    "showShapeshift": true
                 ]
             ]
         )
@@ -53,6 +56,9 @@ class KYCCountrySelectionPresenterTests: XCTestCase {
             json: [
                 "shapeshift": [
                     "countriesBlacklist": ["US"]
+                ],
+                "ios": [
+                    "showShapeshift": true
                 ]
             ]
         )


### PR DESCRIPTION
## Objective

Updating `KYCCountrySelectionPresenter` to use `WalletService.isInPartnerRegionForExchange`

## Description

Previously `KYCCountrySelectionPresenter` manually checked in `WalletOptions` if a country is supported by shapeshift of not. Since 23c92bc2 added that logic in `WalletService`, which is used by `SideMenuPresenter`, this change uses that function as well so that we are consolidating the way we determine if shapeshift is supported.

## How to Test

* Add the `|| host == "api.dev.blockchain.info"` in `NetworkManager` to get around the cert pinning issues
* Launch KYC and go to the country selection screen. Try selecting: (1) a homebrew supported country (e.g. Germany), (2) a SS supported country (e.g. Andorra), and (3) a SS blacklisted country (e.g. Philippines)

## Screenshot

N/A

## Related Information

* Ticket Number:

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [X] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
