### PR TITLE
feat(CreateWalletView): IOS-1189 add privacy policy

### DIFF
--- a/Blockchain/Blockchain-Bridging-Header.h
+++ b/Blockchain/Blockchain-Bridging-Header.h
@@ -57,3 +57,5 @@
 #import "ExchangeTrade.h"
 #import "NSDateFormatter+TimeAgoString.h"
 #import "UIView+ChangeFrameAttribute.h"
+
+#import "UILabel+CGRectForSubstring.h"

--- a/Blockchain/Extensions/Bundle.swift
+++ b/Blockchain/Extensions/Bundle.swift
@@ -22,10 +22,10 @@ extension Bundle {
     }
     /// The build version of the application. Equivalent to CFBundleVersion.
     static var applicationBuildVersion: String? {
-        guard let infoDictionary = main.infoDictionary as? [String: String] else {
+        guard let infoDictionary = main.infoDictionary else {
             return nil
         }
-        guard let buildVersion = infoDictionary["CFBundleVersion"] else {
+        guard let buildVersion = infoDictionary["CFBundleVersion"] as? String else {
             return nil
         }
         return buildVersion

--- a/Blockchain/Extensions/NSAttributedString+Conveniences.swift
+++ b/Blockchain/Extensions/NSAttributedString+Conveniences.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public extension NSMutableAttributedString {
+@objc public extension NSMutableAttributedString {
 
     /// Sets the foreground color of the substring `text` to the provided `color`
     /// if `text` is within this attributed string's range.

--- a/Blockchain/KYC/KYCWelcomeController.swift
+++ b/Blockchain/KYC/KYCWelcomeController.swift
@@ -91,6 +91,8 @@ extension UITapGestureRecognizer {
     /// Checks if the tap occurred inside a specified range within a UILabel.
     /// See: https://stackoverflow.com/a/35789589
     ///
+    /// Warning: Does not work for labels with left-aligned text
+    ///
     /// - Parameters:
     ///   - label: the UILabel
     ///   - range: the NSRange
@@ -133,5 +135,4 @@ extension UITapGestureRecognizer {
 
         return NSLocationInRange(indexOfCharacter, range)
     }
-
 }

--- a/Blockchain/Localization/Base.lproj/MainWindow.xib
+++ b/Blockchain/Localization/Base.lproj/MainWindow.xib
@@ -165,7 +165,7 @@
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="13"/>
                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next"/>
                 </textField>
-                <label autoresizesSubviews="NO" opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="6" id="N1I-Aa-7Pp">
+                <label hidden="YES" autoresizesSubviews="NO" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="6" id="N1I-Aa-7Pp">
                     <rect key="frame" x="15" y="141" width="305" height="15"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <attributedString key="attributedText">
@@ -204,8 +204,8 @@
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="agreementLabel" destination="Qvx-f4-C2O" id="DlP-Fx-sIk"/>
-                <outlet property="agreementTappableLabel" destination="N1I-Aa-7Pp" id="5jT-e5-oqG"/>
+                <outlet property="agreementLabel" destination="Qvx-f4-C2O" id="gsn-PO-Fbo"/>
+                <outlet property="agreementTappablePlaceholderLabel" destination="N1I-Aa-7Pp" id="l4x-nc-TC5"/>
                 <outlet property="emailTextField" destination="LsW-69-Qon" id="DDn-ad-Tlz"/>
                 <outlet property="password2TextField" destination="397" id="452"/>
                 <outlet property="passwordFeedbackLabel" destination="Mk4-63-3pL" id="Vra-AS-94J"/>

--- a/Blockchain/Localization/Base.lproj/MainWindow.xib
+++ b/Blockchain/Localization/Base.lproj/MainWindow.xib
@@ -165,19 +165,20 @@
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="13"/>
                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next"/>
                 </textField>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="wfI-8F-dfm">
+                <label autoresizesSubviews="NO" opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="6" id="N1I-Aa-7Pp">
                     <rect key="frame" x="15" y="141" width="305" height="15"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <fontDescription key="fontDescription" name="GillSans" family="Gill Sans" pointSize="11"/>
-                    <state key="normal" title="Blockchain Terms of Service">
-                        <color key="titleColor" red="0.094117647060000004" green="0.61176470589999998" blue="0.86666666670000003" alpha="1" colorSpace="calibratedRGB"/>
-                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    </state>
-                    <connections>
-                        <action selector="termsOfServiceClicked:" destination="355" eventType="touchUpInside" id="cUG-Yk-K3K"/>
-                    </connections>
-                </button>
+                    <attributedString key="attributedText">
+                        <fragment content="Terms of Service &amp; Privacy Policy">
+                            <attributes>
+                                <color key="NSColor" red="0.63876992460000004" green="0.67347931859999999" blue="0.69598686700000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <font key="NSFont" size="11" name="GillSans"/>
+                                <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="truncatingTail" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                            </attributes>
+                        </fragment>
+                    </attributedString>
+                    <nil key="highlightedColor"/>
+                </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="By creating a new wallet you agree to the" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" id="Qvx-f4-C2O">
                     <rect key="frame" x="15" y="122" width="290" height="21"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
@@ -203,14 +204,14 @@
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
+                <outlet property="agreementLabel" destination="Qvx-f4-C2O" id="DlP-Fx-sIk"/>
+                <outlet property="agreementTappableLabel" destination="N1I-Aa-7Pp" id="5jT-e5-oqG"/>
                 <outlet property="emailTextField" destination="LsW-69-Qon" id="DDn-ad-Tlz"/>
                 <outlet property="password2TextField" destination="397" id="452"/>
                 <outlet property="passwordFeedbackLabel" destination="Mk4-63-3pL" id="Vra-AS-94J"/>
                 <outlet property="passwordStrengthMeter" destination="acf-bJ-kgP" id="ytC-Jd-waT"/>
                 <outlet property="passwordTextField" destination="395" id="451"/>
                 <outlet property="recoveryPhraseView" destination="0Sz-Ta-Xdw" id="xpu-3L-4fd"/>
-                <outlet property="termsOfServiceButton" destination="wfI-8F-dfm" id="t25-7g-ono"/>
-                <outlet property="termsOfServiceLabel" destination="Qvx-f4-C2O" id="nGX-Sx-BCA"/>
             </connections>
             <point key="canvasLocation" x="133" y="-869"/>
         </view>

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -261,6 +261,7 @@ struct LocalizationConstants {
 
     struct Onboarding {
         static let createNewWallet = NSLocalizedString("Create New Wallet", comment: "")
+        static let termsOfServiceAndPrivacyPolicyNoticePrefix = NSLocalizedString("By creating a wallet you agree to Blockchain's", comment: "Text displayed to the user notifying them that they implicitly agree to Blockchain's terms of service and privacy policy when they create a wallet")
         static let automaticPairing = NSLocalizedString("Automatic Pairing", comment: "")
         static let recoverFunds = NSLocalizedString("Recover Funds", comment: "")
         static let recoverFundsOnlyIfForgotCredentials = NSLocalizedString("You should always pair or login if you have access to your Wallet ID and password. Recovering your funds will create a new Wallet ID. Would you like to continue?", comment: "")
@@ -590,6 +591,18 @@ struct LocalizationConstants {
 // TODO: deprecate this once Obj-C is no longer using this
 /// LocalizationConstants class wrapper so that LocalizationConstants can be accessed from Obj-C.
 @objc class LocalizationConstantsObjcBridge: NSObject {
+    @objc class func createWalletLegalAgreementPrefix() -> String {
+        return LocalizationConstants.Onboarding.termsOfServiceAndPrivacyPolicyNoticePrefix
+    }
+
+    @objc class func termsOfService() -> String {
+        return LocalizationConstants.tos
+    }
+
+    @objc class func privacyPolicy() -> String {
+        return LocalizationConstants.privacyPolicy
+    }
+
     @objc class func continueString() -> String { return LocalizationConstants.continueString }
 
     @objc class func warning() -> String { return LocalizationConstants.Errors.warning }

--- a/Blockchain/Modal Content Views/BCCreateWalletView.h
+++ b/Blockchain/Modal Content Views/BCCreateWalletView.h
@@ -23,6 +23,7 @@
 #import "BCRecoveryView.h"
 #import "Wallet.h"
 
+// TICKET: IOS-1232 Refactor/Modernize BCCreateWalletView.
 @interface BCCreateWalletView : BCModalContentView <UITextFieldDelegate, WalletDelegate> {
     IBOutlet UITextField *emailTextField;
     IBOutlet UITextField *passwordTextField;

--- a/Blockchain/Modal Content Views/BCCreateWalletView.h
+++ b/Blockchain/Modal Content Views/BCCreateWalletView.h
@@ -29,8 +29,8 @@
     IBOutlet UITextField *password2TextField;
     IBOutlet UILabel *passwordFeedbackLabel;
     IBOutlet UIProgressView *passwordStrengthMeter;
+    IBOutlet UILabel *agreementTappablePlaceholderLabel;
     IBOutlet UILabel *agreementLabel;
-    IBOutlet UILabel *agreementTappableLabel;
 }
 
 + (nonnull BCCreateWalletView *)instanceFromNib;
@@ -45,4 +45,5 @@
 @property(nonatomic) float passwordStrength;
 @property(nonatomic) BOOL isRecoveringWallet;
 @property(nonatomic) UIButton *createButton;
+@property(nonatomic) UILabel *agreementTappableLabel;
 @end

--- a/Blockchain/Modal Content Views/BCCreateWalletView.h
+++ b/Blockchain/Modal Content Views/BCCreateWalletView.h
@@ -29,13 +29,11 @@
     IBOutlet UITextField *password2TextField;
     IBOutlet UILabel *passwordFeedbackLabel;
     IBOutlet UIProgressView *passwordStrengthMeter;
-    IBOutlet UILabel *termsOfServiceLabel;
-    IBOutlet UIButton *termsOfServiceButton;
+    IBOutlet UILabel *agreementLabel;
+    IBOutlet UILabel *agreementTappableLabel;
 }
 
 + (nonnull BCCreateWalletView *)instanceFromNib;
-
-- (IBAction)termsOfServiceClicked:(id)sender;
 
 - (void)createBlankWallet;
 - (void)showPassphraseTextField;

--- a/Blockchain/Modal Content Views/BCCreateWalletView.m
+++ b/Blockchain/Modal Content Views/BCCreateWalletView.m
@@ -53,31 +53,37 @@
 
     UIFont *agreementLabelFont = [UIFont fontWithName:FONT_GILL_SANS_REGULAR size:FONT_SIZE_EXTRA_EXTRA_SMALL];
     agreementLabel.font = agreementLabelFont;
-    agreementTappableLabel.font = agreementLabelFont;
+    
+    self.agreementTappableLabel = [[UILabel alloc] initWithFrame:CGRectMake(agreementTappablePlaceholderLabel.frame.origin.x, agreementTappablePlaceholderLabel.frame.origin.y, self.bounds.size.width, agreementTappablePlaceholderLabel.frame.size.height)];
+    self.agreementTappableLabel.userInteractionEnabled = YES;
+    [self addSubview:self.agreementTappableLabel];
+    
+    self.agreementTappableLabel.font = agreementLabelFont;
 
     agreementLabel.text = [LocalizationConstantsObjcBridge createWalletLegalAgreementPrefix];
 
     NSString *termsOfService = [LocalizationConstantsObjcBridge termsOfService];
     NSString *privacyPolicy = [LocalizationConstantsObjcBridge privacyPolicy];
-    agreementTappableLabel.text = [NSString stringWithFormat:@"%@ & %@", termsOfService, privacyPolicy];
+    self.agreementTappableLabel.text = [NSString stringWithFormat:@"%@ & %@", termsOfService, privacyPolicy];
 
-    NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:agreementTappableLabel.text attributes:@{NSFontAttributeName: agreementLabelFont, NSForegroundColorAttributeName: agreementLabel.textColor}];
+    NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:self.agreementTappableLabel.text attributes:@{NSFontAttributeName: agreementLabelFont, NSForegroundColorAttributeName: agreementLabel.textColor}];
     [attributedText addForegroundColor:[UIColor brandSecondary] to:termsOfService];
     [attributedText addForegroundColor:[UIColor brandSecondary] to:privacyPolicy];
-    agreementTappableLabel.attributedText = attributedText;
+    self.agreementTappableLabel.attributedText = attributedText;
 
-    UILabel *measuringLabel = [[UILabel alloc] initWithFrame:agreementTappableLabel.bounds];
-    measuringLabel.font = agreementTappableLabel.font;
-    measuringLabel.text = agreementTappableLabel.text;
+    UILabel *measuringLabel = [[UILabel alloc] initWithFrame:self.agreementTappableLabel.bounds];
+    measuringLabel.font = self.agreementTappableLabel.font;
+    measuringLabel.text = self.agreementTappableLabel.text;
 
-    // IOS-1107 - views produced here are offset in width somehow. See PartnerExchangeConfirmViewController.m for a correct implementation.
     UITapGestureRecognizer *tapGestureTermsOfService = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showTermsOfService)];
-    UIView *tappableViewTermsOfService = [self viewWithTapGesture:tapGestureTermsOfService onSubstring:termsOfService ofText:agreementTappableLabel.text inLabel:measuringLabel];
-    [agreementTappableLabel addSubview:tappableViewTermsOfService];
+    UIView *tappableViewTermsOfService = [self viewWithTapGesture:tapGestureTermsOfService onSubstring:termsOfService ofText:self.agreementTappableLabel.text inLabel:measuringLabel];
+    [tappableViewTermsOfService changeYPosition:tappableViewTermsOfService.frame.origin.y - 8];
+    [self.agreementTappableLabel addSubview:tappableViewTermsOfService];
 
     UITapGestureRecognizer *tapGesturePrivacyPolicy = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showPrivacyPolicy)];
-    UIView *tappableViewPrivacyPolicy = [self viewWithTapGesture:tapGesturePrivacyPolicy onSubstring:privacyPolicy ofText:agreementTappableLabel.text inLabel:measuringLabel];
-    [agreementTappableLabel addSubview:tappableViewPrivacyPolicy];
+    UIView *tappableViewPrivacyPolicy = [self viewWithTapGesture:tapGesturePrivacyPolicy onSubstring:privacyPolicy ofText:self.agreementTappableLabel.text inLabel:measuringLabel];
+    [tappableViewPrivacyPolicy changeYPosition:tappableViewPrivacyPolicy.frame.origin.y - 8];
+    [self.agreementTappableLabel addSubview:tappableViewPrivacyPolicy];
 }
 
 - (void)createBlankWallet

--- a/Blockchain/Modal Content Views/BCCreateWalletView.m
+++ b/Blockchain/Modal Content Views/BCCreateWalletView.m
@@ -70,6 +70,7 @@
     measuringLabel.font = agreementTappableLabel.font;
     measuringLabel.text = agreementTappableLabel.text;
 
+    // IOS-1107 - views produced here are offset in width somehow. See PartnerExchangeConfirmViewController.m for a correct implementation.
     UITapGestureRecognizer *tapGestureTermsOfService = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showTermsOfService)];
     UIView *tappableViewTermsOfService = [self viewWithTapGesture:tapGestureTermsOfService onSubstring:termsOfService ofText:agreementTappableLabel.text inLabel:measuringLabel];
     [agreementTappableLabel addSubview:tappableViewTermsOfService];

--- a/Blockchain/Models/TransactionDetailViewModel.m
+++ b/Blockchain/Models/TransactionDetailViewModel.m
@@ -58,7 +58,7 @@
         self.decimalAmount = [NSDecimalNumber decimalNumberWithString:decimalString];
         WalletManager.sharedInstance.latestMultiAddressResponse.symbol_btc = currentSymbol;
         
-        self.detailButtonTitle = [[NSString stringWithFormat:@"%@ %@",BC_STRING_VIEW_ON_URL_ARGUMENT, [[BlockchainAPI sharedInstance] blockchainWallet]] uppercaseString];
+        self.detailButtonTitle = [[NSString stringWithFormat:@"%@ %@",BC_STRING_VIEW_ON_URL_ARGUMENT, [[BlockchainAPI sharedInstance] blockchainDotInfo]] uppercaseString];
         self.detailButtonLink = [[[BlockchainAPI sharedInstance] walletUrl] stringByAppendingFormat:@"/tx/%@", self.myHash];
     }
     return self;

--- a/Blockchain/Network/BlockchainAPI.swift
+++ b/Blockchain/Network/BlockchainAPI.swift
@@ -38,7 +38,8 @@ final class BlockchainAPI: NSObject {
      */
     enum Hosts: String, RawValued {
         case blockchainAPI  = "api.blockchain.info"
-        case blockchainWallet = "blockchain.info"
+        case blockchainDotInfo = "blockchain.info"
+        case blockchainDotCom = "blockchain.com"
     }
 
     /// Public hosts used for partner API calls.
@@ -72,8 +73,11 @@ final class BlockchainAPI: NSObject {
     @objc func blockchainAPI() -> String {
         return Hosts.blockchainAPI.rawValue
     }
-    @objc func blockchainWallet() -> String {
-        return Hosts.blockchainWallet.rawValue
+    @objc func blockchainDotInfo() -> String {
+        return Hosts.blockchainDotInfo.rawValue
+    }
+    @objc func blockchainDotCom() -> String {
+        return Hosts.blockchainDotCom.rawValue
     }
     @objc func blockchair() -> String {
         return PartnerHosts.blockchair.rawValue

--- a/Blockchain/View Controllers/BCWebViewController.m
+++ b/Blockchain/View Controllers/BCWebViewController.m
@@ -136,7 +136,8 @@ NSMutableArray *visitedPages;
 {
     // External sites open in the system browser
     NSString *hostname = [[request URL] host];
-    if ([hostname rangeOfString:[[BlockchainAPI sharedInstance] blockchainWallet]].location == NSNotFound) {
+    if ([hostname rangeOfString:[[BlockchainAPI sharedInstance] blockchainDotInfo]].location == NSNotFound &&
+        [hostname rangeOfString:[[BlockchainAPI sharedInstance] blockchainDotCom]].location == NSNotFound) {
         [[UIApplication sharedApplication] openURL:[request URL]];
         return NO;
     }

--- a/Blockchain/View Controllers/BuyBitcoinViewController.m
+++ b/Blockchain/View Controllers/BuyBitcoinViewController.m
@@ -97,7 +97,8 @@ NSString* loginWithJsonScript(NSString*, NSString*, NSString*, NSString*, BOOL);
 }
 
 - (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler {
-    if ([challenge.protectionSpace.host hasSuffix:[[BlockchainAPI sharedInstance] blockchainWallet]]) {
+    if ([challenge.protectionSpace.host hasSuffix:[[BlockchainAPI sharedInstance] blockchainDotInfo]] ||
+        [challenge.protectionSpace.host hasSuffix:[[BlockchainAPI sharedInstance] blockchainDotCom]]) {
         [[CertificatePinner sharedInstance] didReceive:challenge completion:completionHandler];
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);


### PR DESCRIPTION
## Objective

- Add Privacy Policy link to Create Wallet View.
- Added `.com` and `.info` distinctions to `BlockchainAPI` `Hosts`, since the `BCWebViewController` was leaving the app due to the URLs being from `.com` instead of `.info`

## Description

~~Attempted to use this extension (https://github.com/blockchain/My-Wallet-V3-iOS/blob/kevin/IOS-1189/add_privacy_policy/Blockchain/KYC/KYCWelcomeController.swift#L100) to add a tappable view over attributed text, but it ends up being very offset for `.alignmentLeft`, even when the `textContainerOffset` is set to `0` as a user in the stackoverflow link suggests. Ended up using a pattern similar to the one in `PartnerExchangeConfirmViewController.m` to create tappable views over the Terms of Service and Privacy Policy. Unfortunately spent a lot of time on and havent found a way to fix this offset bug with a xib, possibly due to autoresizing. Moving this to `layoutSubviews` produces similar results:~~

<img width="550" alt="screen shot 2018-08-28 at 2 43 48 pm" src="https://user-images.githubusercontent.com/10579422/44743925-d13b2080-aad1-11e8-8849-69b078ada048.png">

~The implementation in `PartnerExchangeConfirmViewController.m` is exact in width:~
<img width="545" alt="screen shot 2018-08-28 at 2 54 10 pm" src="https://user-images.githubusercontent.com/10579422/44744083-427ad380-aad2-11e8-892e-5e3686d75e51.png">

~~I personally have preferred programmatic views to xibs/storyboards and this is an example of how precise control of views is much more difficult to achieve when using them.~~
Used a new `UILabel` instance separate from the xib initialization to fix:
<img width="516" alt="screen shot 2018-08-29 at 11 38 22 am" src="https://user-images.githubusercontent.com/10579422/44798652-0ef68280-ab80-11e8-94ba-872680eb2c89.png">

## How to Test

Go to create wallet view, tap close to Terms of Service and Privacy Policy.

## Screenshot

![simulator screen shot - iphone 6 - 2018-08-28 at 14 49 34](https://user-images.githubusercontent.com/10579422/44743848-9933dd80-aad1-11e8-8abf-c4943a55f765.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
