### PR TITLE
fix(KYC): add close button to account status view

### DIFF
--- a/Blockchain/KYC/Information/KYCInformationController.swift
+++ b/Blockchain/KYC/Information/KYCInformationController.swift
@@ -40,6 +40,14 @@ final class KYCInformationController: KYCBaseViewController {
         return controller
     }
 
+    // MARK: - IBActions
+
+    @IBAction func dismiss(_ sender: Any) {
+        dismiss(animated: false, completion: {
+            self.coordinator.end()
+        })
+    }
+
     // MARK: - Lifecycle Methods
 
     override func viewDidLoad() {

--- a/Blockchain/KYC/Information/KYCInformationController.swift
+++ b/Blockchain/KYC/Information/KYCInformationController.swift
@@ -44,7 +44,7 @@ final class KYCInformationController: KYCBaseViewController {
 
     @IBAction func dismiss(_ sender: Any) {
         dismiss(animated: false, completion: {
-            self.coordinator.end()
+            self.coordinator.finish()
         })
     }
 

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -88,6 +88,7 @@ protocol KYCCoordinatorDelegate: class {
     }
 
     func finish() {
+        // TODO: if applicable, persist state, do housekeeping, etc...
         navController.dismiss(animated: true)
     }
 

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -87,6 +87,10 @@ protocol KYCCoordinatorDelegate: class {
         navController = presentInNavigationController(welcomeViewController, in: viewController)
     }
 
+    func finish() {
+        navController.dismiss(animated: true)
+    }
+
     func handle(event: KYCEvent) {
         switch event {
         case .pageWillAppear(let type):

--- a/Blockchain/KYC/Storyboards/KYCInformationController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCInformationController.storyboard
@@ -130,6 +130,12 @@
                     </view>
                     <navigationItem key="navigationItem" title="Exchange" id="8I1-K6-NnG">
                         <barButtonItem key="backBarButtonItem" id="Vba-S8-Hwv"/>
+                        <barButtonItem key="rightBarButtonItem" image="close" id="wH2-u4-jo6">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <action selector="dismiss:" destination="uMm-1o-bGV" id="ivw-J1-IEw"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
@@ -147,5 +153,6 @@
     </scenes>
     <resources>
         <image name="AccountApproved" width="130" height="130"/>
+        <image name="close" width="18" height="18"/>
     </resources>
 </document>


### PR DESCRIPTION
## Objective

Add the missing close button to the account status view.

## How to Test

Launch the account status screen and dismiss it. Also observe that the entire KYC flow will be dismissed as well.

## Screenshot

![simulator screen shot - iphone x - 2018-08-30 at 09 47 07](https://user-images.githubusercontent.com/14079155/44855710-acfa5380-ac39-11e8-8d42-c074a1c0602c.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
