### PR TITLE
fix(KYC): IOS-1174 skip enter phone number if user already has a verified number.

### DIFF
--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -95,7 +95,7 @@ protocol KYCCoordinatorDelegate: class {
             handleFailurePage(for: error)
         case .nextPageFromPageType(let type, let payload):
             handlePayloadFromPageType(type, payload)
-            guard let nextPage = type.next else { return }
+            guard let nextPage = type.nextPage(for: self.user) else { return }
             let controller = pageFactory.createFrom(
                 pageType: nextPage,
                 in: self,

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -220,6 +220,9 @@ final class KYCNetworkRequest {
                 guard let responseData = data else {
                     taskFailure(HTTPRequestPayloadError.emptyData); return
                 }
+                if let responseString = String(data: responseData, encoding: .utf8) {
+                    Logger.shared.debug("Response received: \(responseString)")
+                }
                 taskSuccess(responseData)
             }
         })

--- a/Blockchain/KYC/Models/KYCPageType.swift
+++ b/Blockchain/KYC/Models/KYCPageType.swift
@@ -24,7 +24,7 @@ enum KYCPageType {
 extension KYCPageType {
     /// The next page provided that the user successfully entered/selected
     /// information in this page.
-    var next: KYCPageType? {
+    func nextPage(for user: KYCUser?) -> KYCPageType? {
         switch self {
         case .welcome:
             return .country
@@ -33,6 +33,11 @@ extension KYCPageType {
         case .profile:
             return .address
         case .address:
+            // Skip the enter phone step if the user already has verified their
+            // phone number
+            if let user = user, let mobile = user.mobile, mobile.verified {
+                return .verifyIdentity
+            }
             return .enterPhone
         case .enterPhone:
             return .confirmPhone


### PR DESCRIPTION
## Objective

If the user already has set a phone number in their wallet, when they create a KYC user, they will already have those fields populated (no need to have them go through the enter/confirm phone # flow).

## Description

If the user already has set a phone number in their wallet, when they create a KYC user, they will already have those fields populated (no need to have them go through the enter/confirm phone # flow).

## How to Test

1. Create a wallet on dev on web (make sure to use a unique email address)
2. On web, set a phone number and verify it
3. Automatically pair your wallet on iOS and go through the KYC flow (make sure you are using the dev config values), notice that enter phone number is skipped

NOTE: since this requires the dev environment and dev certificates are not working, you'll ned to skip cert pinning by returning `true` in line 160 on NetworkManager.

i.e.

```
if true { //BlockchainAPI.PartnerHosts.rawValues.contains(host) {
    completionHandler(.performDefaultHandling, nil)
}
```

## Screenshot

N/A

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
