### PR TITLE
feat(KYC): add UNDER_REVIEW account state (IOS-1234)

### DIFF
--- a/Blockchain/KYC/Information/KYCInformationViewModel.swift
+++ b/Blockchain/KYC/Information/KYCInformationViewModel.swift
@@ -54,13 +54,22 @@ extension KYCInformationViewModel {
                 buttonTitle: nil,
                 badge: LocalizationConstants.KYC.verificationFailedBadge
             )
-        case.pending:
+        case .pending:
             return KYCInformationViewModel(
                 image: #imageLiteral(resourceName: "AccountInReview"),
                 title: LocalizationConstants.KYC.verificationInProgress,
                 subtitle: LocalizationConstants.KYC.whatHappensNext,
                 description: LocalizationConstants.KYC.verificationInProgressDescription,
                 buttonTitle: LocalizationConstants.KYC.notifyMe,
+                badge: LocalizationConstants.KYC.accountUnderReviewBadge
+            )
+        case .underReview:
+            return KYCInformationViewModel(
+                image: #imageLiteral(resourceName: "AccountInReview"),
+                title: LocalizationConstants.KYC.verificationUnderReview,
+                subtitle: nil,
+                description: LocalizationConstants.KYC.verificationUnderReviewDescription,
+                buttonTitle: nil,
                 badge: LocalizationConstants.KYC.accountUnderReviewBadge
             )
         case .none:
@@ -95,6 +104,9 @@ extension KYCInformationViewConfig {
         case .pending:
             titleColor = UIColor.orange
             isPrimaryButtonEnabled = !UIApplication.shared.isRegisteredForRemoteNotifications
+        case .underReview:
+            titleColor = .orange
+            isPrimaryButtonEnabled = false
         }
         return KYCInformationViewConfig(
             titleColor: titleColor,

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -130,9 +130,10 @@ protocol KYCCoordinatorDelegate: class {
                 }
             case .pending:
                 PushNotificationManager.shared.requestAuthorization()
-            case .failed, .expired, .none:
+            case .failed, .expired:
                 // Confirm with design that this is how we should handle this
                 URL(string: Constants.Url.blockchainSupport)?.launch()
+            case .none, .underReview: return
             }
         }
         presentInNavigationController(accountStatusViewController, in: viewController)

--- a/Blockchain/KYC/Models/KYCAccountStatus.swift
+++ b/Blockchain/KYC/Models/KYCAccountStatus.swift
@@ -9,9 +9,10 @@
 import Foundation
 
 enum KYCAccountStatus: String {
-    case none = "NONE"
-    case expired = "EXPIRED"
     case approved = "VERIFIED"
+    case expired = "EXPIRED"
     case failed = "REJECTED"
+    case none = "NONE"
     case pending = "PENDING"
+    case underReview = "UNDER_REVIEW"
 }

--- a/Blockchain/Settings/Settings+Helpers.swift
+++ b/Blockchain/Settings/Settings+Helpers.swift
@@ -146,7 +146,7 @@ extension AppSettingsController {
             switch status {
             case .approved: cell.detailTextLabel?.backgroundColor = .verified
             case .expired, .failed, .none: cell.detailTextLabel?.backgroundColor = .unverified
-            case .pending: cell.detailTextLabel?.backgroundColor = .pending
+            case .pending, .underReview: cell.detailTextLabel?.backgroundColor = .pending
             }
         } else if let theColor = color {
             cell.detailTextLabel?.backgroundColor = theColor


### PR DESCRIPTION
## Objective

Add missing `UNDER_REVIEW` state to the KYC flow.

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
