### PR TITLE
feat(KYC): add country field to address view (IOS-1188)

### DIFF
--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -28,6 +28,7 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
     @IBOutlet fileprivate var cityTextField: ValidationTextField!
     @IBOutlet fileprivate var stateTextField: ValidationTextField!
     @IBOutlet fileprivate var postalCodeTextField: ValidationTextField!
+    @IBOutlet fileprivate var countryTextField: ValidationTextField!
     @IBOutlet fileprivate var primaryButtonContainer: PrimaryButtonContainer!
 
     // MARK: - Public IBOutlets
@@ -51,11 +52,13 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
     /// This is just for convenience purposes when iterating over the fields
     /// and checking validation etc.
     var validationFields: [ValidationTextField] {
-        return [addressTextField,
-                apartmentTextField,
-                cityTextField,
-                stateTextField,
-                postalCodeTextField
+        return [
+            addressTextField,
+            apartmentTextField,
+            cityTextField,
+            stateTextField,
+            postalCodeTextField,
+            countryTextField
         ]
     }
 
@@ -128,8 +131,11 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
         stateTextField.returnKeyType = .next
         stateTextField.contentType = .addressState
 
-        postalCodeTextField.returnKeyType = .done
+        postalCodeTextField.returnKeyType = .next
         postalCodeTextField.contentType = .postalCode
+
+        countryTextField.returnKeyType = .done
+        countryTextField.contentType = .countryName
 
         validationFields.enumerated().forEach { (index, field) in
             field.returnTappedBlock = { [weak self] in
@@ -214,6 +220,7 @@ extension KYCAddressController: LocationSuggestionInterface {
         cityTextField.text = address.city
         stateTextField.text = address.state
         postalCodeTextField.text = address.postalCode
+        countryTextField.text = address.country
     }
 
     func updateActivityIndicator(_ visibility: Visibility) {

--- a/Blockchain/KYC/Storyboards/Base.lproj/KYCAddressController.storyboard
+++ b/Blockchain/KYC/Storyboards/Base.lproj/KYCAddressController.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1m4-Wz-u3W">
-    <device id="retina4_0" orientation="portrait">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -24,32 +24,32 @@
             <objects>
                 <viewController title="Address View Controller" id="1m4-Wz-u3W" customClass="KYCAddressController" customModule="Blockchain" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="6kS-bR-6h1">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="LU7-BL-Zrb">
-                                <rect key="frame" x="0.0" y="64" width="320" height="8"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="8"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="8" id="Sev-w9-pJR"/>
                                 </constraints>
                             </progressView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fkm-6J-r0r">
-                                <rect key="frame" x="0.0" y="136.5" width="320" height="431.5"/>
+                                <rect key="frame" x="0.0" y="160.66666666666669" width="375" height="617.33333333333326"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <inset key="scrollIndicatorInsets" minX="18" minY="0.0" maxX="0.0" maxY="0.0"/>
                             </tableView>
                             <searchBar contentMode="redraw" verticalHuggingPriority="751" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="6g6-gf-4D1">
-                                <rect key="frame" x="8" y="80" width="304" height="56"/>
+                                <rect key="frame" x="8" y="104" width="359" height="56"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="Wz6-6Z-OCC"/>
                                 </constraints>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HTQ-Da-JDA">
-                                <rect key="frame" x="0.0" y="136" width="320" height="340"/>
+                                <rect key="frame" x="0.0" y="160" width="375" height="526"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HnA-P2-2Gj" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="40" width="288" height="56"/>
+                                        <rect key="frame" x="16" y="39.666666666666657" width="343" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="qiA-WP-2m1"/>
@@ -67,7 +67,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5mF-Bq-VW9" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="96" width="288" height="56"/>
+                                        <rect key="frame" x="16" y="95.666666666666657" width="343" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="OZn-hW-Aaj"/>
@@ -84,7 +84,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j8H-Lr-LlB" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="152" width="288" height="56"/>
+                                        <rect key="frame" x="16" y="151.66666666666669" width="343" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="vO7-yX-H6J"/>
@@ -102,7 +102,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MQL-tY-eAz" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="208" width="136" height="56"/>
+                                        <rect key="frame" x="16" y="207.66666666666669" width="163.66666666666666" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="gxq-ds-nCp"/>
@@ -120,7 +120,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LF7-ax-XE2" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="167.5" y="208" width="136.5" height="56"/>
+                                        <rect key="frame" x="195" y="207.66666666666669" width="164" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="5Kb-Nc-YfN"/>
@@ -138,7 +138,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wad-m7-6Ym" userLabel="Country Text Field" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="264" width="288" height="56"/>
+                                        <rect key="frame" x="16" y="263.66666666666669" width="343" height="56"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="56" id="Lab-xf-F25"/>
@@ -156,13 +156,13 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="What is the address used for?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TVk-mv-RzC">
-                                        <rect key="frame" x="16" y="0.0" width="288" height="15"/>
+                                        <rect key="frame" x="16" y="0.0" width="343" height="15"/>
                                         <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="12"/>
                                         <color key="textColor" red="0.30588235294117649" green="0.30588235294117649" blue="0.30588235294117649" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="999" text="We need this information to verify your identity." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zsH-tV-aX0">
-                                        <rect key="frame" x="16" y="17" width="288" height="15"/>
+                                        <rect key="frame" x="16" y="17" width="343" height="14.666666666666664"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="12"/>
                                         <color key="textColor" red="0.30588235294117649" green="0.30588235294117649" blue="0.30588235294117649" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -183,7 +183,6 @@
                                     <constraint firstItem="zsH-tV-aX0" firstAttribute="top" secondItem="TVk-mv-RzC" secondAttribute="bottom" constant="2" id="Pwb-jJ-RLZ"/>
                                     <constraint firstItem="MQL-tY-eAz" firstAttribute="trailing" secondItem="j8H-Lr-LlB" secondAttribute="centerX" constant="-8" id="QLk-Yl-ULp"/>
                                     <constraint firstItem="MQL-tY-eAz" firstAttribute="top" secondItem="j8H-Lr-LlB" secondAttribute="bottom" id="aPV-xw-zye"/>
-                                    <constraint firstAttribute="bottom" secondItem="MQL-tY-eAz" secondAttribute="bottom" id="cot-jt-cOH"/>
                                     <constraint firstItem="HnA-P2-2Gj" firstAttribute="leading" secondItem="HTQ-Da-JDA" secondAttribute="leading" constant="16" id="gmy-jw-t42"/>
                                     <constraint firstItem="LF7-ax-XE2" firstAttribute="top" secondItem="j8H-Lr-LlB" secondAttribute="bottom" id="nLG-mU-QFX"/>
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="leading" secondItem="HnA-P2-2Gj" secondAttribute="leading" id="nT3-YY-MhI"/>
@@ -195,17 +194,18 @@
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="width" secondItem="HnA-P2-2Gj" secondAttribute="width" id="sWF-2c-nZN"/>
                                     <constraint firstItem="zsH-tV-aX0" firstAttribute="leading" secondItem="TVk-mv-RzC" secondAttribute="leading" id="shJ-4e-F6e"/>
                                     <constraint firstItem="LF7-ax-XE2" firstAttribute="leading" secondItem="j8H-Lr-LlB" secondAttribute="centerX" constant="8" id="uub-Jl-NzC"/>
+                                    <constraint firstAttribute="bottom" secondItem="Wad-m7-6Ym" secondAttribute="bottom" constant="20" symbolic="YES" id="vnX-8b-8T3"/>
                                 </constraints>
                                 <connections>
                                     <outlet property="delegate" destination="1m4-Wz-u3W" id="GHu-es-UQT"/>
                                 </connections>
                             </scrollView>
                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="FFX-OX-l36">
-                                <rect key="frame" x="141.5" y="334" width="37" height="37"/>
+                                <rect key="frame" x="169" y="451" width="37" height="37"/>
                                 <color key="color" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </activityIndicatorView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bhb-q7-xBR" customClass="PrimaryButtonContainer" customModule="Blockchain" customModuleProvider="target">
-                                <rect key="frame" x="16" y="508" width="287.5" height="44"/>
+                                <rect key="frame" x="16" y="718" width="343" height="44"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="7OT-yL-tsy"/>

--- a/Blockchain/KYC/Storyboards/Base.lproj/KYCAddressController.storyboard
+++ b/Blockchain/KYC/Storyboards/Base.lproj/KYCAddressController.storyboard
@@ -137,6 +137,24 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wad-m7-6Ym" userLabel="Country Text Field" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
+                                        <rect key="frame" x="16" y="264" width="288" height="56"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="56" id="Lab-xf-F25"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Country"/>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
+                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                                <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="What is the address used for?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TVk-mv-RzC">
                                         <rect key="frame" x="16" y="0.0" width="288" height="15"/>
                                         <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="12"/>
@@ -159,7 +177,9 @@
                                     <constraint firstItem="j8H-Lr-LlB" firstAttribute="width" secondItem="5mF-Bq-VW9" secondAttribute="width" id="9hf-ex-7fK"/>
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="top" secondItem="HnA-P2-2Gj" secondAttribute="bottom" id="Db8-K7-5xO"/>
                                     <constraint firstItem="MQL-tY-eAz" firstAttribute="leading" secondItem="j8H-Lr-LlB" secondAttribute="leading" id="Egi-9K-lbW"/>
+                                    <constraint firstItem="Wad-m7-6Ym" firstAttribute="leading" secondItem="HTQ-Da-JDA" secondAttribute="leading" constant="16" id="FgZ-94-Q7N"/>
                                     <constraint firstItem="HnA-P2-2Gj" firstAttribute="width" secondItem="HTQ-Da-JDA" secondAttribute="width" constant="-32" id="Jyz-vG-0JH"/>
+                                    <constraint firstAttribute="trailing" secondItem="Wad-m7-6Ym" secondAttribute="trailing" constant="16" id="MuI-xj-vYt"/>
                                     <constraint firstItem="zsH-tV-aX0" firstAttribute="top" secondItem="TVk-mv-RzC" secondAttribute="bottom" constant="2" id="Pwb-jJ-RLZ"/>
                                     <constraint firstItem="MQL-tY-eAz" firstAttribute="trailing" secondItem="j8H-Lr-LlB" secondAttribute="centerX" constant="-8" id="QLk-Yl-ULp"/>
                                     <constraint firstItem="MQL-tY-eAz" firstAttribute="top" secondItem="j8H-Lr-LlB" secondAttribute="bottom" id="aPV-xw-zye"/>
@@ -169,6 +189,7 @@
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="leading" secondItem="HnA-P2-2Gj" secondAttribute="leading" id="nT3-YY-MhI"/>
                                     <constraint firstItem="HnA-P2-2Gj" firstAttribute="top" secondItem="zsH-tV-aX0" secondAttribute="bottom" constant="8" id="nw1-NY-jhH"/>
                                     <constraint firstItem="zsH-tV-aX0" firstAttribute="trailing" secondItem="TVk-mv-RzC" secondAttribute="trailing" id="oBT-ma-W1E"/>
+                                    <constraint firstItem="Wad-m7-6Ym" firstAttribute="top" secondItem="LF7-ax-XE2" secondAttribute="bottom" id="oOL-uO-XQ8"/>
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="height" secondItem="HnA-P2-2Gj" secondAttribute="height" id="qJ0-ut-CxM"/>
                                     <constraint firstAttribute="trailing" secondItem="HnA-P2-2Gj" secondAttribute="trailing" constant="16" id="ro4-4Z-JhY"/>
                                     <constraint firstItem="5mF-Bq-VW9" firstAttribute="width" secondItem="HnA-P2-2Gj" secondAttribute="width" id="sWF-2c-nZN"/>
@@ -229,6 +250,7 @@
                         <outlet property="addressTextField" destination="HnA-P2-2Gj" id="Gl8-tC-Ya0"/>
                         <outlet property="apartmentTextField" destination="5mF-Bq-VW9" id="P4y-WS-nbX"/>
                         <outlet property="cityTextField" destination="j8H-Lr-LlB" id="C3k-xF-5Hp"/>
+                        <outlet property="countryTextField" destination="Wad-m7-6Ym" id="r9K-V2-rp7"/>
                         <outlet property="layoutConstraintBottomButton" destination="mQa-gA-TTY" id="fO2-mo-UgL"/>
                         <outlet property="postalCodeTextField" destination="LF7-ax-XE2" id="1zJ-7Y-SwY"/>
                         <outlet property="primaryButtonContainer" destination="bhb-q7-xBR" id="0UF-pO-SuD"/>


### PR DESCRIPTION
## Objective

Add missing country field to address screen.

## Screenshot/Design assessment

![simulator screen shot - iphone x - 2018-09-05 at 11 42 01](https://user-images.githubusercontent.com/14079155/45104718-b9325500-b100-11e8-9470-7d57306b31fc.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
