### PR TITLE
fix(KYC): IOS-1265 showing correct number on confirmation screen.

### DIFF
--- a/Blockchain/KYC/KYCPageViewFactory.swift
+++ b/Blockchain/KYC/KYCPageViewFactory.swift
@@ -27,7 +27,11 @@ class KYCPageViewFactory {
         case .enterPhone:
             return KYCEnterPhoneNumberController.make(with: coordinator)
         case .confirmPhone:
-            return KYCConfirmPhoneNumberController.make(with: coordinator)
+            let confirmPhoneNumberController = KYCConfirmPhoneNumberController.make(with: coordinator)
+            if let payload = payload, case let .phoneNumberUpdated(number) = payload {
+                confirmPhoneNumberController.phoneNumber = number
+            }
+            return confirmPhoneNumberController
         case .verifyIdentity:
             return KYCVerifyIdentityController.make(with: coordinator)
         case .accountStatus:

--- a/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
+++ b/Blockchain/KYC/Mobile Number/KYCConfirmPhoneNumberController.swift
@@ -10,9 +10,9 @@ import Foundation
 
 final class KYCConfirmPhoneNumberController: KYCBaseViewController, BottomButtonContainerView {
 
-    // MARK: Private Properties
+    // MARK: Public Properties
 
-    private var phoneNumber: String = "" {
+    var phoneNumber: String = "" {
         didSet {
             guard isViewLoaded else { return }
             labelPhoneNumber.text = phoneNumber
@@ -51,6 +51,7 @@ final class KYCConfirmPhoneNumberController: KYCBaseViewController, BottomButton
     override func viewDidLoad() {
         super.viewDidLoad()
         validationTextFieldConfirmationCode.autocapitalizationType = .allCharacters
+        labelPhoneNumber.text = phoneNumber
         originalBottomButtonConstraint = layoutConstraintBottomButton.constant
         validationTextFieldConfirmationCode.becomeFocused()
     }
@@ -66,7 +67,7 @@ final class KYCConfirmPhoneNumberController: KYCBaseViewController, BottomButton
     override func apply(model: KYCPageModel) {
         guard case let .phone(user) = model else { return }
 
-        guard let mobile = user.mobile else { return }
+        guard let mobile = user.mobile, phoneNumber.count == 0 else { return }
         phoneNumber = mobile.phone
     }
 


### PR DESCRIPTION
## Objective

Showing correct entered phone number in `KYCConfirmPhoneNumberController` screen.

## Description

Was showing incorrect number due to a regression introduced in 77775c35 . Regression was introduced because during mid-flow drop-off, we display the stored number in `NabuUser`.

## How to Test

Go through KYC flow and when you get to the enter confirmation code screen for verifying your phone number, verify that the phone number under "Enter the code sent to" is showing the correct digits.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
