### PR TITLE
feat(Homebrew-Exchange): add label for fiat decimal amount.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -854,6 +854,8 @@
 		C7FF10EA2141AAB300CBA3CB /* MarketsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF10E92141AAB300CBA3CB /* MarketsModel.swift */; };
 		C7FF10EB2141AAB300CBA3CB /* MarketsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF10E92141AAB300CBA3CB /* MarketsModel.swift */; };
 		C7FF10FE2141C07A00CBA3CB /* Fix.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF10DE2141A89500CBA3CB /* Fix.swift */; };
+		C7FF110F2141E24000CBA3CB /* InputsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF110E2141E24000CBA3CB /* InputsState.swift */; };
+		C7FF11102141E24000CBA3CB /* InputsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF110E2141E24000CBA3CB /* InputsState.swift */; };
 		C9BE917B1945D8F600FD516D /* PENumpadView.m in Sources */ = {isa = PBXBuildFile; fileRef = C9BE91681945D8F600FD516D /* PENumpadView.m */; };
 		C9BE917C1945D8F600FD516D /* PEPinEntryController.m in Sources */ = {isa = PBXBuildFile; fileRef = C9BE916A1945D8F600FD516D /* PEPinEntryController.m */; };
 		C9BE917D1945D8F600FD516D /* PEViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C9BE916C1945D8F600FD516D /* PEViewController.m */; };
@@ -3282,6 +3284,7 @@
 		C7FA9B58212F499D00B98EBF /* MarketsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsService.swift; sourceTree = "<group>"; };
 		C7FF10DE2141A89500CBA3CB /* Fix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fix.swift; sourceTree = "<group>"; };
 		C7FF10E92141AAB300CBA3CB /* MarketsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsModel.swift; sourceTree = "<group>"; };
+		C7FF110E2141E24000CBA3CB /* InputsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputsState.swift; sourceTree = "<group>"; };
 		C90A0884126BB17EBBDCFD8A /* Pods-BlockchainTests.debug testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlockchainTests.debug testnet.xcconfig"; path = "Pods/Target Support Files/Pods-BlockchainTests/Pods-BlockchainTests.debug testnet.xcconfig"; sourceTree = "<group>"; };
 		C9BE91671945D8F600FD516D /* PENumpadView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PENumpadView.h; sourceTree = "<group>"; };
 		C9BE91681945D8F600FD516D /* PENumpadView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PENumpadView.m; sourceTree = "<group>"; };
@@ -3428,6 +3431,7 @@
 			children = (
 				C7FF10E92141AAB300CBA3CB /* MarketsModel.swift */,
 				C7FF10DE2141A89500CBA3CB /* Fix.swift */,
+				C7FF110E2141E24000CBA3CB /* InputsState.swift */,
 				C72AC6F521349F6D001DA48B /* NumberInputViewModel.swift */,
 				C7C0DC05212F6594000EFE71 /* TradingPair.swift */,
 				3A26AF7121274EF9003A8A08 /* ExchangeTradeCellModel.swift */,
@@ -7691,6 +7695,7 @@
 				C7D5115C21237DE000359651 /* HttpHeader.swift in Sources */,
 				AAF2AEC22123799800687E30 /* KYCPersonalDetailsController.swift in Sources */,
 				AA447BDB2127BC1100EC0FA0 /* SideMenuViewController.swift in Sources */,
+				C7FF11102141E24000CBA3CB /* InputsState.swift in Sources */,
 				AA47709D211B7BC3006356B1 /* BottomButtonContainerView.swift in Sources */,
 				AAF2AEE52123863200687E30 /* BlockchainDataRepository.swift in Sources */,
 				AACE31D22092A99B00B7B806 /* UINavigationController+PopToRootWithCompletion.swift in Sources */,
@@ -7737,6 +7742,7 @@
 				511646DF20851BC600C43522 /* Bundle.swift in Sources */,
 				237C9E901C482132000754F7 /* AccountsAndAddressesDetailViewController.m in Sources */,
 				C7CE25B62135E3D300DCC43B /* ExchangeCreatePresenter.swift in Sources */,
+				C7FF110F2141E24000CBA3CB /* InputsState.swift in Sources */,
 				3A3D5DB6211B96FA00E6C241 /* LocationUpdateAPI.swift in Sources */,
 				23444F8D1DCD219E00573C8C /* BTCData.m in Sources */,
 				60AEA56921125AB50053A753 /* SettingsCell.swift in Sources */,

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -27,7 +27,7 @@ struct ExchangeServices: ExchangeDependencies {
     init() {
         rates = RatesService()
         service = ExchangeService()
-        markets = MarketsService()
+        markets = MarketsService(authenticationService: NabuAuthenticationService())
         inputs = ExchangeInputsService()
         tradeExecution = TradeExecutionService()
     }
@@ -69,7 +69,7 @@ struct ExchangeServices: ExchangeDependencies {
 
     // MARK: - Entry Point
 
-    func start() {
+    func start() {showAppropriateExchange(); return
         if let theUser = user, theUser.status == .approved {
             showAppropriateExchange(); return
         }
@@ -92,7 +92,7 @@ struct ExchangeServices: ExchangeDependencies {
     private func showAppropriateExchange() {
         if WalletManager.shared.wallet.hasEthAccount() {
             let success = { [weak self] (isHomebrewAvailable: Bool) in
-                if isHomebrewAvailable {
+                if !isHomebrewAvailable {
                     self?.showExchange(type: .homebrew)
                 } else {
                     self?.showExchange(type: .shapeshift)
@@ -211,7 +211,7 @@ struct ExchangeServices: ExchangeDependencies {
     private init(
         walletManager: WalletManager = WalletManager.shared,
         walletService: WalletService = WalletService.shared,
-        marketsService: MarketsService = MarketsService(),
+        marketsService: MarketsService = MarketsService(authenticationService: NabuAuthenticationService()),
         exchangeService: ExchangeService = ExchangeService()
     ) {
         self.walletManager = walletManager

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -69,7 +69,7 @@ struct ExchangeServices: ExchangeDependencies {
 
     // MARK: - Entry Point
 
-    func start() {showAppropriateExchange(); return
+    func start() {
         if let theUser = user, theUser.status == .approved {
             showAppropriateExchange(); return
         }
@@ -92,7 +92,7 @@ struct ExchangeServices: ExchangeDependencies {
     private func showAppropriateExchange() {
         if WalletManager.shared.wallet.hasEthAccount() {
             let success = { [weak self] (isHomebrewAvailable: Bool) in
-                if !isHomebrewAvailable {
+                if isHomebrewAvailable {
                     self?.showExchange(type: .homebrew)
                 } else {
                     self?.showExchange(type: .shapeshift)

--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -10,7 +10,7 @@ import Foundation
 
 protocol ExchangeCreateInterface: class {
     func ratesViewVisibility(_ visibility: Visibility)
-    func updateInputLabels(primary: String?, secondary: String?)
+    func updateInputLabels(primary: String?, primaryDecimal: String?, secondary: String?)
     func updateRateLabels(first: String, second: String, third: String)
 }
 
@@ -24,6 +24,6 @@ protocol ExchangeCreateInput: NumberKeypadViewDelegate {
 }
 
 protocol ExchangeCreateOutput: class {
-    func updatedInput(primary: String?, secondary: String?)
+    func updatedInput(primary: String?, primaryDecimal: String?, secondary: String?)
     func updatedRates(first: String, second: String, third: String)
 }

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -5,6 +5,7 @@
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -43,108 +44,148 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UNX-CU-uNI">
-                                <rect key="frame" x="16" y="138" width="343" height="114"/>
+                                <rect key="frame" x="36" y="138.5" width="303" height="113.5"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf">
-                                        <rect key="frame" x="293" y="64" width="42" height="42"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="42" id="adV-rn-OQg"/>
-                                            <constraint firstAttribute="height" constant="42" id="reo-5s-btt"/>
-                                        </constraints>
-                                        <state key="normal" title="Fiat Toggle"/>
-                                        <connections>
-                                            <action selector="displayInputTypeTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="f6g-9r-iu8"/>
-                                        </connections>
-                                    </button>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="FgZ-oU-W6K">
-                                        <rect key="frame" x="111" y="29" width="120.5" height="56.5"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3PK-fM-MXL" userLabel="Label Container">
+                                        <rect key="frame" x="0.0" y="27" width="303" height="60"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.01 BTC" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
-                                                <rect key="frame" x="0.0" y="0.0" width="120.5" height="36"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$200.42" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okC-2w-xB9">
-                                                <rect key="frame" x="27.5" y="36" width="65.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2GY-32-aHY" userLabel="Primary Label Container">
+                                                <rect key="frame" x="70" y="0.0" width="162.5" height="41"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.01 BTC" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
+                                                        <rect key="frame" x="0.0" y="0.0" width="120.5" height="41"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDb-VO-eLj" userLabel="Primary Decimal Label">
+                                                        <rect key="frame" x="120.5" y="5.5" width="42" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstItem="cbA-yh-J0A" firstAttribute="top" secondItem="2GY-32-aHY" secondAttribute="top" id="1Oc-1L-qYs"/>
+                                                    <constraint firstItem="lDb-VO-eLj" firstAttribute="leading" secondItem="cbA-yh-J0A" secondAttribute="trailing" id="3K0-5H-idm"/>
+                                                    <constraint firstAttribute="trailing" secondItem="lDb-VO-eLj" secondAttribute="trailing" id="Gwg-oP-ULF"/>
+                                                    <constraint firstItem="lDb-VO-eLj" firstAttribute="height" secondItem="cbA-yh-J0A" secondAttribute="height" multiplier="0.5" id="LMk-SV-P4d"/>
+                                                    <constraint firstItem="cbA-yh-J0A" firstAttribute="leading" secondItem="2GY-32-aHY" secondAttribute="leading" id="SCh-iI-bD5"/>
+                                                    <constraint firstItem="cbA-yh-J0A" firstAttribute="height" secondItem="2GY-32-aHY" secondAttribute="height" id="W04-DO-PnB"/>
+                                                    <constraint firstItem="lDb-VO-eLj" firstAttribute="top" secondItem="cbA-yh-J0A" secondAttribute="top" constant="6" id="gzG-WL-72M"/>
+                                                </constraints>
+                                            </view>
                                         </subviews>
-                                    </stackView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="2GY-32-aHY" firstAttribute="centerX" secondItem="3PK-fM-MXL" secondAttribute="centerX" id="MzV-q8-AGm"/>
+                                            <constraint firstAttribute="height" constant="60" id="OBZ-E7-Ozj"/>
+                                            <constraint firstItem="2GY-32-aHY" firstAttribute="top" secondItem="3PK-fM-MXL" secondAttribute="top" id="i6l-5g-4vk"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$200.42" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okC-2w-xB9">
+                                        <rect key="frame" x="119" y="68" width="65.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="DPE-Uz-yYf" secondAttribute="trailing" constant="8" id="7CI-oE-xk2"/>
-                                    <constraint firstAttribute="bottom" secondItem="DPE-Uz-yYf" secondAttribute="bottom" constant="8" id="9Lz-pT-6hF"/>
-                                    <constraint firstItem="FgZ-oU-W6K" firstAttribute="centerY" secondItem="UNX-CU-uNI" secondAttribute="centerY" id="DB5-30-W72"/>
-                                    <constraint firstItem="FgZ-oU-W6K" firstAttribute="centerX" secondItem="UNX-CU-uNI" secondAttribute="centerX" id="IqU-5Z-E05"/>
-                                    <constraint firstItem="DPE-Uz-yYf" firstAttribute="top" secondItem="UNX-CU-uNI" secondAttribute="top" constant="64" id="bpv-Ef-Rup"/>
+                                    <constraint firstItem="3PK-fM-MXL" firstAttribute="centerX" secondItem="UNX-CU-uNI" secondAttribute="centerX" id="HjR-Gh-S8T"/>
+                                    <constraint firstItem="okC-2w-xB9" firstAttribute="top" secondItem="2GY-32-aHY" secondAttribute="bottom" id="WQc-3K-TMj"/>
+                                    <constraint firstItem="okC-2w-xB9" firstAttribute="centerX" secondItem="3PK-fM-MXL" secondAttribute="centerX" id="cdp-7H-DPM"/>
+                                    <constraint firstItem="3PK-fM-MXL" firstAttribute="width" secondItem="UNX-CU-uNI" secondAttribute="width" id="llc-Aa-cFe"/>
+                                    <constraint firstItem="3PK-fM-MXL" firstAttribute="centerY" secondItem="UNX-CU-uNI" secondAttribute="centerY" id="zqb-bj-XrF"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="POK-GE-gO7">
-                                <rect key="frame" x="16" y="92" width="343" height="30"/>
+                                <rect key="frame" x="16" y="92.5" width="343" height="30"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rcu-DM-4eH">
-                                        <rect key="frame" x="0.0" y="0.0" width="129.5" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="130" height="30"/>
                                         <state key="normal" title="Button"/>
                                     </button>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="switch_currencies" translatesAutoresizingMaskIntoConstraints="NO" id="t8W-hq-ZjO">
-                                        <rect key="frame" x="129.5" y="0.0" width="84" height="30"/>
+                                        <rect key="frame" x="130" y="0.0" width="84" height="30"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rEg-tW-g6Y">
-                                        <rect key="frame" x="213.5" y="0.0" width="129.5" height="30"/>
+                                        <rect key="frame" x="214" y="0.0" width="129" height="30"/>
                                         <state key="normal" title="Button"/>
                                     </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="t8W-hq-ZjO" firstAttribute="centerX" secondItem="POK-GE-gO7" secondAttribute="centerX" id="6nQ-CX-hVq"/>
+                                </constraints>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Exchange" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mih-H4-tuc">
-                                <rect key="frame" x="16" y="63.5" width="74.5" height="20.5"/>
+                                <rect key="frame" x="16" y="64" width="74.5" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Receive" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hwt-iu-BVZ">
-                                <rect key="frame" x="229.5" y="63.5" width="60" height="20.5"/>
+                                <rect key="frame" x="230" y="64" width="60" height="20.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="60" id="tIR-nD-Exc"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf">
+                                <rect key="frame" x="342" y="210" width="28" height="42"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="28" id="adV-rn-OQg"/>
+                                    <constraint firstAttribute="height" constant="42" id="reo-5s-btt"/>
+                                </constraints>
+                                <state key="normal" title="Fiat Toggle"/>
+                                <connections>
+                                    <action selector="displayInputTypeTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="f6g-9r-iu8"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="DUe-4D-nhJ" secondAttribute="trailing" constant="16" id="5hU-Xa-xif"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="6Rb-58-f8o"/>
+                            <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="DPE-Uz-yYf" secondAttribute="trailing" constant="5" id="6se-NL-E0N"/>
                             <constraint firstItem="UNX-CU-uNI" firstAttribute="top" secondItem="POK-GE-gO7" secondAttribute="bottom" constant="16" id="9E9-SV-0Ls"/>
                             <constraint firstItem="RBP-hF-UKz" firstAttribute="top" secondItem="5uc-t6-nYA" secondAttribute="bottom" constant="8" id="9Uk-BN-3HM"/>
                             <constraint firstItem="rcu-DM-4eH" firstAttribute="top" secondItem="mih-H4-tuc" secondAttribute="bottom" constant="8" id="9Ux-su-GTO"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="AHN-eg-W66"/>
                             <constraint firstItem="mih-H4-tuc" firstAttribute="leading" secondItem="rcu-DM-4eH" secondAttribute="leading" id="BMr-yz-otg"/>
                             <constraint firstItem="5uc-t6-nYA" firstAttribute="top" secondItem="UNX-CU-uNI" secondAttribute="bottom" constant="50" id="CC9-qD-ogT"/>
+                            <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="hwt-iu-BVZ" secondAttribute="trailing" constant="85" id="DUo-fi-B0U"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="top" secondItem="dfm-a1-ad2" secondAttribute="bottom" constant="8" id="EPf-w5-lBJ"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="5uc-t6-nYA" secondAttribute="trailing" constant="16" id="FZ3-8d-31D"/>
                             <constraint firstItem="hwt-iu-BVZ" firstAttribute="leading" secondItem="rEg-tW-g6Y" secondAttribute="leading" id="IRN-cJ-TIc"/>
                             <constraint firstItem="rEg-tW-g6Y" firstAttribute="top" secondItem="hwt-iu-BVZ" secondAttribute="bottom" constant="8" id="Nzc-i6-iDF"/>
-                            <constraint firstItem="UNX-CU-uNI" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="Pkd-gf-mZN"/>
+                            <constraint firstItem="UNX-CU-uNI" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="36" id="Pkd-gf-mZN"/>
                             <constraint firstItem="POK-GE-gO7" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="Pzp-S8-YJl"/>
+                            <constraint firstItem="mih-H4-tuc" firstAttribute="top" secondItem="FIv-WY-bvA" secondAttribute="top" constant="44" id="Qwj-jz-f0B"/>
+                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="leading" secondItem="UNX-CU-uNI" secondAttribute="trailing" constant="3" id="T7B-vE-k04"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="RBP-hF-UKz" secondAttribute="trailing" constant="16" id="TTq-JC-OVd"/>
                             <constraint firstItem="5uc-t6-nYA" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="Txz-FX-khz"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="POK-GE-gO7" secondAttribute="trailing" constant="16" id="XbK-qG-lip"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="top" secondItem="RBP-hF-UKz" secondAttribute="bottom" constant="8" id="hWm-4t-HII"/>
                             <constraint firstItem="5uc-t6-nYA" firstAttribute="top" secondItem="jre-mq-FDr" secondAttribute="top" constant="302" id="jRq-hN-qS8"/>
-                            <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="UNX-CU-uNI" secondAttribute="trailing" constant="16" id="lgz-nF-gUO"/>
+                            <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="UNX-CU-uNI" secondAttribute="trailing" constant="36" id="lgz-nF-gUO"/>
                             <constraint firstItem="RBP-hF-UKz" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="mS9-tQ-guh"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="dfm-a1-ad2" secondAttribute="trailing" constant="16" id="pXZ-qz-MkO"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="bottom" secondItem="DUe-4D-nhJ" secondAttribute="bottom" constant="20" id="pni-o2-RxB"/>
+                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="bottom" secondItem="UNX-CU-uNI" secondAttribute="bottom" id="qd2-ac-G9J"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="FIv-WY-bvA"/>
                     </view>
                     <connections>
+                        <outlet property="decimalLabelSpacingConstraint" destination="3K0-5H-idm" id="W0C-Yz-5aq"/>
                         <outlet property="exchangeButton" destination="DUe-4D-nhJ" id="8Ye-3x-3jU"/>
                         <outlet property="exchangeRateButton" destination="RBP-hF-UKz" id="U09-gZ-aBt"/>
                         <outlet property="numberKeypadView" destination="dfm-a1-ad2" id="yN5-Le-zxp"/>
                         <outlet property="primaryAmountLabel" destination="cbA-yh-J0A" id="xGh-pL-sDT"/>
+                        <outlet property="primaryDecimalLabel" destination="lDb-VO-eLj" id="T5h-at-TGm"/>
                         <outlet property="secondaryAmountLabel" destination="okC-2w-xB9" id="K2v-uv-GkY"/>
                         <outlet property="useMaximumButton" destination="kyX-88-NsD" id="1kX-WQ-I1q"/>
                         <outlet property="useMinimumButton" destination="Gyg-rh-rE6" id="e6a-pn-89k"/>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -13,10 +13,17 @@ class ExchangeCreateViewController: UIViewController {
     // MARK: - IBOutlets
 
     @IBOutlet private var numberKeypadView: NumberKeypadView!
+
     // Label to be updated when amount is being typed in
     @IBOutlet private var primaryAmountLabel: UILabel!
+
+    // Amount being typed for fiat values to the right of the decimal separator
+    @IBOutlet var primaryDecimalLabel: UILabel!
+    @IBOutlet var decimalLabelSpacingConstraint: NSLayoutConstraint!
+
     // Amount being typed in converted to input crypto or input fiat
     @IBOutlet private var secondaryAmountLabel: UILabel!
+
     @IBOutlet private var useMinimumButton: UIButton!
     @IBOutlet private var useMaximumButton: UIButton!
     @IBOutlet private var exchangeRateButton: UIButton!
@@ -59,8 +66,9 @@ class ExchangeCreateViewController: UIViewController {
                 pair: TradingPair(from: .ethereum,to: .bitcoinCash)!,
                 fiatCurrency: "USD",
                 fix: .base,
-                volume: 0
-        ))
+                volume: 0),
+            inputsState: InputsState()
+        )
         numberKeypadView.delegate = self
         presenter = ExchangeCreatePresenter(interactor: interactor)
         presenter.interface = self
@@ -84,8 +92,10 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
 
     }
 
-    func updateInputLabels(primary: String?, secondary: String?) {
+    func updateInputLabels(primary: String?, primaryDecimal: String?, secondary: String?) {
         primaryAmountLabel.text = primary
+        primaryDecimalLabel.text = primaryDecimal
+        decimalLabelSpacingConstraint.constant = primaryDecimal == nil ? 0 : 2
         secondaryAmountLabel.text = secondary
     }
 

--- a/Blockchain/Homebrew/Exchange/DataProviders/ExchangeInputs.swift
+++ b/Blockchain/Homebrew/Exchange/DataProviders/ExchangeInputs.swift
@@ -8,8 +8,11 @@
 
 import Foundation
 
+typealias InputComponents = (integer: String, decimalSeparator: String?, fractional: String?)
+
 protocol ExchangeInputsAPI: class {
     var activeInput: NumberInputDelegate { get }
+    var inputComponents: InputComponents { get }
     var lastOutput: String? { get }
     var conversionRate: Decimal? { get set }
 
@@ -20,6 +23,11 @@ protocol ExchangeInputsAPI: class {
 
 class ExchangeInputsService: ExchangeInputsAPI {
     var activeInput: NumberInputDelegate
+    var inputComponents: InputComponents {
+        let decimalSeparator = activeInput.decimalSeparator
+        let components = activeInput.input.components(separatedBy: decimalSeparator)
+        return (components.first ?? "0", decimalSeparator, components.count > 1 ? components.last : nil)
+    }
     var lastOutput: String?
     var conversionRate: Decimal?
 

--- a/Blockchain/Homebrew/Exchange/Models/InputsState.swift
+++ b/Blockchain/Homebrew/Exchange/Models/InputsState.swift
@@ -1,0 +1,13 @@
+//
+//  InputsState.swift
+//  Blockchain
+//
+//  Created by kevinwu on 9/6/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+class InputsState {
+    var isUsingFiat = false
+}

--- a/Blockchain/Homebrew/Exchange/Models/NumberInputViewModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/NumberInputViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 protocol NumberInputDelegate: class {
+    var decimalSeparator: String { get }
     var input: String { get }
     func add(character: String)
     func backspace()
@@ -17,6 +18,14 @@ protocol NumberInputDelegate: class {
 // Class used to store the results of user input relayed by the NumberKeypadView.
 class NumberInputViewModel: NumberInputDelegate {
 
+    var decimalSeparator: String {
+        // Make sure a decimal separator exists
+        guard let decimalSeparator = Locale.current.decimalSeparator else {
+            Logger.shared.warning("No decimal separator available, using period")
+            return "."
+        }
+        return decimalSeparator
+    }
     private let numbers: Set<String> = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
     private let zero = "0"
     private(set) var input: String
@@ -69,17 +78,5 @@ class NumberInputViewModel: NumberInputDelegate {
             return
         }
         input = String(input.dropLast())
-    }
-}
-
-// MARK: Helpers
-extension NumberInputViewModel {
-    var decimalSeparator: String {
-        // Make sure a decimal separator exists
-        guard let decimalSeparator = Locale.current.decimalSeparator else {
-            Logger.shared.warning("No decimal separator available, using period")
-            return "."
-        }
-        return decimalSeparator
     }
 }

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -40,8 +40,8 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
 }
 
 extension ExchangeCreatePresenter: ExchangeCreateOutput {
-    func updatedInput(primary: String?, secondary: String?) {
-         interface?.updateInputLabels(primary: primary, secondary: secondary)
+    func updatedInput(primary: String?, primaryDecimal: String?, secondary: String?) {
+        interface?.updateInputLabels(primary: primary, primaryDecimal: primaryDecimal, secondary: secondary)
     }
     
     func updatedRates(first: String, second: String, third: String) {

--- a/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
@@ -32,11 +32,11 @@ class MarketsService {
     private let restMessageSubject = PublishSubject<Conversion>()
     private var dataSource: DataSource = .socket
 
-    private let authentication: KYCAuthenticationService
+    private let authentication: NabuAuthenticationService
     var hasAuthenticated: Bool = false
 
-    init(service: KYCAuthenticationService = KYCAuthenticationService.shared) {
-        self.authentication = service
+    init(authenticationService: NabuAuthenticationService = NabuAuthenticationService.shared) {
+        self.authentication = authenticationService
     }
 
     deinit {
@@ -127,7 +127,7 @@ private extension MarketsService {
     }
 
     func authenticateSocket() {
-        let authenticationDisposable = KYCAuthenticationService.shared.getKycSessionToken()
+        let authenticationDisposable = self.authentication.getSessionToken()
             .map { tokenResponse -> Subscription<AuthSubscribeParams> in
                 let params = AuthSubscribeParams(type: "auth", token: tokenResponse.token)
                 return Subscription(channel: "auth", operation: "subscribe", params: params)

--- a/Blockchain/Side Menu/SideMenuPresenter.swift
+++ b/Blockchain/Side Menu/SideMenuPresenter.swift
@@ -57,7 +57,7 @@ class SideMenuPresenter {
                 self.setMenuItems(showExchange: isHomebrewSupported || isPartnerSupported)
             }, onError: { [unowned self] error in
                 Logger.shared.error("Failed to determine whether the country is supported by homebrew or by shapeshift.")
-                self.setMenuItems(showExchange: false)
+                self.setMenuItems(showExchange: true)
             })
     }
 

--- a/Blockchain/Side Menu/SideMenuPresenter.swift
+++ b/Blockchain/Side Menu/SideMenuPresenter.swift
@@ -57,7 +57,7 @@ class SideMenuPresenter {
                 self.setMenuItems(showExchange: isHomebrewSupported || isPartnerSupported)
             }, onError: { [unowned self] error in
                 Logger.shared.error("Failed to determine whether the country is supported by homebrew or by shapeshift.")
-                self.setMenuItems(showExchange: true)
+                self.setMenuItems(showExchange: false)
             })
     }
 


### PR DESCRIPTION
## Objective

Add smaller label for fiat decimal amount input.

## Description

~~Added label to right-hand side of the primary amount label and display the decimal value when fiat input is switched on.~~~ EDIT: This will be deprecated using a more accurate approach using attributed text, but this PR still should be merged to avoid conflicts.

`InputsState` is also deprecated and is removed in active branches.

## How to Test

- Checkout 160de9607ccfb74ff9ab2df0ab601d089adc4d77 and open Exchange.
- Type some numbers
- Tap on the right-hand side button (currently text is truncated `...`) to switch to fiat
- Type more numbers after decimal
- Currently known that fiat symbol is missing and limit of 2 decimal places should be enforced for fiat - more changes are coming.

## Screenshot/Design assessment

Not really close to designs at all yet other than amounts being centered properly.
<img width="328" alt="screen shot 2018-09-07 at 4 37 12 pm" src="https://user-images.githubusercontent.com/10579422/45241951-4d94e700-b2bc-11e8-9f54-ce0e04617eb4.png">

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
