### PR TITLE
fix(Settings): IOS-1192 change verified text color to white

### DIFF
--- a/Blockchain/Settings/Settings+Helpers.swift
+++ b/Blockchain/Settings/Settings+Helpers.swift
@@ -131,7 +131,7 @@ extension AppSettingsController {
         if verified {
             self.createBadge(cell, color: .green)
             cell.detailTextLabel?.text = LocalizationConstants.verified
-            cell.detailTextLabel?.textColor = .green
+            cell.detailTextLabel?.textColor = .white
         } else {
             createBadge(cell, color: .unverified)
             cell.detailTextLabel?.text = LocalizationConstants.unverified


### PR DESCRIPTION
## Objective

To fix the text color of a verified badge in `formatDetailCell`.

## Description

Text color was green. Changed to white.

## How to Test

Verify your email and see white text on green badge.

## Screenshot

![simulator screen shot - iphone 6 - 2018-08-28 at 16 04 33](https://user-images.githubusercontent.com/10579422/44747818-1a906d80-aadc-11e8-9bff-b397848d3717.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [ ] All unit tests pass. (failing on `dev` at the time this was branched from it)
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)