### PR TITLE
feat(KYC): IOS-1163 Complete update address network call.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -400,6 +400,8 @@
 		AA126CE6212C99FF005886A3 /* KYCPageViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CE4212C99FF005886A3 /* KYCPageViewFactory.swift */; };
 		AA126CFD212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CFC212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift */; };
 		AA126CFE212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CFC212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift */; };
+		AA126D12212D1B2B005886A3 /* KYCUpdateAddressRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126D11212D1B2B005886A3 /* KYCUpdateAddressRequest.swift */; };
+		AA126D13212D1B2B005886A3 /* KYCUpdateAddressRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126D11212D1B2B005886A3 /* KYCUpdateAddressRequest.swift */; };
 		AA1E522B2097CA360099BD10 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522A2097CA360099BD10 /* AuthenticationCoordinator.swift */; };
 		AA1E522D2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522C2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift */; };
 		AA1E522F2097CC010099BD10 /* WalletAuthDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1E522E2097CC010099BD10 /* WalletAuthDelegate.swift */; };
@@ -2825,6 +2827,7 @@
 		AA126CE1212C9753005886A3 /* KYCPagePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCPagePayload.swift; sourceTree = "<group>"; };
 		AA126CE4212C99FF005886A3 /* KYCPageViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCPageViewFactory.swift; sourceTree = "<group>"; };
 		AA126CFC212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KYCUpdatePersonalDetailsRequest.swift; path = Network/KYCUpdatePersonalDetailsRequest.swift; sourceTree = "<group>"; };
+		AA126D11212D1B2B005886A3 /* KYCUpdateAddressRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KYCUpdateAddressRequest.swift; path = Network/KYCUpdateAddressRequest.swift; sourceTree = "<group>"; };
 		AA1E522A2097CA360099BD10 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinator.swift; sourceTree = "<group>"; };
 		AA1E522C2097CA480099BD10 /* AuthenticationCoordinator+Pin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthenticationCoordinator+Pin.swift"; sourceTree = "<group>"; };
 		AA1E522E2097CC010099BD10 /* WalletAuthDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAuthDelegate.swift; sourceTree = "<group>"; };
@@ -5884,6 +5887,7 @@
 				AA126CD5212C94CB005886A3 /* KYCApiTokenResponse.swift */,
 				AA126CD6212C94CB005886A3 /* KYCCreateUserResponse.swift */,
 				AA126CD7212C94CB005886A3 /* KYCSessionTokenResponse.swift */,
+				AA126D11212D1B2B005886A3 /* KYCUpdateAddressRequest.swift */,
 				AA126CFC212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift */,
 			);
 			name = Network;
@@ -7036,6 +7040,7 @@
 				C79B27B220A6215B0061D0F2 /* WalletSendEtherDelegate.swift in Sources */,
 				AAF2AEC4212379D800687E30 /* PersonalDetailsDelegate.swift in Sources */,
 				516546F6208FCF710019EE63 /* NetworkManager+UserAgent.swift in Sources */,
+				AA126D13212D1B2B005886A3 /* KYCUpdateAddressRequest.swift in Sources */,
 				AAC9FCE620ADF17100E28B7A /* SoundManager.swift in Sources */,
 				51135708209CF69C00056D65 /* BackupWordsViewController.swift in Sources */,
 				AACE31C42092A99B00B7B806 /* Constants.swift in Sources */,
@@ -7377,6 +7382,7 @@
 				511BF4ED20E67B3B00A14072 /* AppReviewPrompt.swift in Sources */,
 				51A7349120891EB3009727D5 /* CertificatePinner.swift in Sources */,
 				602B9CF42118E15300BD3D60 /* KYCCoordinator.swift in Sources */,
+				AA126D12212D1B2B005886A3 /* KYCUpdateAddressRequest.swift in Sources */,
 				AA69F65F2086A7500054EFCE /* BlockchainSettings.swift in Sources */,
 				AAD279E0209A99DA00C0EAFC /* AVCaptureDeviceInput.swift in Sources */,
 				23B731D31E01AC1100129770 /* ReminderModalViewController.m in Sources */,

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -41,6 +41,8 @@ protocol KYCCoordinatorDelegate: class {
 
     private(set) var user: KYCUser?
 
+    private(set) var country: KYCCountry?
+
     weak var delegate: KYCCoordinatorDelegate?
 
     // MARK: - Private Properties
@@ -92,6 +94,7 @@ protocol KYCCoordinatorDelegate: class {
         case .failurePageForPageType(_, let error):
             handleFailurePage(for: error)
         case .nextPageFromPageType(let type, let payload):
+            handlePayloadFromPageType(type, payload)
             guard let nextPage = type.next else { return }
             let controller = pageFactory.createFrom(
                 pageType: nextPage,
@@ -124,6 +127,14 @@ protocol KYCCoordinatorDelegate: class {
 
     // MARK: Private Methods
 
+    private func handlePayloadFromPageType(_ pageType: KYCPageType, _ payload: KYCPagePayload?) {
+        guard let payload = payload else { return }
+        switch payload {
+        case .countrySelected(let country):
+            self.country = country
+        }
+    }
+
     private func handleFailurePage(for error: KYCPageError) {
         switch error {
         case .countryNotSupported(let country):
@@ -153,13 +164,11 @@ protocol KYCCoordinatorDelegate: class {
             delegate?.apply(model: .personalDetails(current))
         case .address:
             guard let current = user else { return }
-            guard let address = current.address else { return }
-            delegate?.apply(model: .address(address))
-
+            guard let country = country else { return }
+            delegate?.apply(model: .address(current, country))
         case .enterPhone:
             guard let current = user else { return }
-            guard let mobile = current.mobile else { return }
-            delegate?.apply(model: .phone(mobile))
+            delegate?.apply(model: .phone(current))
         }
     }
 

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -91,7 +91,7 @@ final class KYCNetworkRequest {
         enum PUT {
             case updateUserDetails
             case updateMobileNumber(userId: String)
-            case updateAddress(userId: String)
+            case updateAddress
 
             var path: String {
                 switch self {
@@ -99,8 +99,8 @@ final class KYCNetworkRequest {
                     return "/users/current"
                 case .updateMobileNumber(let userId):
                     return "/users/\(userId)/mobile"
-                case .updateAddress(let userId):
-                    return "/users/\(userId)/address"
+                case .updateAddress:
+                    return "/users/current/address"
                 }
             }
         }

--- a/Blockchain/KYC/Models/KYCPageModel.swift
+++ b/Blockchain/KYC/Models/KYCPageModel.swift
@@ -10,6 +10,6 @@ import Foundation
 
 enum KYCPageModel {
     case personalDetails(KYCUser)
-    case address(UserAddress)
-    case phone(Mobile)
+    case address(KYCUser, KYCCountry)
+    case phone(KYCUser)
 }

--- a/Blockchain/KYC/Models/Network/KYCUpdateAddressRequest.swift
+++ b/Blockchain/KYC/Models/Network/KYCUpdateAddressRequest.swift
@@ -1,0 +1,22 @@
+//
+//  KYCUpdateAddressRequest.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 8/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Model for updating the user's address during KYC
+struct KYCUpdateAddressRequest: Codable {
+    let address: UserAddress
+
+    enum CodingKeys: String, CodingKey {
+        case address
+    }
+
+    init(address: UserAddress) {
+        self.address = address
+    }
+}

--- a/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
@@ -50,6 +50,7 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
     override class func make(with coordinator: KYCCoordinator) -> KYCPersonalDetailsController {
         let controller = makeFromStoryboard()
         controller.coordinator = coordinator
+        controller.user = coordinator.user
         controller.pageType = .profile
         return controller
     }

--- a/Blockchain/KYC/Search/LocationSuggestionCoordinator.swift
+++ b/Blockchain/KYC/Search/LocationSuggestionCoordinator.swift
@@ -86,8 +86,7 @@ extension LocationSuggestionCoordinator: SearchControllerDelegate {
     func onSubmission(_ address: UserAddress, completion: @escaping () -> Void) {
         interface?.primaryButtonActivityIndicator(.visible)
         interface?.primaryButtonEnabled(false)
-        // TODO: Pass in correct userID
-        api.updateAddress(address: address, for: "userID") { [weak self] (error) in
+        api.updateAddress(address: address) { [weak self] (error) in
             guard let this = self else { return }
             this.interface?.primaryButtonActivityIndicator(.hidden)
             this.interface?.primaryButtonEnabled(true)

--- a/Blockchain/KYC/Search/Models/PostalAddress.swift
+++ b/Blockchain/KYC/Search/Models/PostalAddress.swift
@@ -37,7 +37,7 @@ struct UserAddress: Codable {
 }
 
 extension UserAddress: Equatable {
-    static func ==(lhs: UserAddress, rhs: UserAddress) -> Bool {
+    static func == (lhs: UserAddress, rhs: UserAddress) -> Bool {
         return lhs.lineOne == rhs.lineOne &&
             lhs.lineTwo == rhs.lineTwo &&
             lhs.postalCode == rhs.postalCode &&

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -562,6 +562,10 @@ struct LocalizationConstants {
             "Back to Dashboard",
             comment: "Text displayed on a button when the user wishes to navigate back to the dashboard view."
         )
+        static let yourHomeAddress = NSLocalizedString(
+            "Your Home Address",
+            comment: "Text displayed on the search bar when adding an address during KYC."
+        )
     }
 }
 


### PR DESCRIPTION
## Objective

Complete KYC update address network call.

## Description

This PR completes the address update network call when a user tries to update their address during KYC. This was done by:
1. Providing the selected `KYCCountry` into `KYCAddressController`
2. Using `KYCAuthenticationService` to retrieve a session token followed by using that token to attach it to the "Authorization" header of the `PUT /users/current/address` network call

NOTE: this is reviewable but would like to merge #423 first before this PR (once #423 is merged, I'll update the base branch for this PR, I chose to base it off of `personal_details` to make reviewing easier)

## How to Test

1. Pull in these changes
2. Launch KYC
3. Select a homebrew supported country (e.g. Germany)
4. Go through personal details screen and hit next
5. Select an address and hit next and verify that you can go to the next step (ie entering your phone number)

REMINDER: if you fail to get a KYCUser when you create a new wallet, make sure you use a unique email address. This is because the backend will complain if you try to create a new KYCUser if one has already been created for the email address provided (an email address already exists for the address "test@doesnotexist.com")

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
