### PR TITLE
fix(KYC): IOS-1190 improve error copy

### DIFF
--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -477,7 +477,7 @@ struct LocalizationConstants {
 
     struct KYC {
         static let failedToConfirmNumber = NSLocalizedString(
-            "Failed to confirm number. Please try again.",
+            "The mobile number you have entered is already associated with an existing user.",
             comment: "Error message displayed to the user when the mobile confirmation steps fails."
         )
         static let termsOfServiceAndPrivacyPolicyNotice = NSLocalizedString(


### PR DESCRIPTION
## Objective

Improve the error handling when an existing phone number is used.

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
