### PR TITLE
fix(KYC): pass country code instead of name (IOS-1270)

### DIFF
--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -179,7 +179,7 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
             postalCode: postalCodeTextField.text ?? "",
             city: cityTextField.text ?? "",
             state: stateTextField.text ?? "",
-            country: country?.code ?? user?.address?.country ?? ""
+            countryCode: country?.code ?? user?.address?.countryCode ?? ""
         )
         searchDelegate?.onSubmission(address, completion: { [weak self] in
             guard let this = self else { return }

--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -179,7 +179,7 @@ class KYCAddressController: KYCBaseViewController, ValidationFormView, BottomBut
             postalCode: postalCodeTextField.text ?? "",
             city: cityTextField.text ?? "",
             state: stateTextField.text ?? "",
-            country: country?.name ?? user?.address?.country ?? ""
+            country: country?.code ?? user?.address?.country ?? ""
         )
         searchDelegate?.onSubmission(address, completion: { [weak self] in
             guard let this = self else { return }

--- a/Blockchain/KYC/Search/Models/PostalAddress.swift
+++ b/Blockchain/KYC/Search/Models/PostalAddress.swift
@@ -24,7 +24,7 @@ struct UserAddress: Codable {
     let postalCode: String
     let city: String
     let state: String?
-    let country: String
+    let countryCode: String
 
     enum CodingKeys: String, CodingKey {
         case lineOne = "line1"
@@ -32,7 +32,7 @@ struct UserAddress: Codable {
         case postalCode = "postCode"
         case city = "city"
         case state = "state"
-        case country = "country"
+        case countryCode = "country"
     }
 }
 
@@ -42,7 +42,7 @@ extension UserAddress: Equatable {
             lhs.lineTwo == rhs.lineTwo &&
             lhs.postalCode == rhs.postalCode &&
             lhs.city == rhs.city &&
-            lhs.country == rhs.country &&
+            lhs.countryCode == rhs.countryCode &&
             lhs.state == rhs.state
     }
 }
@@ -53,6 +53,6 @@ extension UserAddress: Hashable {
             lineTwo.hashValue ^
             postalCode.hashValue ^
             city.hashValue ^
-            country.hashValue
+            countryCode.hashValue
     }
 }


### PR DESCRIPTION
## Objective

Pass the country code instead of the country name when updating the user.

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [ ] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
