### PR TITLE
fix(ExchangeCoordinator): show partner exchange if country is availab…

### DIFF
--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -159,6 +159,12 @@ struct ExchangeServices: ExchangeDependencies {
         }
     }
 
+    // TODO: use event handlers
+    func showPartnerExchange(rootViewController: UIViewController) {
+        self.rootViewController = rootViewController
+        showExchange(type: .shapeshift)
+    }
+
     // MARK: - Services
     private let marketsService: MarketsService
     private let exchangeService: ExchangeService

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -209,7 +209,7 @@ extension KYCCountrySelectionController: KYCCountrySelectionView {
     }
 
     func startPartnerExchangeFlow(country: KYCCountry) {
-        ExchangeCoordinator.shared.start(rootViewController: self)
+        ExchangeCoordinator.shared.showPartnerExchange(rootViewController: self)
     }
 
     func showExchangeNotAvailable(country: KYCCountry) {


### PR DESCRIPTION
…le for shapeshift but not for homebrew

## Objective

Fix circular logic where KYC keeps attempting to start itself when a country is not supported.

## Description

Added a temporary method `showPartnerExchange` that presents shapeshift on a given view controller.

## How to Test

Start KYC, select a country that is not supported by Homebrew but is supported by Shapeshift (e.g. Georgia) - shapeshift flow should appear. Closing that, selecting a country supported by Homebrew should allow user to proceed.

## Screenshot

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
