### PR TITLE
feat(KYC): IOS-1142 restore view state if user drops of mid-flow.

### DIFF
--- a/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
@@ -32,10 +32,10 @@ class MarketsService {
     private let restMessageSubject = PublishSubject<Conversion>()
     private var dataSource: DataSource = .socket
 
-    private let authentication: KYCAuthenticationService
+    private let authentication: NabuAuthenticationService
     var hasAuthenticated: Bool = false
 
-    init(service: KYCAuthenticationService = KYCAuthenticationService.shared) {
+    init(service: NabuAuthenticationService = NabuAuthenticationService.shared) {
         self.authentication = service
     }
 
@@ -127,7 +127,7 @@ private extension MarketsService {
     }
 
     func authenticateSocket() {
-        let authenticationDisposable = KYCAuthenticationService.shared.getKycSessionToken()
+        let authenticationDisposable = authentication.getSessionToken()
             .map { tokenResponse -> Subscription<AuthSubscribeParams> in
                 let params = AuthSubscribeParams(type: "auth", token: tokenResponse.token)
                 return Subscription(channel: "auth", operation: "subscribe", params: params)

--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -74,6 +74,13 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
         guard case let .address(user, country) = model else { return }
         self.user = user
         self.country = country
+
+        guard let address = user.address else { return }
+        addressTextField.text = address.lineOne
+        apartmentTextField.text = address.lineTwo
+        postalCodeTextField.text = address.postalCode
+        cityTextField.text = address.city
+        stateTextField.text = address.state
     }
 
     // MARK: Lifecycle
@@ -163,10 +170,7 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
 
     fileprivate func primaryButtonTapped() {
         guard checkFieldsValidity() else { return }
-        guard let country = country else {
-            Logger.shared.debug("country is nil. Cannot proceed.")
-            return
-        }
+
         validationFields.forEach({$0.resignFocus()})
 
         let address = UserAddress(
@@ -175,7 +179,7 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
             postalCode: postalCodeTextField.text ?? "",
             city: cityTextField.text ?? "",
             state: stateTextField.text ?? "",
-            country: country.name
+            country: country?.name ?? user?.address?.country ?? ""
         )
         searchDelegate?.onSubmission(address, completion: { [weak self] in
             guard let this = self else { return }

--- a/Blockchain/KYC/KYCPageViewFactory.swift
+++ b/Blockchain/KYC/KYCPageViewFactory.swift
@@ -27,11 +27,7 @@ class KYCPageViewFactory {
         case .enterPhone:
             return KYCEnterPhoneNumberController.make(with: coordinator)
         case .confirmPhone:
-            let viewController = KYCConfirmPhoneNumberController.make(with: coordinator)
-            if let payload = payload, case let .phoneNumberUpdated(number) = payload {
-                viewController.phoneNumber = number
-            }
-            return viewController
+            return KYCConfirmPhoneNumberController.make(with: coordinator)
         case .verifyIdentity:
             return KYCVerifyIdentityController.make(with: coordinator)
         case .accountStatus:

--- a/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
@@ -10,9 +10,9 @@ import Foundation
 
 final class KYCConfirmPhoneNumberController: KYCBaseViewController, BottomButtonContainerView {
 
-    // MARK: Public Properties
+    // MARK: Private Properties
 
-    var phoneNumber: String = "" {
+    private var phoneNumber: String = "" {
         didSet {
             guard isViewLoaded else { return }
             labelPhoneNumber.text = phoneNumber
@@ -50,9 +50,7 @@ final class KYCConfirmPhoneNumberController: KYCBaseViewController, BottomButton
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // TICKET: IOS-1141 display correct % in the progress view
         validationTextFieldConfirmationCode.autocapitalizationType = .allCharacters
-        labelPhoneNumber.text = phoneNumber
         originalBottomButtonConstraint = layoutConstraintBottomButton.constant
         validationTextFieldConfirmationCode.becomeFocused()
     }
@@ -61,6 +59,15 @@ final class KYCConfirmPhoneNumberController: KYCBaseViewController, BottomButton
         super.viewDidAppear(animated)
         setUpBottomButtonContainerView()
         validationTextFieldConfirmationCode.becomeFocused()
+    }
+
+    // MARK: - KYCCoordinatorDelegate
+
+    override func apply(model: KYCPageModel) {
+        guard case let .phone(user) = model else { return }
+
+        guard let mobile = user.mobile else { return }
+        phoneNumber = mobile.phone
     }
 
     // MARK: IBActions

--- a/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCEnterPhoneNumberController.swift
@@ -48,6 +48,9 @@ final class KYCEnterPhoneNumberController: KYCBaseViewController, BottomButtonCo
     override func apply(model: KYCPageModel) {
         guard case let .phone(user) = model else { return }
         self.user = user
+
+        guard let mobile = user.mobile else { return }
+        validationTextFieldMobileNumber.text = mobile.phone
     }
 
     // MARK: - UIViewController Lifecycle Methods

--- a/Blockchain/KYC/Models/KYCPageModel.swift
+++ b/Blockchain/KYC/Models/KYCPageModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum KYCPageModel {
     case personalDetails(NabuUser)
-    case address(NabuUser, KYCCountry)
+    case address(NabuUser, KYCCountry?)
     case phone(NabuUser)
     case verifyIdentity(KYCCountry)
 }

--- a/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
@@ -57,7 +57,16 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
 
     override func apply(model: KYCPageModel) {
         guard case let .personalDetails(user) = model else { return }
+
         self.user = user
+
+        guard let personalDetails = user.personalDetails else { return }
+
+        firstNameField.text = personalDetails.firstName
+        lastNameField.text = personalDetails.lastName
+        if let birthday = personalDetails.birthday {
+            birthdayField.selectedDate = birthday
+        }
     }
 
     // MARK: Lifecycle

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -61,6 +61,10 @@ struct LocalizationConstants {
     )
 
     struct Errors {
+        static let genericError = NSLocalizedString(
+            "An error occured. Please try again.",
+            comment: "Generic error message displayed when an error occurs."
+        )
         static let error = NSLocalizedString("Error", comment: "")
         static let loadingSettings = NSLocalizedString("loading Settings", comment: "")
         static let errorLoadingWallet = NSLocalizedString("Unable to load wallet due to no server response. You may be offline or Blockchain is experiencing difficulties. Please try again later.", comment: "")

--- a/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.swift
+++ b/Blockchain/Views/ValidationTextField/ValidationDateField/ValidationDateField.swift
@@ -19,7 +19,13 @@ class ValidationDateField: ValidationTextField {
     }()
 
     var selectedDate: Date {
-        return pickerView.date
+        get {
+            return pickerView.date
+        }
+        set {
+            pickerView.date = newValue
+            datePickerUpdated(pickerView)
+        }
     }
 
     override func awakeFromNib() {


### PR DESCRIPTION
## Objective

Restoring KYC page stack if user drops off mid-flow.

**Note**: the base of this PR will be changed once #461 is merged.

## Description

This was done by inferring where the user is at during KYC by inspecting the Nabu user data. And depending on the page, the navigation controller is restored by pushing page view controllers wherein the top view controller is where the user left off.

## How to Test

Pull in these changes, go through KYC, drop off at some point, notice that the view state is restored.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
