### PR TITLE
fix(KYC): allow description label to grow vertically (IOS-1180)

### DIFF
--- a/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
@@ -49,7 +49,7 @@
                                         <color key="textColor" red="0.30588235289999999" green="0.30588235289999999" blue="0.30588235289999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Right now, digital currency conversions are only available in select countries." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wZm-cR-Ltr">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Right now, digital currency conversions are only available in select countries." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wZm-cR-Ltr">
                                         <rect key="frame" x="16" y="39" width="343" height="29.333333333333329"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="12"/>
                                         <color key="textColor" red="0.30588235289999999" green="0.30588235289999999" blue="0.30588235289999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
## Objective

Prevent copy from being cut off on smaller devices.

## Description

Changed the text label's `number of lines` attribute to allow the label to grow vertically.

## Screenshot/Design assessment

![simulator screen shot - iphone se - 2018-09-05 at 13 44 27](https://user-images.githubusercontent.com/14079155/45111007-d4599080-b111-11e8-9702-e0af2a901399.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
