### PR TITLE
feat(KYC): IOS-1167 attach authorization token to KYC personal details screen

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -386,6 +386,20 @@
 		A2599BA71B0B726900C2EA81 /* BackupVerifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2599BA61B0B726900C2EA81 /* BackupVerifyViewController.swift */; };
 		A269E92E1B32D51F0052F953 /* SecondPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A269E92D1B32D51F0052F953 /* SecondPasswordViewController.swift */; };
 		A2913FA21B31830000DC6C15 /* BackupNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2913FA11B31830000DC6C15 /* BackupNavigationViewController.swift */; };
+		AA126CD8212C94CB005886A3 /* KYCApiTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CD5212C94CB005886A3 /* KYCApiTokenResponse.swift */; };
+		AA126CD9212C94CB005886A3 /* KYCApiTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CD5212C94CB005886A3 /* KYCApiTokenResponse.swift */; };
+		AA126CDA212C94CB005886A3 /* KYCCreateUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CD6212C94CB005886A3 /* KYCCreateUserResponse.swift */; };
+		AA126CDB212C94CB005886A3 /* KYCCreateUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CD6212C94CB005886A3 /* KYCCreateUserResponse.swift */; };
+		AA126CDC212C94CB005886A3 /* KYCSessionTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CD7212C94CB005886A3 /* KYCSessionTokenResponse.swift */; };
+		AA126CDD212C94CB005886A3 /* KYCSessionTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CD7212C94CB005886A3 /* KYCSessionTokenResponse.swift */; };
+		AA126CDF212C9735005886A3 /* KYCPageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CDE212C9735005886A3 /* KYCPageError.swift */; };
+		AA126CE0212C9735005886A3 /* KYCPageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CDE212C9735005886A3 /* KYCPageError.swift */; };
+		AA126CE2212C9753005886A3 /* KYCPagePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CE1212C9753005886A3 /* KYCPagePayload.swift */; };
+		AA126CE3212C9753005886A3 /* KYCPagePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CE1212C9753005886A3 /* KYCPagePayload.swift */; };
+		AA126CE5212C99FF005886A3 /* KYCPageViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CE4212C99FF005886A3 /* KYCPageViewFactory.swift */; };
+		AA126CE6212C99FF005886A3 /* KYCPageViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CE4212C99FF005886A3 /* KYCPageViewFactory.swift */; };
+		AA126CFD212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CFC212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift */; };
+		AA126CFE212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CFC212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift */; };
 		AA1E522B2097CA360099BD10 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522A2097CA360099BD10 /* AuthenticationCoordinator.swift */; };
 		AA1E522D2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522C2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift */; };
 		AA1E522F2097CC010099BD10 /* WalletAuthDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522E2097CC010099BD10 /* WalletAuthDelegate.swift */; };
@@ -580,12 +594,6 @@
 		AAF2AEE52123863200687E30 /* BlockchainDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD158DD2123740C0058B3C8 /* BlockchainDataRepository.swift */; };
 		AAF2AF062123952500687E30 /* KYCInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2AF052123952500687E30 /* KYCInformationViewModel.swift */; };
 		AAF2AF072123952500687E30 /* KYCInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2AF052123952500687E30 /* KYCInformationViewModel.swift */; };
-		AAF2AF3B2124D8E900687E30 /* KYCCreateUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2AF3A2124D8E900687E30 /* KYCCreateUserResponse.swift */; };
-		AAF2AF3C2124D8E900687E30 /* KYCCreateUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2AF3A2124D8E900687E30 /* KYCCreateUserResponse.swift */; };
-		AAF2AF3E2124D8F700687E30 /* KYCApiTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2AF3D2124D8F700687E30 /* KYCApiTokenResponse.swift */; };
-		AAF2AF3F2124D8F700687E30 /* KYCApiTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2AF3D2124D8F700687E30 /* KYCApiTokenResponse.swift */; };
-		AAF2AF412124E70500687E30 /* KYCSessionTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2AF402124E70500687E30 /* KYCSessionTokenResponse.swift */; };
-		AAF2AF422124E70500687E30 /* KYCSessionTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2AF402124E70500687E30 /* KYCSessionTokenResponse.swift */; };
 		AAFA97AE2115110000D19ED3 /* SettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FBE083211258F300AD514A /* SettingsCell.swift */; };
 		AAFA97AF2115110000D19ED3 /* SettingsTwoStepVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FBE084211258F300AD514A /* SettingsTwoStepVC.swift */; };
 		AAFA97B02115110000D19ED3 /* SettingsProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FBE085211258F300AD514A /* SettingsProtocols.swift */; };
@@ -2810,6 +2818,13 @@
 		A2AADC041B0B98720085144B /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Backup.strings; sourceTree = "<group>"; };
 		A2AADC071B0B999F0085144B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Backup.strings; sourceTree = "<group>"; };
 		A5185A3368C92DCF1134710A /* Pods_BlockchainTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlockchainTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA126CD5212C94CB005886A3 /* KYCApiTokenResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KYCApiTokenResponse.swift; path = Network/KYCApiTokenResponse.swift; sourceTree = "<group>"; };
+		AA126CD6212C94CB005886A3 /* KYCCreateUserResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KYCCreateUserResponse.swift; path = Network/KYCCreateUserResponse.swift; sourceTree = "<group>"; };
+		AA126CD7212C94CB005886A3 /* KYCSessionTokenResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KYCSessionTokenResponse.swift; path = Network/KYCSessionTokenResponse.swift; sourceTree = "<group>"; };
+		AA126CDE212C9735005886A3 /* KYCPageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCPageError.swift; sourceTree = "<group>"; };
+		AA126CE1212C9753005886A3 /* KYCPagePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCPagePayload.swift; sourceTree = "<group>"; };
+		AA126CE4212C99FF005886A3 /* KYCPageViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCPageViewFactory.swift; sourceTree = "<group>"; };
+		AA126CFC212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KYCUpdatePersonalDetailsRequest.swift; path = Network/KYCUpdatePersonalDetailsRequest.swift; sourceTree = "<group>"; };
 		AA1E522A2097CA360099BD10 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinator.swift; sourceTree = "<group>"; };
 		AA1E522C2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthenticationCoordinator+Pin.swift"; sourceTree = "<group>"; };
 		AA1E522E2097CC010099BD10 /* WalletAuthDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAuthDelegate.swift; sourceTree = "<group>"; };
@@ -2909,9 +2924,6 @@
 		AAE94F6920C75C4E005A3595 /* MockPinView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPinView.swift; sourceTree = "<group>"; };
 		AAE94F6B20C75C67005A3595 /* MockPinInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPinInteractor.swift; sourceTree = "<group>"; };
 		AAF2AF052123952500687E30 /* KYCInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCInformationViewModel.swift; sourceTree = "<group>"; };
-		AAF2AF3A2124D8E900687E30 /* KYCCreateUserResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KYCCreateUserResponse.swift; path = Blockchain/KYC/Models/Network/KYCCreateUserResponse.swift; sourceTree = SOURCE_ROOT; };
-		AAF2AF3D2124D8F700687E30 /* KYCApiTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KYCApiTokenResponse.swift; path = Blockchain/KYC/Models/Network/KYCApiTokenResponse.swift; sourceTree = SOURCE_ROOT; };
-		AAF2AF402124E70500687E30 /* KYCSessionTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KYCSessionTokenResponse.swift; path = Blockchain/KYC/Models/Network/KYCSessionTokenResponse.swift; sourceTree = SOURCE_ROOT; };
 		AAFA97B3211511D000D19ED3 /* Settings+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Settings+Helpers.swift"; sourceTree = "<group>"; };
 		AAFA97B4211511D000D19ED3 /* Settings+Table.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Settings+Table.swift"; sourceTree = "<group>"; };
 		AAFE9E742100D169002E4E1E /* PinStoreKeyPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinStoreKeyPair.swift; sourceTree = "<group>"; };
@@ -3212,10 +3224,10 @@
 			children = (
 				3A8B2289211E0B380091E706 /* KYCPersonalDetailsController.swift */,
 				3A3D5DD1211CA4A700E6C241 /* PersonalDetailsCoordinator.swift */,
-				3A3D5DCB211C9C5400E6C241 /* Service */,
-				3A3D5DC8211C9A7900E6C241 /* Models */,
-				3A3D5DC4211C991700E6C241 /* API */,
 				3A8B224B211CA7990091E706 /* PersonalDetailsDelegate.swift */,
+				3A3D5DC4211C991700E6C241 /* API */,
+				3A3D5DC8211C9A7900E6C241 /* Models */,
+				3A3D5DCB211C9C5400E6C241 /* Service */,
 			);
 			path = Personal;
 			sourceTree = "<group>";
@@ -3543,6 +3555,7 @@
 				602B9CCE2118E15200BD3D60 /* KYCCoordinator.swift */,
 				602B9CB12118E15200BD3D60 /* KYCNetworkRequest.swift */,
 				602B9CD12118E15200BD3D60 /* KYCOnboardingNavigationController.swift */,
+				AA126CE4212C99FF005886A3 /* KYCPageViewFactory.swift */,
 				602B9CD22118E15200BD3D60 /* KYCVerifyIdentityController.swift */,
 				602B9CD62118E15200BD3D60 /* KYCWelcomeController.swift */,
 				601F5EE0211B32AA002697AB /* OnfidoController.swift */,
@@ -3601,10 +3614,12 @@
 			children = (
 				AA4770B6211BA984006356B1 /* KYCAccountStatus.swift */,
 				602B9CBB2118E15200BD3D60 /* KYCCountry.swift */,
+				AA126CDE212C9735005886A3 /* KYCPageError.swift */,
 				3AFD18AE21221D95007145EA /* KYCPageModel.swift */,
+				AA126CE1212C9753005886A3 /* KYCPagePayload.swift */,
 				3A8B2291211E228C0091E706 /* KYCPageType.swift */,
 				3A8B229C211E2A960091E706 /* KYCUser.swift */,
-				AAF2AF392124AFBC00687E30 /* Network */,
+				AA126CD4212C94C1005886A3 /* Network */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -5863,6 +5878,17 @@
 			path = "View Controllers";
 			sourceTree = "<group>";
 		};
+		AA126CD4212C94C1005886A3 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				AA126CD5212C94CB005886A3 /* KYCApiTokenResponse.swift */,
+				AA126CD6212C94CB005886A3 /* KYCCreateUserResponse.swift */,
+				AA126CD7212C94CB005886A3 /* KYCSessionTokenResponse.swift */,
+				AA126CFC212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift */,
+			);
+			name = Network;
+			sourceTree = "<group>";
+		};
 		AA31A7B82098DFB900FE6268 /* Side Menu */ = {
 			isa = PBXGroup;
 			children = (
@@ -6169,17 +6195,6 @@
 				AAD158DD2123740C0058B3C8 /* BlockchainDataRepository.swift */,
 			);
 			path = Data;
-			sourceTree = "<group>";
-		};
-		AAF2AF392124AFBC00687E30 /* Network */ = {
-			isa = PBXGroup;
-			children = (
-				AAF2AF3D2124D8F700687E30 /* KYCApiTokenResponse.swift */,
-				AAF2AF3A2124D8E900687E30 /* KYCCreateUserResponse.swift */,
-				AAF2AF402124E70500687E30 /* KYCSessionTokenResponse.swift */,
-			);
-			name = Network;
-			path = "New Group";
 			sourceTree = "<group>";
 		};
 		C75F64F52124BB9000396B65 /* Homebrew */ = {
@@ -7030,10 +7045,12 @@
 				C72B851B210FC098002EBDB9 /* ExchangeCreateView.swift in Sources */,
 				C74E866220B3272B00F7263D /* TransferAllCoordinator.swift in Sources */,
 				AAE94F3D20C70F4B005A3595 /* BIP21URI.swift in Sources */,
+				AA126CFE212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift in Sources */,
 				51A862BE2090DD6400B338E0 /* PairingInstructionsView.swift in Sources */,
 				AAF2AF072123952500687E30 /* KYCInformationViewModel.swift in Sources */,
 				AA722C1A20B4BBA900262A5F /* AssetAddressRepository.swift in Sources */,
 				511356E4209CAFC600056D65 /* NetworkManager+PushNotifications.swift in Sources */,
+				AA126CDB212C94CB005886A3 /* KYCCreateUserResponse.swift in Sources */,
 				AAD27A29209CFE2100C0EAFC /* PasswordConfirmView.swift in Sources */,
 				C7057660212B4DD70027C6AA /* FromToButtonDelegateIntermediate.swift in Sources */,
 				C740FA8A210BAF740060292F /* WalletExchangeIntermediateDelegate.swift in Sources */,
@@ -7085,6 +7102,7 @@
 				602B9D162118E25A00BD3D60 /* LocationSuggestionService.swift in Sources */,
 				AA1E52332097CC260099BD10 /* WalletAuthDelegate.swift in Sources */,
 				AAE94DCF20C25F37005A3595 /* MockNetworkManager.swift in Sources */,
+				AA126CDD212C94CB005886A3 /* KYCSessionTokenResponse.swift in Sources */,
 				AACE31CF2092A99B00B7B806 /* AuthenticationManager.swift in Sources */,
 				51135707209CF68500056D65 /* BackupViewController.swift in Sources */,
 				AA94965F20CB5FA600A9C2DD /* AssetAddressFactory.swift in Sources */,
@@ -7098,6 +7116,7 @@
 				AACE31C32092A99B00B7B806 /* AppDelegate.swift in Sources */,
 				602B9D232118E27100BD3D60 /* KYCEnterPhoneNumberController.swift in Sources */,
 				AA3CA9B32107F2B700C2AD46 /* LogDestination.swift in Sources */,
+				AA126CD9212C94CB005886A3 /* KYCApiTokenResponse.swift in Sources */,
 				AADB027F20C0BACA000FFFEC /* WalletCryptoService.swift in Sources */,
 				AACE31822092858600B7B806 /* Pin.swift in Sources */,
 				AACE31D72092A99B00B7B806 /* Enum+Enumeratable.swift in Sources */,
@@ -7114,12 +7133,10 @@
 				C7BEE13120C720CA0096003B /* BitcoinCashURLPayload.swift in Sources */,
 				602B9D262118E27100BD3D60 /* KYCVerifyPhoneNumberInteractor.swift in Sources */,
 				51FC1B0A21270DBC007BEB18 /* SettingsTableSectionHeader.swift in Sources */,
-				AAF2AF422124E70500687E30 /* KYCSessionTokenResponse.swift in Sources */,
 				51DC2F6120B7312600E03AF2 /* EthereumAddress.swift in Sources */,
 				AA24D4C820D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift in Sources */,
 				AACE31DD2092A99B00B7B806 /* UserDefaults.swift in Sources */,
 				AACE31DF2092A99B00B7B806 /* CertificatePinner.swift in Sources */,
-				AAF2AF3C2124D8E900687E30 /* KYCCreateUserResponse.swift in Sources */,
 				AAE94F3620C70B97005A3595 /* AssetURLPayload.swift in Sources */,
 				AAFE9E9321016132002E4E1E /* PinError.swift in Sources */,
 				51D17A9A20A33A700071E7E0 /* PrivateKeyReader.swift in Sources */,
@@ -7206,7 +7223,6 @@
 				AACE31C62092A99B00B7B806 /* LoadingViewPresenter.swift in Sources */,
 				AAE9113620A520D40093A431 /* WalletAccountInfoDelegate.swift in Sources */,
 				C7D5115C21237DE000359651 /* HttpHeader.swift in Sources */,
-				AAF2AF3F2124D8F700687E30 /* KYCApiTokenResponse.swift in Sources */,
 				AAF2AEC22123799800687E30 /* KYCPersonalDetailsController.swift in Sources */,
 				AA447BDB2127BC1100EC0FA0 /* SideMenuViewController.swift in Sources */,
 				AA47709D211B7BC3006356B1 /* BottomButtonContainerView.swift in Sources */,
@@ -7222,6 +7238,8 @@
 				602B9D0D2118E23800BD3D60 /* KYCOnboardingNavigationController.swift in Sources */,
 				5114EA2420CD8B900098E26E /* UINavigationBar+TitleAttributes.swift in Sources */,
 				AA3CA9B02107F18D00C2AD46 /* Logger.swift in Sources */,
+				AA126CE6212C99FF005886A3 /* KYCPageViewFactory.swift in Sources */,
+				AA126CE0212C9735005886A3 /* KYCPageError.swift in Sources */,
 				600E18BB2118D46B003C1846 /* KeyboardPayload.swift in Sources */,
 				C764372A20ED199500CA7CA4 /* BalanceChartModel.swift in Sources */,
 				AADB023A20C0A871000FFFEC /* HttpMethod.swift in Sources */,
@@ -7232,6 +7250,7 @@
 				AA447BDA2127BC1100EC0FA0 /* SideMenuCell.swift in Sources */,
 				60B10D452118ED26003F945F /* CountryDataProvider.swift in Sources */,
 				C70576B3212CFFFC0027C6AA /* Nibable.swift in Sources */,
+				AA126CE3212C9753005886A3 /* KYCPagePayload.swift in Sources */,
 				AA94966420CB613100A9C2DD /* AssetAddressFactoryTests.swift in Sources */,
 				C76D732D20B2F5CD00040B57 /* WalletFiatAtTimeDelegate.swift in Sources */,
 			);
@@ -7241,6 +7260,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA126CDA212C94CB005886A3 /* KYCCreateUserResponse.swift in Sources */,
 				C7442E3A1FBB636300695E4C /* FromToView.m in Sources */,
 				AACE31582091681100B7B806 /* WalletManager.swift in Sources */,
 				3A76F8FE211A067A002F7946 /* ValidationFormView.swift in Sources */,
@@ -7269,6 +7289,7 @@
 				AAA3314E20893CE100BBD292 /* PairingInstructionsView.swift in Sources */,
 				AAA3316B2089650B00BBD292 /* AlertViewPresenter.swift in Sources */,
 				51E5C73320741A130000A7FD /* LocalizationConstants.swift in Sources */,
+				AA126CE2212C9753005886A3 /* KYCPagePayload.swift in Sources */,
 				C764372920ED199500CA7CA4 /* BalanceChartModel.swift in Sources */,
 				23FB5C101D9ABB730008C6AB /* TransactionDetailDateCell.m in Sources */,
 				606399EC2110FC2D005B6DF5 /* SRMutex.m in Sources */,
@@ -7304,13 +7325,13 @@
 				60AEA56821125AB20053A753 /* SettingsTwoStepVC.swift in Sources */,
 				AA3CA9B82107F66E00C2AD46 /* ConsoleLogDestination.swift in Sources */,
 				9F765F3214BC622E00048EFB /* TransactionsBitcoinViewController.m in Sources */,
+				AA126CDF212C9735005886A3 /* KYCPageError.swift in Sources */,
 				3A3D5DD2211CA4A700E6C241 /* PersonalDetailsCoordinator.swift in Sources */,
 				AA447BCA21276DA900EC0FA0 /* SideMenuPresenter.swift in Sources */,
 				AAFE9E752100D169002E4E1E /* PinStoreKeyPair.swift in Sources */,
 				C7A0E9261FA89FE9004F4267 /* ExchangeModalView.m in Sources */,
 				3AD7EEA221126578006B924F /* NibBasedView.swift in Sources */,
 				C7BEE13020C720CA0096003B /* BitcoinCashURLPayload.swift in Sources */,
-				AAF2AF3B2124D8E900687E30 /* KYCCreateUserResponse.swift in Sources */,
 				23964C031DCA3F19001323BE /* KeyPair.m in Sources */,
 				AA5B3B8020C9FC9C0026029D /* PEPinEntryController+PinView.swift in Sources */,
 				230FD2DC1C5BFB4300336683 /* QRCodeGenerator.m in Sources */,
@@ -7413,6 +7434,7 @@
 				C790E0F81E4E60AE0063D141 /* NSDateFormatter+TimeAgoString.m in Sources */,
 				230FD2D31C5BD04000336683 /* BCEditAddressView.m in Sources */,
 				3A3D5DC6211C992B00E6C241 /* PersonalDetailsAPI.swift in Sources */,
+				AA126CFD212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift in Sources */,
 				C75EE7D8201BBA820067BA16 /* UITextView+Animations.m in Sources */,
 				23C95EA61C0779C600E4692A /* SettingsChangePasswordViewController.m in Sources */,
 				51578AEA20B448BF00B0080A /* WalletKeyImportDelegate.swift in Sources */,
@@ -7484,6 +7506,7 @@
 				6775569919E752A00054699B /* BCWebViewController.m in Sources */,
 				C7442E341FBA1E7800695E4C /* ExchangeTableViewCell.m in Sources */,
 				C7559CBA1F573763005B2375 /* EtherTransaction.m in Sources */,
+				AA126CDC212C94CB005886A3 /* KYCSessionTokenResponse.swift in Sources */,
 				511356BE209B7F6E00056D65 /* BlockchainAPI+Payload.swift in Sources */,
 				C76135641F9E55DF0029E159 /* ExchangeCreateViewController.m in Sources */,
 				606399E42110FC2D005B6DF5 /* SRProxyConnect.m in Sources */,
@@ -7528,7 +7551,6 @@
 				602B9CF82118E15300BD3D60 /* PrimaryButtonContainer.swift in Sources */,
 				3A8B224C211CA7990091E706 /* PersonalDetailsDelegate.swift in Sources */,
 				AABDED92208FDFE3002D8BAC /* HTTPCookieStorage.swift in Sources */,
-				AAF2AF412124E70500687E30 /* KYCSessionTokenResponse.swift in Sources */,
 				9F1831E21516A39500FB3D52 /* NSData+Hex.m in Sources */,
 				6710DA0E1A8E82D80089DDED /* BCLine.m in Sources */,
 				C79B27B120A6215B0061D0F2 /* WalletSendEtherDelegate.swift in Sources */,
@@ -7554,6 +7576,7 @@
 				2322321A1B44D4CB00E5DF26 /* UpgradeViewController.m in Sources */,
 				9F1831EE151744EB00FB3D52 /* ReceiveTableCell.m in Sources */,
 				C72D6CBF1EC0B4AB0000F922 /* BCFeeSelectionView.m in Sources */,
+				AA126CD8212C94CB005886A3 /* KYCApiTokenResponse.swift in Sources */,
 				C7BEE13B20C828B20096003B /* BuySellCoordinator.swift in Sources */,
 				67EE1DCB19E3325900DBBFC9 /* ECSlidingAnimationController.m in Sources */,
 				60639A002110FC2D005B6DF5 /* SRConstants.m in Sources */,
@@ -7577,8 +7600,8 @@
 				6780DB921A40BDA70048EED2 /* AddressInOut.m in Sources */,
 				9F2780B715343A7D0015F83F /* UncaughtExceptionHandler.m in Sources */,
 				C76D731720B24B5400040B57 /* WalletTransferAllDelegate.swift in Sources */,
-				AAF2AF3E2124D8F700687E30 /* KYCApiTokenResponse.swift in Sources */,
 				C7559CAF1F55E874005B2375 /* BCConfirmPaymentViewModel.m in Sources */,
+				AA126CE5212C99FF005886A3 /* KYCPageViewFactory.swift in Sources */,
 				C733A89321236F02007DADE0 /* HttpHeader.swift in Sources */,
 				AA31A7D12099310B00FE6268 /* WalletBuySellDelegate.swift in Sources */,
 				84FC02FE19815F1B00B97D5B /* sha256.c in Sources */,

--- a/Blockchain/Data/BlockchainDataRepository.swift
+++ b/Blockchain/Data/BlockchainDataRepository.swift
@@ -18,7 +18,7 @@ import RxSwift
 
     private let authenticationService: KYCAuthenticationService
 
-    init(authenticationService: KYCAuthenticationService = KYCAuthenticationService()) {
+    init(authenticationService: KYCAuthenticationService = KYCAuthenticationService.shared) {
         self.authenticationService = authenticationService
     }
 

--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -170,14 +170,8 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
         )
         searchDelegate?.onSubmission(address, completion: { [weak self] in
             guard let this = self else { return }
-            this.coordinator.handle(event: .nextPageFromPageType(this.pageType))
+            this.coordinator.handle(event: .nextPageFromPageType(this.pageType, nil))
         })
-    }
-
-    // MARK: - Navigation
-
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // TODO: implement method body
     }
 }
 

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -213,7 +213,8 @@ extension KYCCountrySelectionController: UITableViewDataSource, UITableViewDeleg
 
 extension KYCCountrySelectionController: KYCCountrySelectionView {
     func continueKycFlow(country: KYCCountry) {
-        coordinator.handle(event: .nextPageFromPageType(pageType))
+        let payload = KYCPagePayload.countrySelected(country: country)
+        coordinator.handle(event: .nextPageFromPageType(pageType, payload))
     }
 
     func startPartnerExchangeFlow(country: KYCCountry) {

--- a/Blockchain/KYC/KYCAuthenticationService.swift
+++ b/Blockchain/KYC/KYCAuthenticationService.swift
@@ -18,6 +18,8 @@ final class KYCAuthenticationService {
         static let userId = "userId"
     }
 
+    static let shared = KYCAuthenticationService()
+
     private var cachedSessionToken = BehaviorRelay<KYCSessionTokenResponse?>(value: nil)
     private let wallet: Wallet
 

--- a/Blockchain/KYC/KYCBaseViewController.swift
+++ b/Blockchain/KYC/KYCBaseViewController.swift
@@ -19,7 +19,7 @@ class KYCBaseViewController: UIViewController, KYCCoordinatorDelegate {
     }
 
     func apply(model: KYCPageModel) {
-        Logger.shared.debug("Should be override to do something with KYCPageModel.")
+        Logger.shared.debug("Should be overriden to do something with KYCPageModel.")
     }
 
     override func viewDidLoad() {

--- a/Blockchain/KYC/KYCBaseViewController.swift
+++ b/Blockchain/KYC/KYCBaseViewController.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class KYCBaseViewController: UIViewController {
+class KYCBaseViewController: UIViewController, KYCCoordinatorDelegate {
 
     var coordinator: KYCCoordinator!
     var pageType: KYCPageType = .welcome
@@ -18,9 +18,22 @@ class KYCBaseViewController: UIViewController {
         return KYCBaseViewController()
     }
 
+    func apply(model: KYCPageModel) {
+        Logger.shared.debug("Should be override to do something with KYCPageModel.")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        coordinator.delegate = self
         coordinator.handle(event: .pageWillAppear(pageType))
     }
-}
 
+    override func viewWillDisappear(_ animated: Bool) {
+        coordinator.delegate = nil
+        super.viewWillDisappear(animated)
+    }
+}

--- a/Blockchain/KYC/KYCPageViewFactory.swift
+++ b/Blockchain/KYC/KYCPageViewFactory.swift
@@ -1,0 +1,37 @@
+//
+//  KYCPageViewFactory.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Factory for constructing a KYCBaseViewController
+class KYCPageViewFactory {
+    func createFrom(
+        pageType: KYCPageType,
+        in coordinator: KYCCoordinator,
+        payload: KYCPagePayload? = nil
+    ) -> KYCBaseViewController {
+        switch pageType {
+        case .welcome:
+            return KYCWelcomeController.make(with: coordinator)
+        case .country:
+            return KYCCountrySelectionController.make(with: coordinator)
+        case .profile:
+            return KYCPersonalDetailsController.make(with: coordinator)
+        case .address:
+            return KYCAddressController.make(with: coordinator)
+        case .enterPhone:
+            return KYCEnterPhoneNumberController.make(with: coordinator)
+        case .confirmPhone:
+            return KYCConfirmPhoneNumberController.make(with: coordinator)
+        case .verifyIdentity:
+            return KYCVerifyIdentityController.make(with: coordinator)
+        case .accountStatus:
+            return KYCInformationController.make(with: coordinator)
+        }
+    }
+}

--- a/Blockchain/KYC/KYCWelcomeController.swift
+++ b/Blockchain/KYC/KYCWelcomeController.swift
@@ -73,7 +73,7 @@ final class KYCWelcomeController: KYCBaseViewController {
     }
 
     @IBAction private func primaryButtonTapped(_ sender: Any) {
-        coordinator.handle(event: .nextPageFromPageType(pageType))
+        coordinator.handle(event: .nextPageFromPageType(pageType, nil))
     }
 
     // MARK: - Private Methods

--- a/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
@@ -93,7 +93,7 @@ final class KYCConfirmPhoneNumberController: KYCBaseViewController, BottomButton
 
 extension KYCConfirmPhoneNumberController: KYCConfirmPhoneNumberView {
     func confirmCodeSuccess() {
-        coordinator.handle(event: .nextPageFromPageType(pageType))
+        coordinator.handle(event: .nextPageFromPageType(pageType, nil))
     }
 
     func startVerificationSuccess() {

--- a/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
@@ -114,7 +114,7 @@ extension KYCEnterPhoneNumberController: KYCVerifyPhoneNumberView {
 
     func startVerificationSuccess() {
         Logger.shared.info("Show verification view!")
-        coordinator.handle(event: .nextPageFromPageType(pageType))
+        coordinator.handle(event: .nextPageFromPageType(pageType, nil))
     }
 
     func hideLoadingView() {

--- a/Blockchain/KYC/Models/KYCPageError.swift
+++ b/Blockchain/KYC/Models/KYCPageError.swift
@@ -1,0 +1,13 @@
+//
+//  KYCPageError.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+enum KYCPageError {
+    case countryNotSupported(KYCCountry)
+}

--- a/Blockchain/KYC/Models/KYCPageModel.swift
+++ b/Blockchain/KYC/Models/KYCPageModel.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum KYCPageModel {
-    case personalDetails(PersonalDetails)
+    case personalDetails(KYCUser)
     case address(UserAddress)
     case phone(Mobile)
 }

--- a/Blockchain/KYC/Models/KYCPagePayload.swift
+++ b/Blockchain/KYC/Models/KYCPagePayload.swift
@@ -1,0 +1,14 @@
+//
+//  KYCPagePayload.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Enumerates the supported payload types as a result of completing completing a KYC page
+enum KYCPagePayload {
+    case countrySelected(country: KYCCountry)
+}

--- a/Blockchain/KYC/Models/KYCPageType.swift
+++ b/Blockchain/KYC/Models/KYCPageType.swift
@@ -8,10 +8,6 @@
 
 import Foundation
 
-enum KYCPageError {
-    case countryNotSupported(KYCCountry)
-}
-
 enum KYCPageType {
     typealias PhoneNumber = String
 

--- a/Blockchain/KYC/Models/Network/KYCUpdatePersonalDetailsRequest.swift
+++ b/Blockchain/KYC/Models/Network/KYCUpdatePersonalDetailsRequest.swift
@@ -12,17 +12,17 @@ import Foundation
 struct KYCUpdatePersonalDetailsRequest: Codable {
     let firstName: String?
     let lastName: String?
-    let dob: Date?
+    let birthday: Date?
 
     enum CodingKeys: String, CodingKey {
         case firstName = "firstName"
         case lastName = "lastName"
-        case dob = "dob"
+        case birthday = "dob"
     }
 
-    init(firstName: String?, lastName: String?, dob: Date?) {
+    init(firstName: String?, lastName: String?, birthday: Date?) {
         self.firstName = firstName
         self.lastName = lastName
-        self.dob = dob
+        self.birthday = birthday
     }
 }

--- a/Blockchain/KYC/Models/Network/KYCUpdatePersonalDetailsRequest.swift
+++ b/Blockchain/KYC/Models/Network/KYCUpdatePersonalDetailsRequest.swift
@@ -1,0 +1,28 @@
+//
+//  KYCUpdatePersonalDetailsRequest.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Struct for updating the user's personal details during KYC
+struct KYCUpdatePersonalDetailsRequest: Codable {
+    let firstName: String?
+    let lastName: String?
+    let dob: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case firstName = "firstName"
+        case lastName = "lastName"
+        case dob = "dob"
+    }
+
+    init(firstName: String?, lastName: String?, dob: Date?) {
+        self.firstName = firstName
+        self.lastName = lastName
+        self.dob = dob
+    }
+}

--- a/Blockchain/KYC/Personal/API/PersonalDetailsAPI.swift
+++ b/Blockchain/KYC/Personal/API/PersonalDetailsAPI.swift
@@ -11,5 +11,5 @@ import Foundation
 typealias PersonalDetailsUpdateCompletion = ((Error?) -> Void)
 
 protocol PersonalDetailsAPI {
-    func update(personalDetails: PersonalDetails, with completion: @escaping PersonalDetailsUpdateCompletion)
+    func update(personalDetails: KYCUpdatePersonalDetailsRequest, with completion: @escaping PersonalDetailsUpdateCompletion)
 }

--- a/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
@@ -30,14 +30,10 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
     @IBOutlet var scrollView: UIScrollView!
 
     var validationFields: [ValidationTextField] {
-        get {
-            return [firstNameField,
-                    lastNameField,
-                    birthdayField]
-        }
+        return [firstNameField, lastNameField, birthdayField]
     }
 
-    var keyboard: KeyboardPayload? = nil
+    var keyboard: KeyboardPayload?
 
     // MARK: Public Properties
 
@@ -47,6 +43,8 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
 
     fileprivate var detailsCoordinator: PersonalDetailsCoordinator!
 
+    private var user: KYCUser?
+
     // MARK: Overrides
 
     override class func make(with coordinator: KYCCoordinator) -> KYCPersonalDetailsController {
@@ -54,6 +52,11 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
         controller.coordinator = coordinator
         controller.pageType = .profile
         return controller
+    }
+
+    override func apply(model: KYCPageModel) {
+        guard case let .personalDetails(user) = model else { return }
+        self.user = user
     }
 
     // MARK: Lifecycle
@@ -97,7 +100,7 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
 
         birthdayField.validationBlock = { value in
             guard let birthday = value else { return .invalid(nil) }
-            guard let date = DateFormatter.birthday.date(from: birthday) else { return .invalid(nil) }
+            guard let date = DateFormatter.medium.date(from: birthday) else { return .invalid(nil) }
             if date <= Date.eighteenYears {
                 return .valid
             } else {
@@ -126,31 +129,18 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
 
     fileprivate func primaryButtonTapped() {
         guard checkFieldsValidity() else { return }
-        guard let email = WalletManager.shared.wallet.getEmail() else { return }
         validationFields.forEach({$0.resignFocus()})
 
-        guard let details = PersonalDetails(
-            id: "",
-            first: firstNameField.text,
-            last: lastNameField.text,
-            email: email,
-            birthday: birthdayField.selectedDate
-            ) else { return }
+        let details = KYCUpdatePersonalDetailsRequest(
+            firstName: firstNameField.text,
+            lastName: lastNameField.text,
+            dob: birthdayField.selectedDate
+        )
 
         delegate?.onSubmission(details, completion: { [weak self] in
             guard let this = self else { return }
-            this.coordinator.handle(event: .nextPageFromPageType(this.pageType))
+            this.coordinator.handle(event: .nextPageFromPageType(this.pageType, nil))
         })
-    }
-
-    // MARK: - Navigation
-
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        guard let enterPhoneNumberController = segue.destination as? KYCEnterPhoneNumberController else {
-            return
-        }
-        // TODO: pass in actual userID
-        enterPhoneNumberController.userId = "userId"
     }
 }
 
@@ -175,8 +165,6 @@ extension KYCPersonalDetailsController: PersonalDetailsInterface {
 
 extension KYCPersonalDetailsController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        // TODO: May not be necessary. 
-        validationFields.forEach({$0.resignFocus()})
     }
 }
 
@@ -184,5 +172,6 @@ extension Date {
     static let eighteenYears: Date = Calendar.current.date(
         byAdding: .year,
         value: -18,
-        to: Date()) ?? Date()
+        to: Date()
+    ) ?? Date()
 }

--- a/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
@@ -134,7 +134,7 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
         let details = KYCUpdatePersonalDetailsRequest(
             firstName: firstNameField.text,
             lastName: lastNameField.text,
-            dob: birthdayField.selectedDate
+            birthday: birthdayField.selectedDate
         )
 
         delegate?.onSubmission(details, completion: { [weak self] in

--- a/Blockchain/KYC/Personal/PersonalDetailsCoordinator.swift
+++ b/Blockchain/KYC/Personal/PersonalDetailsCoordinator.swift
@@ -25,8 +25,7 @@ class PersonalDetailsCoordinator: NSObject {
 }
 
 extension PersonalDetailsCoordinator: PersonalDetailsDelegate {
-
-    func onSubmission(_ input: PersonalDetails, completion: @escaping () -> Void) {
+    func onSubmission(_ input: KYCUpdatePersonalDetailsRequest, completion: @escaping () -> Void) {
         interface?.primaryButtonEnabled(false)
         interface?.primaryButtonActivityIndicator(.visible)
         service.update(personalDetails: input) { [weak self] (error) in
@@ -35,7 +34,7 @@ extension PersonalDetailsCoordinator: PersonalDetailsDelegate {
 
             if let err = error {
                 // TODO: Error state
-                Logger.shared.error("\(err)")
+                Logger.shared.error("Failed to update personal details: \(err)")
             } else {
                 completion()
             }

--- a/Blockchain/KYC/Personal/PersonalDetailsDelegate.swift
+++ b/Blockchain/KYC/Personal/PersonalDetailsDelegate.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 protocol PersonalDetailsDelegate: class {
-    func onSubmission(_ input: PersonalDetails, completion: @escaping () -> Void)
+    func onSubmission(_ input: KYCUpdatePersonalDetailsRequest, completion: @escaping () -> Void)
 }

--- a/Blockchain/KYC/Storyboards/KYCPersonalDetailsController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCPersonalDetailsController.storyboard
@@ -38,7 +38,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oDQ-tQ-rDw">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="oDQ-tQ-rDw">
                                 <rect key="frame" x="0.0" y="47.333333333333314" width="375" height="642.66666666666674"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFe-4p-8Bl" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">

--- a/Blockchain/Network/NetworkManager.swift
+++ b/Blockchain/Network/NetworkManager.swift
@@ -105,7 +105,7 @@ class NetworkManager: NSObject, URLSessionDelegate {
         let host = challenge.protectionSpace.host
         Logger.shared.info("Received challenge from \(host)")
 
-        if BlockchainAPI.PartnerHosts.rawValues.contains(host) {
+        if BlockchainAPI.PartnerHosts.rawValues.contains(host) || host == "api.dev.blockchain.info" {
             completionHandler(.performDefaultHandling, nil)
         } else {
             CertificatePinner.shared.didReceive(challenge, completion: completionHandler)

--- a/Blockchain/Views/ValidationTextField/ValidationTextField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationTextField.swift
@@ -125,9 +125,12 @@ class ValidationTextField: NibBasedView {
         }
     }
 
-    var text: String? = "" {
-        didSet {
-            textField.text = text
+    var text: String? {
+        set {
+            textField.text = newValue
+        }
+        get {
+            return textField.text
         }
     }
 


### PR DESCRIPTION
## Objective

Complete personal detail screen

## Description

Completing the personal details screen—previously, the network call made after tapping on "next" did not work because it was blocked by KYC authentication.

Other changes:
* Creating `KYCPageViewFactory` which is in charge of constructing a `KYCBaseViewController` given a `KYCPageType` and `KYCPayload`
* Creating `KYCPayload` and updating the `nextPageFromPageType`. The idea behind this is that when a page completes it can pass in a `KYCPayload` (e.g. thought of this so that we can pass around the data selected from `KYCCountrySelectionController`

## How to Test

1. Pull these changes in
2. Add `|| host == "api.dev.blockchain.info"` to `NetworkManager`
3. Launch KYC -> Select "Germany" -> Fill out personal details screen -> verify that you can get passed this step

NOTE: if you fail to get a `KYCUser` when you create a new wallet, _make sure you use a unique email address._ This is because the backend will complain if you try to create a new `KYCUser` if one has already been created for the email address provided (an email address already exists for the address "test@doesnotexist.com")

## Screenshot

## Related Information

* Ticket Number: IOS-1167

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
