### PR TITLE
feat(KYCWelcome): IOS-1160 add close button to welcome screen.

### DIFF
--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -120,7 +120,7 @@ protocol KYCCoordinatorDelegate: class {
                 titleColor: UIColor.gray5,
                 isPrimaryButtonEnabled: true
             )
-            informationViewController.primaryButtonAction = { [unowned self] viewController in
+            informationViewController.primaryButtonAction = { viewController in
                 viewController.presentingViewController?.presentingViewController?.dismiss(animated: true)
             }
             presentInNavigationController(informationViewController, in: navController)

--- a/Blockchain/KYC/KYCWelcomeController.swift
+++ b/Blockchain/KYC/KYCWelcomeController.swift
@@ -54,6 +54,9 @@ final class KYCWelcomeController: KYCBaseViewController {
     }
 
     // MARK: - Actions
+    @IBAction func onCloseTapped(_ sender: Any) {
+        self.presentingViewController?.dismiss(animated: true)
+    }
 
     @IBAction private func onLabelTapped(_ sender: UITapGestureRecognizer) {
         guard let text = labelTermsOfService.text else {

--- a/Blockchain/KYC/Storyboards/KYCWelcomeController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCWelcomeController.storyboard
@@ -109,7 +109,12 @@ identity verification to start buying and selling cryptocurrencies. This will on
                         <viewLayoutGuide key="safeArea" id="AzT-gm-yhf"/>
                     </view>
                     <navigationItem key="navigationItem" title="Exchange" id="PEt-7H-7Yn">
-                        <barButtonItem key="backBarButtonItem" id="EAJ-Wl-eES"/>
+                        <barButtonItem key="rightBarButtonItem" title="asdf" image="close" id="hvI-Vv-SE2">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <action selector="onCloseTapped:" destination="jKB-tY-Hco" id="Rkh-bF-xde"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
@@ -128,5 +133,6 @@ identity verification to start buying and selling cryptocurrencies. This will on
     </scenes>
     <resources>
         <image name="Welcome" width="272" height="137"/>
+        <image name="close" width="18" height="18"/>
     </resources>
 </document>


### PR DESCRIPTION
## Objective

Add close button to KYC welcome screen.

## Description

Add close button to KYC welcome screen so that there is a way to exit out of KYC.

## How to Test

Launch KYC.

## Screenshot

![simulator screen shot - iphone x - 2018-08-20 at 17 41 13](https://user-images.githubusercontent.com/38220701/44374043-24ddb680-a4a1-11e8-94ab-73936ecbfa39.png)

## Related Information

* Ticket Number: IOS-1160

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
