### PR TITLE
fix(KYC): IOS-1187 show correct verification status for new wallets

### DIFF
--- a/Blockchain/KYC/Information/KYCInformationViewModel.swift
+++ b/Blockchain/KYC/Information/KYCInformationViewModel.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 struct KYCInformationViewModel {
-    let image: UIImage
-    let title: String
+    let image: UIImage?
+    let title: String?
     let subtitle: String?
-    let description: String
+    let description: String?
     let buttonTitle: String?
     var badge: String?
 }
@@ -45,7 +45,7 @@ extension KYCInformationViewModel {
                 buttonTitle: LocalizationConstants.KYC.getStarted,
                 badge: LocalizationConstants.KYC.accounVerifiedBadge
             )
-        case .expired, .failed, .none:
+        case .expired, .failed:
             return KYCInformationViewModel(
                 image: #imageLiteral(resourceName: "AccountFailed"),
                 title: LocalizationConstants.KYC.verificationFailed,
@@ -62,6 +62,15 @@ extension KYCInformationViewModel {
                 description: LocalizationConstants.KYC.verificationInProgressDescription,
                 buttonTitle: LocalizationConstants.KYC.notifyMe,
                 badge: LocalizationConstants.KYC.accountUnderReviewBadge
+            )
+        case .none:
+            return KYCInformationViewModel(
+                image: nil,
+                title: nil,
+                subtitle: nil,
+                description: nil,
+                buttonTitle: nil,
+                badge: LocalizationConstants.KYC.accountUnverifiedBadge
             )
         }
     }

--- a/Blockchain/Localization/Base.lproj/Settings.storyboard
+++ b/Blockchain/Localization/Base.lproj/Settings.storyboard
@@ -52,8 +52,8 @@
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Unknown" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="uKc-pD-0Gk" customClass="EdgeInsetBadge" customModule="Blockchain" customModuleProvider="target">
-                                                    <rect key="frame" x="285.66666666666669" y="24" width="54.333333333333336" height="13.666666666666666"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Unverified" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="uKc-pD-0Gk" customClass="EdgeInsetBadge" customModule="Blockchain" customModuleProvider="target">
+                                                    <rect key="frame" x="282.33333333333331" y="24" width="57.666666666666664" height="13.666666666666666"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="11"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Blockchain/Settings/Settings+Helpers.swift
+++ b/Blockchain/Settings/Settings+Helpers.swift
@@ -148,8 +148,10 @@ extension AppSettingsController {
             case .expired, .failed, .none: cell.detailTextLabel?.backgroundColor = .unverified
             case .pending: cell.detailTextLabel?.backgroundColor = .pending
             }
+        } else if let theColor = color {
+            cell.detailTextLabel?.backgroundColor = theColor
         } else {
-            cell.detailTextLabel?.backgroundColor = color
+            cell.detailTextLabel?.backgroundColor = .unverified
         }
         cell.detailTextLabel?.textColor = .white
         cell.detailTextLabel?.font = UIFont(name: Constants.FontNames.montserratSemiBold, size: Constants.FontSizes.Tiny)

--- a/Blockchain/Settings/Settings+Table.swift
+++ b/Blockchain/Settings/Settings+Table.swift
@@ -216,7 +216,7 @@ extension SettingsTableViewController {
         switch indexPath.section {
         case sectionProfile:
             switch indexPath.row {
-            case identityVerification: KYCCoordinator.shared.start()
+            case identityVerification: KYCCoordinator.shared.start(from: self)
             case profileWalletIdentifier: walletIdentifierClicked()
             case profileEmail: emailClicked()
             case profileMobileNumber: mobileNumberClicked()

--- a/Blockchain/Settings/Settings+Table.swift
+++ b/Blockchain/Settings/Settings+Table.swift
@@ -136,15 +136,13 @@ extension SettingsTableViewController {
     }
 
     func prepareIdentityCell(_ cell: UITableViewCell) {
-        if preparedIdentityStatus { return }
-        self.createBadge(cell, color: .clear)
-        self.getUserVerificationStatus { status, success in
+        self.createBadge(cell)
+        self.getUserVerificationStatus { user, success in
             if success {
-                if let hasDetail = status?.status {
-                    let userModel = KYCInformationViewModel.create(for: hasDetail)
-                    self.createBadge(cell, status)
+                if let theUser = user {
+                    let userModel = KYCInformationViewModel.create(for: theUser.status)
+                    self.createBadge(cell, theUser)
                     cell.detailTextLabel?.text = userModel.badge
-                    self.preparedIdentityStatus = true
                 }
             } else {
                 self.createBadge(cell, color: .unverified)
@@ -187,7 +185,6 @@ extension SettingsTableViewController {
         case (sectionSecurity, pinBiometry): prepareRow(cell, .biometry)
         case (sectionSecurity, pinSwipeToReceive): prepareRow(cell, .swipeReceive)
         default: break
-
         }
     }
 
@@ -205,7 +202,7 @@ extension SettingsTableViewController {
         if indexPath.section == sectionProfile && indexPath.row == profileWalletIdentifier {
             return indexPath
         }
-        let hasLoadedAccountInfoDictionary: Bool = walletManager.wallet.hasLoadedAccountInfo ? true : false
+        let hasLoadedAccountInfoDictionary = walletManager.wallet.hasLoadedAccountInfo ? true : false
         if !hasLoadedAccountInfoDictionary || (UserDefaults.standard.object(forKey: "loadedSettings") as! Int != 0) == false {
             alertUserOfErrorLoadingSettings()
             return nil

--- a/Blockchain/View Controllers/Settings/SettingsCell.swift
+++ b/Blockchain/View Controllers/Settings/SettingsCell.swift
@@ -89,18 +89,14 @@ import UIKit
 
         self.detailTextLabel?.frame.origin.x = screenWidth - detailWidth! - 40
 
-        
         self.detailTextLabel?.font = UIFont(name: Constants.FontNames.montserratSemiBold, size: Constants.FontSizes.Tiny)
 
-        
 //        self.detailTextLabel?.layer.cornerRadius = 4
 //        self.detailTextLabel?.layer.masksToBounds = true
 //        self.detailTextLabel?.backgroundColor = .orange
 //        self.detailTextLabel?.textColor = .white
 //        sizeToFit()
 //        layoutIfNeeded()
-    
-        
     }
 }
 

--- a/Blockchain/View Controllers/Settings/SettingsCell.swift
+++ b/Blockchain/View Controllers/Settings/SettingsCell.swift
@@ -86,17 +86,8 @@ import UIKit
         self.detailTextLabel?.frame.origin.y = ypos
         let detailWidth =  self.detailTextLabel?.frame.size.width
         let screenWidth = UIScreen.main.bounds.width
-
         self.detailTextLabel?.frame.origin.x = screenWidth - detailWidth! - 40
-
         self.detailTextLabel?.font = UIFont(name: Constants.FontNames.montserratSemiBold, size: Constants.FontSizes.Tiny)
-
-//        self.detailTextLabel?.layer.cornerRadius = 4
-//        self.detailTextLabel?.layer.masksToBounds = true
-//        self.detailTextLabel?.backgroundColor = .orange
-//        self.detailTextLabel?.textColor = .white
-//        sizeToFit()
-//        layoutIfNeeded()
     }
 }
 

--- a/Blockchain/View Controllers/Settings/SettingsViewController.swift
+++ b/Blockchain/View Controllers/Settings/SettingsViewController.swift
@@ -57,8 +57,8 @@ MobileNumberDelegate, WalletAccountInfoDelegate {
     weak var delegate: (UIViewController & EmailDelegate)!
     weak var numberDelegate: (UIViewController & MobileNumberDelegate)!
     let walletManager: WalletManager
-    var userIdentityStatus: KYCUser?
-    var preparedIdentityStatus: Bool = false
+//    var userIdentityStatus: KYCUser?
+//    var preparedIdentityStatus: Bool = false
     
     var disposable: Disposable?
     
@@ -79,7 +79,7 @@ MobileNumberDelegate, WalletAccountInfoDelegate {
         super.viewDidAppear(animated)
         tableView.reloadData()
         self.walletManager.accountInfoDelegate = self
-        preparedIdentityStatus == false
+        // preparedIdentityStatus == false
     }
 
     convenience init(walletManager: WalletManager = WalletManager.shared) {

--- a/Blockchain/View Controllers/Settings/SettingsViewController.swift
+++ b/Blockchain/View Controllers/Settings/SettingsViewController.swift
@@ -57,8 +57,6 @@ MobileNumberDelegate, WalletAccountInfoDelegate {
     weak var delegate: (UIViewController & EmailDelegate)!
     weak var numberDelegate: (UIViewController & MobileNumberDelegate)!
     let walletManager: WalletManager
-//    var userIdentityStatus: KYCUser?
-//    var preparedIdentityStatus: Bool = false
     
     var disposable: Disposable?
     
@@ -79,7 +77,6 @@ MobileNumberDelegate, WalletAccountInfoDelegate {
         super.viewDidAppear(animated)
         tableView.reloadData()
         self.walletManager.accountInfoDelegate = self
-        // preparedIdentityStatus == false
     }
 
     convenience init(walletManager: WalletManager = WalletManager.shared) {


### PR DESCRIPTION
## Objective

Fix the default identity verification status for newly created wallets.

## Description

Previously, the case for a new user was handled in the same way as a user with a `failed` state.

## How to Test

Create a new wallet and launch the settings view. Observe that the label inside the identity verification cell reads `Unverified` as opposed to `Failed`.

## Screenshot/Design assessment

![simulator screen shot - iphone x - 2018-09-04 at 16 04 25](https://user-images.githubusercontent.com/14079155/45054851-38218200-b05c-11e8-93c4-5b50bced255a.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
