### PR TITLE
fix(KYC): do not prefill birthday field with current date (IOS-1264)

### DIFF
--- a/Blockchain/Homebrew/Models/NabuUser.swift
+++ b/Blockchain/Homebrew/Models/NabuUser.swift
@@ -54,7 +54,7 @@ struct NabuUser: Decodable {
             first: firstName,
             last: lastName,
             email: email,
-            birthday: Date()
+            birthday: nil
         )
         
         if let number = phoneNumber {


### PR DESCRIPTION
## Objective

Do not prefill the birthday field with the current date.

## How to Test

Debug KYC flow until personal details screen is reached and observe that the birthday field is initially empty again.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
