### PR TITLE
fix(KYC): IOS-1228 adjust font weight on application completed screen

### DIFF
--- a/Blockchain/KYC/Storyboards/Base.lproj/KYCApplicationCompleteController.storyboard
+++ b/Blockchain/KYC/Storyboards/Base.lproj/KYCApplicationCompleteController.storyboard
@@ -10,9 +10,6 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
-        <array key="Montserrat-Light.ttf">
-            <string>Montserrat-Light</string>
-        </array>
         <array key="Montserrat-Regular.ttf">
             <string>Montserrat-Regular</string>
         </array>
@@ -39,8 +36,8 @@
                                         <rect key="frame" x="16" y="68" width="343" height="34.333333333333343"/>
                                         <string key="text">You successfuly submitted your information.
 Your account is now in review!</string>
-                                        <fontDescription key="fontDescription" name="Montserrat-Light" family="Montserrat" pointSize="14"/>
-                                        <nil key="textColor"/>
+                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
+                                        <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Done and Done!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OLG-9h-uZo">

--- a/Blockchain/KYC/Storyboards/Base.lproj/KYCApplicationCompleteController.storyboard
+++ b/Blockchain/KYC/Storyboards/Base.lproj/KYCApplicationCompleteController.storyboard
@@ -73,7 +73,7 @@ Your account is now in review!</string>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Country Selected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uhl-K2-ecB">
                                                 <rect key="frame" x="24" y="17" width="291" height="22"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" red="0.35686274509803922" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="6Mv-wE-w0S">
@@ -100,7 +100,7 @@ Your account is now in review!</string>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Profile Created" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bod-ac-mOs">
                                                 <rect key="frame" x="24" y="17" width="291" height="22"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" red="0.35686274509803922" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="Z2q-Ln-8Wl">
@@ -128,7 +128,7 @@ Your account is now in review!</string>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Home Address Added" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B4E-de-rse">
                                                 <rect key="frame" x="24" y="17" width="291" height="22"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="pfb-u3-qtd">
@@ -156,7 +156,7 @@ Your account is now in review!</string>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Device Verified" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ERB-lu-LbF">
                                                 <rect key="frame" x="24" y="17" width="291" height="22"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="XaQ-UI-CG3">
@@ -184,7 +184,7 @@ Your account is now in review!</string>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ID Uploaded" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fQ9-vv-Op5">
                                                 <rect key="frame" x="24" y="17" width="291" height="22"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="l4h-0d-Y4w">
@@ -212,7 +212,7 @@ Your account is now in review!</string>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="&quot;Hello Blockchain!&quot;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iRq-np-1Cz">
                                                 <rect key="frame" x="24" y="17" width="291" height="22"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="78x-fg-VtL">

--- a/Blockchain/KYC/Storyboards/Base.lproj/KYCApplicationCompleteController.storyboard
+++ b/Blockchain/KYC/Storyboards/Base.lproj/KYCApplicationCompleteController.storyboard
@@ -120,7 +120,6 @@ Your account is now in review!</string>
                                             <constraint firstAttribute="trailing" secondItem="Z2q-Ln-8Wl" secondAttribute="trailing" constant="24" id="hWd-qT-lN3"/>
                                             <constraint firstItem="Z2q-Ln-8Wl" firstAttribute="centerY" secondItem="nlb-i5-ZvY" secondAttribute="centerY" id="n6F-Pe-IlM"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="rrc-9z-kP9"/>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MkZ-R3-OEu" userLabel="Home Address Added Item">
                                         <rect key="frame" x="0.0" y="112" width="375" height="56"/>
@@ -148,7 +147,6 @@ Your account is now in review!</string>
                                             <constraint firstItem="B4E-de-rse" firstAttribute="leading" secondItem="MkZ-R3-OEu" secondAttribute="leading" constant="24" id="rX9-93-Ffy"/>
                                             <constraint firstAttribute="trailing" secondItem="pfb-u3-qtd" secondAttribute="trailing" constant="24" id="wUY-aP-BMv"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="2v5-8i-ocy"/>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lac-Yg-d13" userLabel="Device Verified Item">
                                         <rect key="frame" x="0.0" y="168" width="375" height="56"/>
@@ -176,7 +174,6 @@ Your account is now in review!</string>
                                             <constraint firstItem="ERB-lu-LbF" firstAttribute="leading" secondItem="lac-Yg-d13" secondAttribute="leading" constant="24" id="T3U-LI-kZv"/>
                                             <constraint firstAttribute="trailing" secondItem="XaQ-UI-CG3" secondAttribute="trailing" constant="24" id="v1H-jY-Xka"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="TAr-a4-Jik"/>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F4r-w7-una" userLabel="ID Uploaded Item">
                                         <rect key="frame" x="0.0" y="224" width="375" height="56"/>
@@ -204,7 +201,6 @@ Your account is now in review!</string>
                                             <constraint firstAttribute="height" constant="56" id="MIu-CH-W2s"/>
                                             <constraint firstItem="l4h-0d-Y4w" firstAttribute="centerY" secondItem="F4r-w7-una" secondAttribute="centerY" id="Sk9-hl-sRo"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="Icj-kY-SBc"/>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Th6-tZ-j5N" userLabel="Hello Blockchain Item">
                                         <rect key="frame" x="0.0" y="280" width="375" height="56"/>
@@ -232,7 +228,6 @@ Your account is now in review!</string>
                                             <constraint firstItem="iRq-np-1Cz" firstAttribute="centerY" secondItem="Th6-tZ-j5N" secondAttribute="centerY" id="jHb-uw-13a"/>
                                             <constraint firstAttribute="height" constant="56" id="pUt-ec-EtJ"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="ftQ-fm-wL0"/>
                                     </view>
                                 </subviews>
                                 <constraints>

--- a/Blockchain/KYC/Storyboards/Base.lproj/KYCApplicationCompleteController.storyboard
+++ b/Blockchain/KYC/Storyboards/Base.lproj/KYCApplicationCompleteController.storyboard
@@ -64,190 +64,202 @@ Your account is now in review!</string>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8KM-y2-CxS">
                                 <rect key="frame" x="0.0" y="134" width="375" height="480"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SxA-LM-ADP" userLabel="Country Selected Item">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ew-hS-p53">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="336"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Country Selected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uhl-K2-ecB">
-                                                <rect key="frame" x="24" y="17" width="291" height="22"/>
-                                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <color key="textColor" red="0.35686274509803922" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="6Mv-wE-w0S">
-                                                <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="odm-NO-3hJ" userLabel="Country Selected Item">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Country Selected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Puc-o5-mob">
+                                                        <rect key="frame" x="24" y="17" width="291" height="22"/>
+                                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
+                                                        <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="Jyw-9e-hnP">
+                                                        <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="20" id="Z0C-vo-kcc"/>
+                                                            <constraint firstAttribute="width" constant="20" id="fFY-LP-rCi"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="20" id="4fC-a3-hBM"/>
-                                                    <constraint firstAttribute="width" constant="20" id="AU3-J8-a6j"/>
+                                                    <constraint firstItem="Puc-o5-mob" firstAttribute="centerY" secondItem="odm-NO-3hJ" secondAttribute="centerY" id="0JY-JF-YEs"/>
+                                                    <constraint firstAttribute="height" constant="56" id="Nyb-ac-gUp"/>
+                                                    <constraint firstItem="Puc-o5-mob" firstAttribute="leading" secondItem="odm-NO-3hJ" secondAttribute="leading" constant="24" id="cUn-qe-ThF"/>
+                                                    <constraint firstItem="Jyw-9e-hnP" firstAttribute="centerY" secondItem="odm-NO-3hJ" secondAttribute="centerY" id="uE3-Mq-WqE"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Jyw-9e-hnP" secondAttribute="trailing" constant="24" id="v7Q-gc-mBd"/>
+                                                    <constraint firstItem="Jyw-9e-hnP" firstAttribute="leading" secondItem="Puc-o5-mob" secondAttribute="trailing" constant="16" id="zYU-AQ-cw0"/>
                                                 </constraints>
-                                            </imageView>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="Uhl-K2-ecB" firstAttribute="centerY" secondItem="SxA-LM-ADP" secondAttribute="centerY" id="QDd-rz-ZUC"/>
-                                            <constraint firstItem="6Mv-wE-w0S" firstAttribute="centerY" secondItem="SxA-LM-ADP" secondAttribute="centerY" id="QaC-li-sM4"/>
-                                            <constraint firstAttribute="height" constant="56" id="RDP-yv-xhY"/>
-                                            <constraint firstItem="6Mv-wE-w0S" firstAttribute="leading" secondItem="Uhl-K2-ecB" secondAttribute="trailing" constant="16" id="eSL-DH-loh"/>
-                                            <constraint firstAttribute="trailing" secondItem="6Mv-wE-w0S" secondAttribute="trailing" constant="24" id="j9f-Gl-GdO"/>
-                                            <constraint firstItem="Uhl-K2-ecB" firstAttribute="leading" secondItem="SxA-LM-ADP" secondAttribute="leading" constant="24" id="prx-4a-d1b"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nlb-i5-ZvY" userLabel="Profile Created Item">
-                                        <rect key="frame" x="0.0" y="56" width="375" height="56"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Profile Created" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bod-ac-mOs">
-                                                <rect key="frame" x="24" y="17" width="291" height="22"/>
-                                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <color key="textColor" red="0.35686274509803922" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="Z2q-Ln-8Wl">
-                                                <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fBf-Dl-Jpl" userLabel="Profile Created Item">
+                                                <rect key="frame" x="0.0" y="56" width="375" height="56"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Profile Created" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="USd-te-JzK">
+                                                        <rect key="frame" x="24" y="17" width="291" height="22"/>
+                                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
+                                                        <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="Nbx-j0-Qub">
+                                                        <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="20" id="3NL-gM-WUd"/>
+                                                            <constraint firstAttribute="height" constant="20" id="Okm-1a-Icp"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="20" id="1Ze-vU-0Yu"/>
-                                                    <constraint firstAttribute="width" constant="20" id="c5V-Dw-rxg"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Nbx-j0-Qub" secondAttribute="trailing" constant="24" id="CaH-iN-fxH"/>
+                                                    <constraint firstItem="USd-te-JzK" firstAttribute="centerY" secondItem="fBf-Dl-Jpl" secondAttribute="centerY" id="QcK-QG-KFI"/>
+                                                    <constraint firstItem="USd-te-JzK" firstAttribute="leading" secondItem="fBf-Dl-Jpl" secondAttribute="leading" constant="24" id="VyO-iu-hHi"/>
+                                                    <constraint firstAttribute="height" constant="56" id="rQR-z7-kGH"/>
+                                                    <constraint firstItem="Nbx-j0-Qub" firstAttribute="leading" secondItem="USd-te-JzK" secondAttribute="trailing" constant="16" id="uuL-Y2-THD"/>
+                                                    <constraint firstItem="Nbx-j0-Qub" firstAttribute="centerY" secondItem="fBf-Dl-Jpl" secondAttribute="centerY" id="vYm-As-ZV1"/>
                                                 </constraints>
-                                            </imageView>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="56" id="Duj-oV-UVD"/>
-                                            <constraint firstItem="bod-ac-mOs" firstAttribute="centerY" secondItem="nlb-i5-ZvY" secondAttribute="centerY" id="QiS-Mo-p8u"/>
-                                            <constraint firstItem="bod-ac-mOs" firstAttribute="leading" secondItem="nlb-i5-ZvY" secondAttribute="leading" constant="24" id="YA8-3Q-c5s"/>
-                                            <constraint firstItem="Z2q-Ln-8Wl" firstAttribute="leading" secondItem="bod-ac-mOs" secondAttribute="trailing" constant="16" id="eHv-ZB-1Lw"/>
-                                            <constraint firstAttribute="trailing" secondItem="Z2q-Ln-8Wl" secondAttribute="trailing" constant="24" id="hWd-qT-lN3"/>
-                                            <constraint firstItem="Z2q-Ln-8Wl" firstAttribute="centerY" secondItem="nlb-i5-ZvY" secondAttribute="centerY" id="n6F-Pe-IlM"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MkZ-R3-OEu" userLabel="Home Address Added Item">
-                                        <rect key="frame" x="0.0" y="112" width="375" height="56"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Home Address Added" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B4E-de-rse">
-                                                <rect key="frame" x="24" y="17" width="291" height="22"/>
-                                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="pfb-u3-qtd">
-                                                <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ejx-vW-uvf" userLabel="Home Address Added Item">
+                                                <rect key="frame" x="0.0" y="112" width="375" height="56"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Home Address Added" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wwO-B7-dU9">
+                                                        <rect key="frame" x="24" y="17" width="291" height="22"/>
+                                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
+                                                        <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="Lnv-Bk-jEG">
+                                                        <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="20" id="C4b-a3-n6f"/>
+                                                            <constraint firstAttribute="width" constant="20" id="pmO-Gk-NM6"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="20" id="eRu-hx-qiY"/>
-                                                    <constraint firstAttribute="width" constant="20" id="zAV-fg-alj"/>
+                                                    <constraint firstItem="Lnv-Bk-jEG" firstAttribute="centerY" secondItem="ejx-vW-uvf" secondAttribute="centerY" id="CfF-AC-KgH"/>
+                                                    <constraint firstItem="Lnv-Bk-jEG" firstAttribute="leading" secondItem="wwO-B7-dU9" secondAttribute="trailing" constant="16" id="D82-wF-0yz"/>
+                                                    <constraint firstItem="wwO-B7-dU9" firstAttribute="leading" secondItem="ejx-vW-uvf" secondAttribute="leading" constant="24" id="H4Q-XX-JyG"/>
+                                                    <constraint firstAttribute="height" constant="56" id="b28-OO-BmF"/>
+                                                    <constraint firstItem="wwO-B7-dU9" firstAttribute="centerY" secondItem="ejx-vW-uvf" secondAttribute="centerY" id="gv1-ma-KaN"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Lnv-Bk-jEG" secondAttribute="trailing" constant="24" id="hPm-hC-xPD"/>
                                                 </constraints>
-                                            </imageView>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="pfb-u3-qtd" firstAttribute="centerY" secondItem="MkZ-R3-OEu" secondAttribute="centerY" id="0ZH-pe-Fb9"/>
-                                            <constraint firstItem="pfb-u3-qtd" firstAttribute="leading" secondItem="B4E-de-rse" secondAttribute="trailing" constant="16" id="Kj5-Ft-jfZ"/>
-                                            <constraint firstAttribute="height" constant="56" id="Knv-fA-Xn1"/>
-                                            <constraint firstItem="B4E-de-rse" firstAttribute="centerY" secondItem="MkZ-R3-OEu" secondAttribute="centerY" id="hFm-S8-Yt9"/>
-                                            <constraint firstItem="B4E-de-rse" firstAttribute="leading" secondItem="MkZ-R3-OEu" secondAttribute="leading" constant="24" id="rX9-93-Ffy"/>
-                                            <constraint firstAttribute="trailing" secondItem="pfb-u3-qtd" secondAttribute="trailing" constant="24" id="wUY-aP-BMv"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lac-Yg-d13" userLabel="Device Verified Item">
-                                        <rect key="frame" x="0.0" y="168" width="375" height="56"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Device Verified" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ERB-lu-LbF">
-                                                <rect key="frame" x="24" y="17" width="291" height="22"/>
-                                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="XaQ-UI-CG3">
-                                                <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mZ8-i4-bdm" userLabel="Device Verified Item">
+                                                <rect key="frame" x="0.0" y="168" width="375" height="56"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Device Verified" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kka-o3-LnN">
+                                                        <rect key="frame" x="24" y="17" width="291" height="22"/>
+                                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
+                                                        <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="nie-wH-yjo">
+                                                        <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="20" id="La7-b4-FPY"/>
+                                                            <constraint firstAttribute="height" constant="20" id="oJb-vx-M4j"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="20" id="0o8-k0-QTA"/>
-                                                    <constraint firstAttribute="height" constant="20" id="TA9-T5-JG8"/>
+                                                    <constraint firstItem="Kka-o3-LnN" firstAttribute="centerY" secondItem="mZ8-i4-bdm" secondAttribute="centerY" id="86w-Nh-fXp"/>
+                                                    <constraint firstItem="Kka-o3-LnN" firstAttribute="leading" secondItem="mZ8-i4-bdm" secondAttribute="leading" constant="24" id="Z5U-sE-UgL"/>
+                                                    <constraint firstAttribute="height" constant="56" id="kF1-Zw-JCq"/>
+                                                    <constraint firstItem="nie-wH-yjo" firstAttribute="centerY" secondItem="mZ8-i4-bdm" secondAttribute="centerY" id="spE-PF-Jbi"/>
+                                                    <constraint firstItem="nie-wH-yjo" firstAttribute="leading" secondItem="Kka-o3-LnN" secondAttribute="trailing" constant="16" id="wkz-P0-ljm"/>
+                                                    <constraint firstAttribute="trailing" secondItem="nie-wH-yjo" secondAttribute="trailing" constant="24" id="yX0-f6-hgi"/>
                                                 </constraints>
-                                            </imageView>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="XaQ-UI-CG3" firstAttribute="leading" secondItem="ERB-lu-LbF" secondAttribute="trailing" constant="16" id="0Gc-PT-uwI"/>
-                                            <constraint firstItem="ERB-lu-LbF" firstAttribute="centerY" secondItem="lac-Yg-d13" secondAttribute="centerY" id="Kpq-vC-FpA"/>
-                                            <constraint firstAttribute="height" constant="56" id="Pk0-se-JC7"/>
-                                            <constraint firstItem="XaQ-UI-CG3" firstAttribute="centerY" secondItem="lac-Yg-d13" secondAttribute="centerY" id="Qy9-C9-ORz"/>
-                                            <constraint firstItem="ERB-lu-LbF" firstAttribute="leading" secondItem="lac-Yg-d13" secondAttribute="leading" constant="24" id="T3U-LI-kZv"/>
-                                            <constraint firstAttribute="trailing" secondItem="XaQ-UI-CG3" secondAttribute="trailing" constant="24" id="v1H-jY-Xka"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F4r-w7-una" userLabel="ID Uploaded Item">
-                                        <rect key="frame" x="0.0" y="224" width="375" height="56"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ID Uploaded" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fQ9-vv-Op5">
-                                                <rect key="frame" x="24" y="17" width="291" height="22"/>
-                                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="l4h-0d-Y4w">
-                                                <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NTd-jA-pHp" userLabel="Hello Blockchain Item">
+                                                <rect key="frame" x="0.0" y="280" width="375" height="56"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="&quot;Hello Blockchain!&quot;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ddc-sc-fJJ">
+                                                        <rect key="frame" x="24" y="17" width="291" height="22"/>
+                                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
+                                                        <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="tCs-E5-mBm">
+                                                        <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="20" id="1QY-Wy-yOh"/>
+                                                            <constraint firstAttribute="width" constant="20" id="J28-8C-fdS"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="20" id="icv-bQ-ygL"/>
-                                                    <constraint firstAttribute="width" constant="20" id="zYi-9u-X43"/>
+                                                    <constraint firstItem="tCs-E5-mBm" firstAttribute="centerY" secondItem="NTd-jA-pHp" secondAttribute="centerY" id="BQU-rU-fmr"/>
+                                                    <constraint firstItem="Ddc-sc-fJJ" firstAttribute="leading" secondItem="NTd-jA-pHp" secondAttribute="leading" constant="24" id="Fhf-0P-yWi"/>
+                                                    <constraint firstAttribute="trailing" secondItem="tCs-E5-mBm" secondAttribute="trailing" constant="24" id="V0y-aU-ugx"/>
+                                                    <constraint firstItem="tCs-E5-mBm" firstAttribute="leading" secondItem="Ddc-sc-fJJ" secondAttribute="trailing" constant="16" id="qSg-CX-TBH"/>
+                                                    <constraint firstAttribute="height" constant="56" id="tEY-gg-iAz"/>
+                                                    <constraint firstItem="Ddc-sc-fJJ" firstAttribute="centerY" secondItem="NTd-jA-pHp" secondAttribute="centerY" id="yhz-a2-vZ9"/>
                                                 </constraints>
-                                            </imageView>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="l4h-0d-Y4w" firstAttribute="leading" secondItem="fQ9-vv-Op5" secondAttribute="trailing" constant="16" id="5To-jd-zp0"/>
-                                            <constraint firstItem="fQ9-vv-Op5" firstAttribute="centerY" secondItem="F4r-w7-una" secondAttribute="centerY" id="GZo-5p-fI3"/>
-                                            <constraint firstAttribute="trailing" secondItem="l4h-0d-Y4w" secondAttribute="trailing" constant="24" id="KRr-Dg-RYG"/>
-                                            <constraint firstItem="fQ9-vv-Op5" firstAttribute="leading" secondItem="F4r-w7-una" secondAttribute="leading" constant="24" id="Ksh-Tk-zlM"/>
-                                            <constraint firstAttribute="height" constant="56" id="MIu-CH-W2s"/>
-                                            <constraint firstItem="l4h-0d-Y4w" firstAttribute="centerY" secondItem="F4r-w7-una" secondAttribute="centerY" id="Sk9-hl-sRo"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Th6-tZ-j5N" userLabel="Hello Blockchain Item">
-                                        <rect key="frame" x="0.0" y="280" width="375" height="56"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="&quot;Hello Blockchain!&quot;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iRq-np-1Cz">
-                                                <rect key="frame" x="24" y="17" width="291" height="22"/>
-                                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
-                                                <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="78x-fg-VtL">
-                                                <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5YT-eC-7cM" userLabel="ID Uploaded Item">
+                                                <rect key="frame" x="0.0" y="224" width="375" height="56"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ID Uploaded" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lae-zZ-Cfr">
+                                                        <rect key="frame" x="24" y="17" width="291" height="22"/>
+                                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="18"/>
+                                                        <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="itemChecked" translatesAutoresizingMaskIntoConstraints="NO" id="9bp-b4-oRP">
+                                                        <rect key="frame" x="331" y="18" width="20" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="20" id="4jm-aM-0rT"/>
+                                                            <constraint firstAttribute="width" constant="20" id="6H6-vT-pmD"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="20" id="JvD-AA-qJx"/>
-                                                    <constraint firstAttribute="height" constant="20" id="oKI-hE-BZY"/>
+                                                    <constraint firstItem="9bp-b4-oRP" firstAttribute="leading" secondItem="lae-zZ-Cfr" secondAttribute="trailing" constant="16" id="2Rt-Gu-k1F"/>
+                                                    <constraint firstAttribute="height" constant="56" id="7Le-5c-YWE"/>
+                                                    <constraint firstItem="lae-zZ-Cfr" firstAttribute="leading" secondItem="5YT-eC-7cM" secondAttribute="leading" constant="24" id="8zK-A6-xrK"/>
+                                                    <constraint firstAttribute="trailing" secondItem="9bp-b4-oRP" secondAttribute="trailing" constant="24" id="AYn-os-wMC"/>
+                                                    <constraint firstItem="lae-zZ-Cfr" firstAttribute="centerY" secondItem="5YT-eC-7cM" secondAttribute="centerY" id="kSH-tl-aNo"/>
+                                                    <constraint firstItem="9bp-b4-oRP" firstAttribute="centerY" secondItem="5YT-eC-7cM" secondAttribute="centerY" id="nSL-tO-hgy"/>
                                                 </constraints>
-                                            </imageView>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstItem="78x-fg-VtL" firstAttribute="leading" secondItem="iRq-np-1Cz" secondAttribute="trailing" constant="16" id="6FB-dd-c68"/>
-                                            <constraint firstItem="78x-fg-VtL" firstAttribute="centerY" secondItem="Th6-tZ-j5N" secondAttribute="centerY" id="GxR-ID-4mX"/>
-                                            <constraint firstAttribute="trailing" secondItem="78x-fg-VtL" secondAttribute="trailing" constant="24" id="XwK-qh-yeS"/>
-                                            <constraint firstItem="iRq-np-1Cz" firstAttribute="leading" secondItem="Th6-tZ-j5N" secondAttribute="leading" constant="24" id="fdM-Pv-h2x"/>
-                                            <constraint firstItem="iRq-np-1Cz" firstAttribute="centerY" secondItem="Th6-tZ-j5N" secondAttribute="centerY" id="jHb-uw-13a"/>
-                                            <constraint firstAttribute="height" constant="56" id="pUt-ec-EtJ"/>
+                                            <constraint firstItem="ejx-vW-uvf" firstAttribute="top" secondItem="fBf-Dl-Jpl" secondAttribute="bottom" id="1V1-yM-Iwd"/>
+                                            <constraint firstItem="NTd-jA-pHp" firstAttribute="top" secondItem="5YT-eC-7cM" secondAttribute="bottom" id="6ER-gn-mIt"/>
+                                            <constraint firstItem="mZ8-i4-bdm" firstAttribute="top" secondItem="ejx-vW-uvf" secondAttribute="bottom" id="AUP-bO-Ti8"/>
+                                            <constraint firstItem="fBf-Dl-Jpl" firstAttribute="leading" secondItem="8ew-hS-p53" secondAttribute="leading" id="EPq-zR-cEe"/>
+                                            <constraint firstItem="NTd-jA-pHp" firstAttribute="leading" secondItem="8ew-hS-p53" secondAttribute="leading" id="HJf-Z3-CQc"/>
+                                            <constraint firstItem="odm-NO-3hJ" firstAttribute="leading" secondItem="8ew-hS-p53" secondAttribute="leading" id="Hvz-jp-7Te"/>
+                                            <constraint firstItem="5YT-eC-7cM" firstAttribute="top" secondItem="mZ8-i4-bdm" secondAttribute="bottom" id="Mlq-Yt-K0r"/>
+                                            <constraint firstItem="fBf-Dl-Jpl" firstAttribute="top" secondItem="odm-NO-3hJ" secondAttribute="bottom" id="Nn6-Ud-E3u"/>
+                                            <constraint firstAttribute="trailing" secondItem="5YT-eC-7cM" secondAttribute="trailing" id="Qd7-LX-fHs"/>
+                                            <constraint firstAttribute="height" constant="336" id="bAQ-di-yp5"/>
+                                            <constraint firstItem="odm-NO-3hJ" firstAttribute="top" secondItem="8ew-hS-p53" secondAttribute="top" id="cCQ-qZ-B9j"/>
+                                            <constraint firstAttribute="trailing" secondItem="fBf-Dl-Jpl" secondAttribute="trailing" id="dvy-zd-eRW"/>
+                                            <constraint firstItem="5YT-eC-7cM" firstAttribute="leading" secondItem="8ew-hS-p53" secondAttribute="leading" id="f4s-Ya-vHS"/>
+                                            <constraint firstAttribute="trailing" secondItem="mZ8-i4-bdm" secondAttribute="trailing" id="gPz-TL-FDo"/>
+                                            <constraint firstItem="ejx-vW-uvf" firstAttribute="leading" secondItem="8ew-hS-p53" secondAttribute="leading" id="hER-6H-MMa"/>
+                                            <constraint firstAttribute="trailing" secondItem="NTd-jA-pHp" secondAttribute="trailing" id="huy-Js-MKG"/>
+                                            <constraint firstAttribute="trailing" secondItem="ejx-vW-uvf" secondAttribute="trailing" id="lg0-r2-dbR"/>
+                                            <constraint firstAttribute="trailing" secondItem="odm-NO-3hJ" secondAttribute="trailing" id="mly-I1-aYQ"/>
+                                            <constraint firstItem="mZ8-i4-bdm" firstAttribute="leading" secondItem="8ew-hS-p53" secondAttribute="leading" id="wdP-wo-qqe"/>
                                         </constraints>
                                     </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="leading" secondItem="lac-Yg-d13" secondAttribute="leading" id="878-1B-RNH"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="leading" secondItem="Th6-tZ-j5N" secondAttribute="leading" id="C4E-uE-DHt"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="top" secondItem="nlb-i5-ZvY" secondAttribute="bottom" id="CpN-CS-CVZ"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="trailing" secondItem="F4r-w7-una" secondAttribute="trailing" id="GB5-gU-gdL"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="trailing" secondItem="lac-Yg-d13" secondAttribute="trailing" id="KZ2-HG-kGH"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="trailing" secondItem="nlb-i5-ZvY" secondAttribute="trailing" id="M68-Mc-Ysh"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="trailing" secondItem="SxA-LM-ADP" secondAttribute="trailing" id="MOt-8l-vs1"/>
-                                    <constraint firstItem="nlb-i5-ZvY" firstAttribute="top" secondItem="SxA-LM-ADP" secondAttribute="bottom" id="RSj-ll-BfD"/>
-                                    <constraint firstItem="SxA-LM-ADP" firstAttribute="leading" secondItem="8KM-y2-CxS" secondAttribute="leading" id="UQK-G9-Ofn"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="leading" secondItem="F4r-w7-una" secondAttribute="leading" id="YVq-dE-S3c"/>
-                                    <constraint firstItem="Th6-tZ-j5N" firstAttribute="top" secondItem="F4r-w7-una" secondAttribute="bottom" id="Zn5-4o-fDh"/>
-                                    <constraint firstItem="lac-Yg-d13" firstAttribute="top" secondItem="MkZ-R3-OEu" secondAttribute="bottom" id="Zno-YK-ZgJ"/>
-                                    <constraint firstItem="F4r-w7-una" firstAttribute="top" secondItem="lac-Yg-d13" secondAttribute="bottom" id="c6y-s0-nwB"/>
-                                    <constraint firstItem="SxA-LM-ADP" firstAttribute="centerX" secondItem="8KM-y2-CxS" secondAttribute="centerX" id="cTE-Eb-GxS"/>
-                                    <constraint firstItem="SxA-LM-ADP" firstAttribute="top" secondItem="8KM-y2-CxS" secondAttribute="top" id="eIq-AT-Kdy"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="leading" secondItem="SxA-LM-ADP" secondAttribute="leading" id="gZL-69-NAO"/>
-                                    <constraint firstAttribute="bottom" secondItem="SxA-LM-ADP" secondAttribute="bottom" constant="416" id="jP1-6i-f4M"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="trailing" secondItem="Th6-tZ-j5N" secondAttribute="trailing" id="kBR-4J-fyN"/>
-                                    <constraint firstItem="MkZ-R3-OEu" firstAttribute="leading" secondItem="nlb-i5-ZvY" secondAttribute="leading" id="lQB-JP-yBR"/>
-                                    <constraint firstAttribute="trailing" secondItem="SxA-LM-ADP" secondAttribute="trailing" id="ycY-6l-2vC"/>
+                                    <constraint firstAttribute="trailing" secondItem="8ew-hS-p53" secondAttribute="trailing" id="2GG-KJ-Ptr"/>
+                                    <constraint firstItem="8ew-hS-p53" firstAttribute="leading" secondItem="8KM-y2-CxS" secondAttribute="leading" id="7W9-8p-7G8"/>
+                                    <constraint firstItem="8ew-hS-p53" firstAttribute="centerX" secondItem="8KM-y2-CxS" secondAttribute="centerX" id="P9E-8v-Emh"/>
+                                    <constraint firstItem="8ew-hS-p53" firstAttribute="top" secondItem="8KM-y2-CxS" secondAttribute="top" id="Xru-jZ-PdL"/>
+                                    <constraint firstAttribute="bottom" secondItem="8ew-hS-p53" secondAttribute="bottom" id="tIL-nl-lON"/>
                                 </constraints>
                             </scrollView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZwK-eI-yC5" customClass="PrimaryButton" customModule="Blockchain" customModuleProvider="target">
@@ -269,15 +281,15 @@ Your account is now in review!</string>
                         <constraints>
                             <constraint firstItem="iJa-Sa-q3Y" firstAttribute="trailing" secondItem="zBG-wU-ESN" secondAttribute="trailing" id="3Lk-4E-D3X"/>
                             <constraint firstItem="zBG-wU-ESN" firstAttribute="leading" secondItem="iJa-Sa-q3Y" secondAttribute="leading" id="41p-es-aIK"/>
+                            <constraint firstItem="ZwK-eI-yC5" firstAttribute="top" secondItem="8KM-y2-CxS" secondAttribute="bottom" constant="16" id="8Q1-s2-Gqr"/>
+                            <constraint firstItem="8KM-y2-CxS" firstAttribute="top" secondItem="zBG-wU-ESN" secondAttribute="bottom" id="DMJ-Fa-4Zi"/>
                             <constraint firstItem="ZwK-eI-yC5" firstAttribute="leading" secondItem="iJa-Sa-q3Y" secondAttribute="leading" constant="16" id="Ix8-VN-tYx"/>
-                            <constraint firstItem="8KM-y2-CxS" firstAttribute="trailing" secondItem="zBG-wU-ESN" secondAttribute="trailing" id="Rqu-BB-8fc"/>
                             <constraint firstItem="iJa-Sa-q3Y" firstAttribute="trailing" secondItem="ZwK-eI-yC5" secondAttribute="trailing" constant="16" id="TLy-Qi-CfU"/>
                             <constraint firstItem="iJa-Sa-q3Y" firstAttribute="top" secondItem="zBG-wU-ESN" secondAttribute="bottom" constant="-134" id="XQd-e8-2iU"/>
-                            <constraint firstItem="8KM-y2-CxS" firstAttribute="top" secondItem="zBG-wU-ESN" secondAttribute="bottom" id="Ztx-X4-nyO"/>
                             <constraint firstItem="zBG-wU-ESN" firstAttribute="top" secondItem="iJa-Sa-q3Y" secondAttribute="top" id="b4n-fr-ZJT"/>
+                            <constraint firstItem="8KM-y2-CxS" firstAttribute="leading" secondItem="zBG-wU-ESN" secondAttribute="leading" id="gMY-NY-e02"/>
                             <constraint firstItem="iJa-Sa-q3Y" firstAttribute="bottom" secondItem="ZwK-eI-yC5" secondAttribute="bottom" constant="16" id="rwQ-76-9MU"/>
-                            <constraint firstItem="ZwK-eI-yC5" firstAttribute="top" secondItem="8KM-y2-CxS" secondAttribute="bottom" constant="16" id="rwd-dK-GNW"/>
-                            <constraint firstItem="8KM-y2-CxS" firstAttribute="leading" secondItem="zBG-wU-ESN" secondAttribute="leading" id="xVf-f2-cDo"/>
+                            <constraint firstItem="8KM-y2-CxS" firstAttribute="trailing" secondItem="zBG-wU-ESN" secondAttribute="trailing" id="zAQ-TF-06l"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="iJa-Sa-q3Y"/>
                     </view>


### PR DESCRIPTION
## Objective

Adjust the font weight and label text color for the *Application Completed* screen.

## Description

Updated font weight and colors to match the designs. Also fixed the content scrolling behavior on smaller devices.

## How to Test

In `KYCCoordinator`, replace...
```
        guard let welcomeViewController = pageFactory.createFrom(
            pageType: .welcome,
            in: self
        ) as? KYCWelcomeController else { return }
        navController = presentInNavigationController(welcomeViewController, in: viewController)
```
with...
```
        guard let applicationCompleteController = pageFactory.createFrom(
            pageType: .applicationComplete,
            in: self) as? KYCApplicationCompleteController else { return }
        navController = presentInNavigationController(applicationCompleteController, in: viewController)
```

## Screenshot

![simulator screen shot - iphone x - 2018-08-29 at 10 54 12](https://user-images.githubusercontent.com/14079155/44795951-e53a5d00-ab79-11e8-99b9-f39d31721013.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [ ] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
