### PR TITLE
feat(KYC): IOS-1173 passing in Onfido applicant ID to Blockchain

### DIFF
--- a/Blockchain/KYC/Identity Verification/Service/OnfidoService.swift
+++ b/Blockchain/KYC/Identity Verification/Service/OnfidoService.swift
@@ -34,6 +34,26 @@ class OnfidoService {
         }
     }
 
+    /// Submits the Onfido user to Blockchain to complete KYC processing.
+    /// This should be invoked upon successfully uploading the identity docs to Onfido.
+    ///
+    /// - Parameter user: the OnfidoUser
+    /// - Returns: a Completable
+    func submitVerification(_ user: OnfidoUser) -> Completable {
+        return authService.getKycSessionToken().flatMapCompletable { token in
+            let headers = [HttpHeaderField.authorization: token.token]
+            let payload = [
+                "applicantId": user.identifier,
+                HttpHeaderField.clientType: HttpHeaderValue.clientTypeApp
+            ]
+            return KYCNetworkRequest.request(
+                post: .submitVerification,
+                parameters: payload,
+                headers: headers
+            )
+        }
+    }
+
     // MARK: - Private
 
     private func getOnfidoCredentials() -> Single<OnfidoCredentials> {

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -209,6 +209,15 @@ final class KYCNetworkRequest {
                 guard let httpResponse = response as? HTTPURLResponse else {
                     taskFailure(HTTPRequestServerError.badResponse); return
                 }
+                guard let responseData = data else {
+                    taskFailure(HTTPRequestPayloadError.emptyData); return
+                }
+
+                // Debugging
+                if let responseString = String(data: responseData, encoding: .utf8) {
+                    Logger.shared.debug("Response received: \(responseString)")
+                }
+
                 guard (200...299).contains(httpResponse.statusCode) else {
                     taskFailure(HTTPRequestServerError.badStatusCode(code: httpResponse.statusCode)); return
                 }
@@ -216,12 +225,6 @@ final class KYCNetworkRequest {
                     guard mimeType == HttpHeaderValue.json else {
                         taskFailure(HTTPRequestPayloadError.invalidMimeType(type: mimeType)); return
                     }
-                }
-                guard let responseData = data else {
-                    taskFailure(HTTPRequestPayloadError.emptyData); return
-                }
-                if let responseString = String(data: responseData, encoding: .utf8) {
-                    Logger.shared.debug("Response received: \(responseString)")
                 }
                 taskSuccess(responseData)
             }

--- a/Blockchain/KYC/OnfidoController.swift
+++ b/Blockchain/KYC/OnfidoController.swift
@@ -17,8 +17,8 @@ protocol OnfidoControllerDelegate: class {
 }
 
 class OnfidoController: UIViewController {
-    static let shared = OnfidoController()
     weak var delegate: OnfidoControllerDelegate?
+    var user: OnfidoUser!
     private var config: OnfidoConfig?
 
     convenience init() {


### PR DESCRIPTION
## Objective

Passing in the user's Onfido applicantId to Nabu/Blockchain upon submitting their identity docs.

## Description

Previously, the applicantId was not passed to the backend upon submitting identity docs to complete KYC processing.

Other changes:
* requiring the user to take a video rather than a selfie after submitting a capture of their identity card
* improving error logging in `KYCNetworkRequest` (i.e. prints to the console the error JSON we receive from the backend when we get a 4xx status code)

## How to Test

Launch KYC and go through the full steps. Unfortunately this is very difficult at the moment because KYC requires a unique mobile phone #.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
