### PR TITLE
fix(KYC): launch application complete screen after onfido flow.

### DIFF
--- a/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
+++ b/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
@@ -150,6 +150,7 @@ final class KYCVerifyIdentityController: KYCBaseViewController {
             return
         }
         let onfidoController = OnfidoController(config: currentConfig)
+        onfidoController.delegate = self
         onfidoController.modalPresentationStyle = .overCurrentContext
         self.present(onfidoController, animated: true)
     }
@@ -160,5 +161,22 @@ final class KYCVerifyIdentityController: KYCBaseViewController {
         DispatchQueue.main.async {
             self.setUpAndShowDocumentDialog()
         }
+    }
+}
+
+extension KYCVerifyIdentityController: OnfidoControllerDelegate {
+    func onOnfidoControllerCancelled(_ onfidoController: OnfidoController) {
+        onfidoController.dismiss(animated: true)
+    }
+
+    func onOnfidoControllerErrored(_ onfidoController: OnfidoController, error: Error) {
+        onfidoController.dismiss(animated: true) {
+            AlertViewPresenter.shared.standardError(message: LocalizationConstants.Errors.error)
+        }
+    }
+
+    func onOnfidoControllerSuccess(_ onfidoController: OnfidoController) {
+        onfidoController.dismiss(animated: true)
+        coordinator.handle(event: .nextPageFromPageType(pageType, nil))
     }
 }

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -159,7 +159,6 @@ protocol KYCCoordinatorDelegate: class {
         case .welcome,
              .country,
              .confirmPhone,
-             .verifyIdentity,
              .accountStatus,
              .applicationComplete:
             break


### PR DESCRIPTION
## Objective

Launch KYC application complete screen after going through Onfido flow.

## How to Test

Go through KYC end-to-end.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [ ] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
