### PR TITLE
fix(KYC): IOS-1245 IOS-1217 IOS-1179 Personal details UI polish.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -641,6 +641,9 @@
 		AAC9FCE620ADF17100E28B7A /* SoundManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC9FCE420ADF17100E28B7A /* SoundManager.swift */; };
 		AAC9FCEE20AE456400E28B7A /* WalletTransactionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC9FCED20AE456400E28B7A /* WalletTransactionDelegate.swift */; };
 		AAC9FCEF20AE456400E28B7A /* WalletTransactionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC9FCED20AE456400E28B7A /* WalletTransactionDelegate.swift */; };
+		AACB48B821478472008FCCD0 /* Collection+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACB48B721478472008FCCD0 /* Collection+Helpers.swift */; };
+		AACB48B921478472008FCCD0 /* Collection+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACB48B721478472008FCCD0 /* Collection+Helpers.swift */; };
+		AACB48BB214784D6008FCCD0 /* Collection+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACB48BA214784D6008FCCD0 /* Collection+HelpersTests.swift */; };
 		AACE31222091004A00B7B806 /* UIApplication+Suspend.m in Sources */ = {isa = PBXBuildFile; fileRef = AACE31212091004A00B7B806 /* UIApplication+Suspend.m */; };
 		AACE3132209121B300B7B806 /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED68208EB4FB002D8BAC /* PushNotificationManager.swift */; };
 		AACE3134209121B800B7B806 /* WalletManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDED6B208EC330002D8BAC /* WalletManager.swift */; };
@@ -3115,6 +3118,8 @@
 		AAC8F35520993BB8004B7D33 /* WebSocketCloseCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketCloseCode.swift; sourceTree = "<group>"; };
 		AAC9FCE420ADF17100E28B7A /* SoundManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundManager.swift; sourceTree = "<group>"; };
 		AAC9FCED20AE456400E28B7A /* WalletTransactionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTransactionDelegate.swift; sourceTree = "<group>"; };
+		AACB48B721478472008FCCD0 /* Collection+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Helpers.swift"; sourceTree = "<group>"; };
+		AACB48BA214784D6008FCCD0 /* Collection+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+HelpersTests.swift"; sourceTree = "<group>"; };
 		AACE31202091004900B7B806 /* UIApplication+Suspend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIApplication+Suspend.h"; sourceTree = "<group>"; };
 		AACE31212091004A00B7B806 /* UIApplication+Suspend.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIApplication+Suspend.m"; sourceTree = "<group>"; };
 		AACE314B209152D800B7B806 /* Application+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Application+Helpers.swift"; sourceTree = "<group>"; };
@@ -3843,28 +3848,29 @@
 		510EA19620811FF100A63AB8 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				C76143AA211A80D30041411E /* Codable+Coding.swift */,
-				6055D371210F692D000B8E95 /* UIView.swift */,
+				AACE31202091004900B7B806 /* UIApplication+Suspend.h */,
+				AACE31212091004A00B7B806 /* UIApplication+Suspend.m */,
 				AACE314B209152D800B7B806 /* Application+Helpers.swift */,
 				511646DE20851BC600C43522 /* Bundle.swift */,
+				C76143AA211A80D30041411E /* Codable+Coding.swift */,
+				AACB48B721478472008FCCD0 /* Collection+Helpers.swift */,
+				3A76F901211A3BA5002F7946 /* DateFormatter+Conveniences.swift */,
 				516546F7208FCF800019EE63 /* Enum+Enumeratable.swift */,
 				5185E123208F6E5E00A26B64 /* Enum+RawValued.swift */,
+				3AE92BDC2110DF33008D7BDC /* NotificationCenter+Conveniences.swift */,
+				3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */,
 				AABDED6F208FACB9002D8BAC /* Reachability.swift */,
 				51C2ADD520BDECE700D66108 /* String+EscapeJS.swift */,
 				AA3CA96721079B7500C2AD46 /* Strings.swift */,
 				5114EA1E20CB2BA90098E26E /* TabControllerManager+Nib.swift */,
-				AACE31202091004900B7B806 /* UIApplication+Suspend.h */,
-				AACE31212091004A00B7B806 /* UIApplication+Suspend.m */,
 				511646E1208523E300C43522 /* UIDevice.swift */,
 				513C826B20EBF30C00ECDE52 /* UIDevice+Biometrics.swift */,
 				5114EA2220CD8B900098E26E /* UINavigationBar+TitleAttributes.swift */,
+				6055D371210F692D000B8E95 /* UIView.swift */,
 				51C9EBB520DBE4A700AB521D /* UIView+SafeAreaFrame.swift */,
 				AABDED3F208A6E8D002D8BAC /* UIViewController.swift */,
 				AA63F84A20A12AE9002B719B /* URLs.swift */,
 				513913EF2081206C002578FD /* UserDefaults.swift */,
-				3AC97559210FBD10006A9263 /* NSAttributedString+Conveniences.swift */,
-				3AE92BDC2110DF33008D7BDC /* NotificationCenter+Conveniences.swift */,
-				3A76F901211A3BA5002F7946 /* DateFormatter+Conveniences.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4045,6 +4051,7 @@
 		51C9EBBF20DBE88000AB521D /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				AACB48BA214784D6008FCCD0 /* Collection+HelpersTests.swift */,
 				AA56423A20DDBDBB0092A022 /* NumberFormatter+AssetsTests.swift */,
 				AA56423920DDBDBB0092A022 /* String+EscapeJSTests.swift */,
 			);
@@ -7721,6 +7728,7 @@
 				AA126CDD212C94CB005886A3 /* NabuSessionTokenResponse.swift in Sources */,
 				AACE31CF2092A99B00B7B806 /* AuthenticationManager.swift in Sources */,
 				AA126DA0212E189C005886A3 /* OnfidoUser.swift in Sources */,
+				AACB48B921478472008FCCD0 /* Collection+Helpers.swift in Sources */,
 				51135707209CF68500056D65 /* BackupViewController.swift in Sources */,
 				AA94965F20CB5FA600A9C2DD /* AssetAddressFactory.swift in Sources */,
 				AACE31CA2092A99B00B7B806 /* AssetAddress.swift in Sources */,
@@ -7768,6 +7776,7 @@
 				AA24D4C820D9D1EC0096DD5D /* AssetTypeLegacyHelper.swift in Sources */,
 				AACE31DD2092A99B00B7B806 /* UserDefaults.swift in Sources */,
 				AACE31DF2092A99B00B7B806 /* CertificatePinner.swift in Sources */,
+				AACB48BB214784D6008FCCD0 /* Collection+HelpersTests.swift in Sources */,
 				AAE94F3620C70B97005A3595 /* AssetURLPayload.swift in Sources */,
 				AAFE9E9321016132002E4E1E /* PinError.swift in Sources */,
 				51D17A9A20A33A700071E7E0 /* PrivateKeyReader.swift in Sources */,
@@ -8006,6 +8015,7 @@
 				C7CE25AA2135E3B500DCC43B /* ExchangeCreateContracts.swift in Sources */,
 				C7EEB8451EA95505002F28B9 /* UIView+ChangeFrameAttribute.m in Sources */,
 				C774A1262102B87300DCCC17 /* ExchangeRate.swift in Sources */,
+				AACB48B821478472008FCCD0 /* Collection+Helpers.swift in Sources */,
 				5114EA2320CD8B900098E26E /* UINavigationBar+TitleAttributes.swift in Sources */,
 				606399FA2110FC2D005B6DF5 /* SRSIMDHelpers.m in Sources */,
 				606399EE2110FC2D005B6DF5 /* SRHTTPConnectMessage.m in Sources */,

--- a/Blockchain/Arrays.swift
+++ b/Blockchain/Arrays.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension Array where Element : Equatable {
+extension Array where Element: Equatable {
 
     /// Returns an array of unique values in the array
     var unique: [Element] {

--- a/Blockchain/Extensions/Collection+Helpers.swift
+++ b/Blockchain/Extensions/Collection+Helpers.swift
@@ -1,0 +1,21 @@
+//
+//  Collection+Helpers.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 9/10/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+extension Collection {
+
+    /// Allows safe indexing into this collection. If the provided index is within
+    /// bounds, the item will be returned, otherwise, nil.
+    subscript (safe index: Index) -> Element? {
+        guard indices.contains(index) else {
+            return nil
+        }
+        return self[index]
+    }
+}

--- a/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
+++ b/Blockchain/KYC/Personal/KYCPersonalDetailsController.swift
@@ -9,7 +9,16 @@
 import UIKit
 
 /// Personal details entry screen in KYC flow
-final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormView, ProgressableView {
+final class KYCPersonalDetailsController: KYCBaseViewController,
+    ValidationFormView,
+    ProgressableView,
+    BottomButtonContainerView {
+
+    // MARK: - BottomButtonContainerView
+
+    var originalBottomButtonConstraint: CGFloat!
+
+    @IBOutlet var layoutConstraintBottomButton: NSLayoutConstraint!
 
     // MARK: - ProgressableView
 
@@ -32,8 +41,6 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
     var validationFields: [ValidationTextField] {
         return [firstNameField, lastNameField, birthdayField]
     }
-
-    var keyboard: KeyboardPayload?
 
     // MARK: Public Properties
 
@@ -71,6 +78,10 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
 
     // MARK: Lifecycle
 
+    deinit {
+        cleanUp()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -97,6 +108,14 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
                 next.becomeFocused()
             }
         }
+
+        originalBottomButtonConstraint = layoutConstraintBottomButton.constant
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setUpBottomButtonContainerView()
+        firstNameField.becomeFocused()
     }
 
     // MARK: - Private Methods
@@ -121,12 +140,7 @@ final class KYCPersonalDetailsController: KYCBaseViewController, ValidationFormV
 
     fileprivate func setupNotifications() {
         NotificationCenter.when(.UIKeyboardWillHide) { [weak self] _ in
-            self?.scrollView.contentInset = .zero
             self?.scrollView.setContentOffset(.zero, animated: true)
-        }
-        NotificationCenter.when(.UIKeyboardWillShow) { [weak self] notification in
-            let keyboard = KeyboardPayload(notification: notification)
-            self?.keyboard = keyboard
         }
     }
 

--- a/Blockchain/KYC/Storyboards/Base.lproj/KYCPersonalDetailsController.storyboard
+++ b/Blockchain/KYC/Storyboards/Base.lproj/KYCPersonalDetailsController.storyboard
@@ -32,119 +32,129 @@
                                     <constraint firstAttribute="height" constant="8" id="VjU-hs-80k"/>
                                 </constraints>
                                 <color key="progressTintColor" red="0.13725490196078433" green="0.58823529411764708" blue="0.42352941176470588" alpha="1" colorSpace="calibratedRGB"/>
-                                <color key="trackTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </progressView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Why do we need this information?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmZ-Mg-6Kp">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="751" text="Why do we need this information?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmZ-Mg-6Kp">
                                 <rect key="frame" x="16" y="16" width="343" height="14"/>
                                 <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="12"/>
                                 <color key="textColor" red="0.30588235289999999" green="0.30588235289999999" blue="0.30588235289999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="999" text="Regulations require that users must be 18 or older to trade crypto." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IMs-GD-oqE">
-                                <rect key="frame" x="16" y="32" width="343" height="29.333333333333329"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="751" text="Regulations require that users must be 18 or older to trade crypto." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IMs-GD-oqE">
+                                <rect key="frame" x="16" y="32" width="343" height="28"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="12"/>
                                 <color key="textColor" red="0.30588235289999999" green="0.30588235289999999" blue="0.30588235289999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="oDQ-tQ-rDw">
-                                <rect key="frame" x="0.0" y="61.333333333333314" width="375" height="628.66666666666674"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalHuggingPriority="249" verticalCompressionResistancePriority="749" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="oDQ-tQ-rDw">
+                                <rect key="frame" x="0.0" y="60" width="375" height="554"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFe-4p-8Bl" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="0.0" width="343" height="56"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AKj-ci-QYf">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="553"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFe-4p-8Bl" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
+                                                <rect key="frame" x="16" y="8" width="343" height="56"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="56" id="unQ-2Z-OTz"/>
+                                                </constraints>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="First Name"/>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
+                                                        <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                                        <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Nk-Gd-qS1" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
+                                                <rect key="frame" x="16" y="72" width="343" height="56"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="56" id="JbJ-Qu-aif"/>
+                                                </constraints>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Last Name"/>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
+                                                        <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                                        <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="38g-Ci-yOA" customClass="ValidationDateField" customModule="Blockchain" customModuleProvider="target">
+                                                <rect key="frame" x="16" y="136" width="343" height="56"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="56" id="wLH-Yd-Id7"/>
+                                                </constraints>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Birthday"/>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
+                                                        <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                                        <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="56" id="unQ-2Z-OTz"/>
-                                        </constraints>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="First Name"/>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
-                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
-                                                <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Nk-Gd-qS1" customClass="ValidationTextField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="55.666666666666657" width="343" height="56"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="56" id="JbJ-Qu-aif"/>
-                                        </constraints>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Last Name"/>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
-                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
-                                                <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="38g-Ci-yOA" customClass="ValidationDateField" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="111.99999999999997" width="343" height="56"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="56" id="wLH-Yd-Id7"/>
-                                        </constraints>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Birthday"/>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="placeholderFillColor">
-                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="supportsAutoCorrect" value="NO"/>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
-                                                <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="optionalField" value="NO"/>
-                                        </userDefinedRuntimeAttributes>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vzT-Yr-4Pj" customClass="PrimaryButtonContainer" customModule="Blockchain" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="175.99999999999997" width="343" height="44"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="bSS-7M-SFM"/>
+                                            <constraint firstItem="6Nk-Gd-qS1" firstAttribute="top" secondItem="dFe-4p-8Bl" secondAttribute="bottom" constant="8" id="DFJ-j0-jbd"/>
+                                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="38g-Ci-yOA" secondAttribute="bottom" constant="8" id="Obr-Vt-NcW"/>
+                                            <constraint firstItem="38g-Ci-yOA" firstAttribute="top" secondItem="6Nk-Gd-qS1" secondAttribute="bottom" constant="8" id="Pnw-IN-twF"/>
+                                            <constraint firstItem="dFe-4p-8Bl" firstAttribute="leading" secondItem="AKj-ci-QYf" secondAttribute="leading" constant="16" id="QKE-Iq-DEa"/>
+                                            <constraint firstItem="6Nk-Gd-qS1" firstAttribute="trailing" secondItem="dFe-4p-8Bl" secondAttribute="trailing" id="TWO-EY-L4k"/>
+                                            <constraint firstItem="dFe-4p-8Bl" firstAttribute="top" secondItem="AKj-ci-QYf" secondAttribute="top" constant="8" id="Z6M-Ba-vFd"/>
+                                            <constraint firstItem="38g-Ci-yOA" firstAttribute="leading" secondItem="6Nk-Gd-qS1" secondAttribute="leading" id="ezw-gL-pDN"/>
+                                            <constraint firstAttribute="trailing" secondItem="dFe-4p-8Bl" secondAttribute="trailing" constant="16" id="hMG-Xh-5ma"/>
+                                            <constraint firstItem="38g-Ci-yOA" firstAttribute="trailing" secondItem="6Nk-Gd-qS1" secondAttribute="trailing" id="jEn-JR-3n8"/>
+                                            <constraint firstItem="6Nk-Gd-qS1" firstAttribute="leading" secondItem="dFe-4p-8Bl" secondAttribute="leading" id="mN4-iu-TyF"/>
                                         </constraints>
                                     </view>
                                 </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="38g-Ci-yOA" secondAttribute="trailing" constant="16" id="2Nv-Xp-mtz"/>
-                                    <constraint firstItem="vzT-Yr-4Pj" firstAttribute="top" secondItem="38g-Ci-yOA" secondAttribute="bottom" constant="8" id="4O8-WT-eh2"/>
-                                    <constraint firstAttribute="bottom" secondItem="vzT-Yr-4Pj" secondAttribute="bottom" constant="16" id="62l-VR-Ycl"/>
-                                    <constraint firstItem="38g-Ci-yOA" firstAttribute="leading" secondItem="oDQ-tQ-rDw" secondAttribute="leading" constant="16" id="CTl-rG-4bv"/>
-                                    <constraint firstItem="6Nk-Gd-qS1" firstAttribute="leading" secondItem="oDQ-tQ-rDw" secondAttribute="leading" constant="16" id="Ml9-p3-cbv"/>
-                                    <constraint firstItem="vzT-Yr-4Pj" firstAttribute="trailing" secondItem="38g-Ci-yOA" secondAttribute="trailing" id="NTE-fx-E8F"/>
-                                    <constraint firstAttribute="trailing" secondItem="dFe-4p-8Bl" secondAttribute="trailing" constant="16" id="NVi-mF-g0o"/>
-                                    <constraint firstItem="dFe-4p-8Bl" firstAttribute="top" secondItem="oDQ-tQ-rDw" secondAttribute="top" id="NXv-A1-W8C"/>
-                                    <constraint firstItem="38g-Ci-yOA" firstAttribute="top" secondItem="6Nk-Gd-qS1" secondAttribute="bottom" id="QQC-DJ-NmU"/>
-                                    <constraint firstAttribute="trailing" secondItem="6Nk-Gd-qS1" secondAttribute="trailing" constant="16" id="UuH-7W-WIs"/>
-                                    <constraint firstItem="6Nk-Gd-qS1" firstAttribute="width" secondItem="dFe-4p-8Bl" secondAttribute="width" id="V5R-nI-Lz9"/>
-                                    <constraint firstItem="dFe-4p-8Bl" firstAttribute="leading" secondItem="oDQ-tQ-rDw" secondAttribute="leading" constant="16" id="Vgt-w3-Sgq"/>
-                                    <constraint firstItem="38g-Ci-yOA" firstAttribute="width" secondItem="6Nk-Gd-qS1" secondAttribute="width" id="XCo-fP-XdL"/>
-                                    <constraint firstItem="6Nk-Gd-qS1" firstAttribute="top" secondItem="dFe-4p-8Bl" secondAttribute="bottom" id="b1j-iP-iOP"/>
-                                    <constraint firstItem="vzT-Yr-4Pj" firstAttribute="leading" secondItem="38g-Ci-yOA" secondAttribute="leading" id="jB4-tk-HAT"/>
+                                    <constraint firstItem="AKj-ci-QYf" firstAttribute="centerX" secondItem="oDQ-tQ-rDw" secondAttribute="centerX" id="2Hj-nY-HAb"/>
+                                    <constraint firstItem="AKj-ci-QYf" firstAttribute="top" secondItem="oDQ-tQ-rDw" secondAttribute="top" id="QZZ-Uk-KD6"/>
+                                    <constraint firstAttribute="bottom" secondItem="AKj-ci-QYf" secondAttribute="bottom" id="Yv1-Na-f8G"/>
+                                    <constraint firstAttribute="trailing" secondItem="AKj-ci-QYf" secondAttribute="trailing" id="p9Y-6z-QKn"/>
+                                    <constraint firstItem="AKj-ci-QYf" firstAttribute="leading" secondItem="oDQ-tQ-rDw" secondAttribute="leading" id="pPN-Jh-HzQ"/>
                                 </constraints>
                                 <connections>
                                     <outlet property="delegate" destination="VK4-jv-eiz" id="oke-kY-her"/>
                                 </connections>
                             </scrollView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vzT-Yr-4Pj" customClass="PrimaryButtonContainer" customModule="Blockchain" customModuleProvider="target">
+                                <rect key="frame" x="16" y="630" width="343" height="44"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="bSS-7M-SFM"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="tmZ-Mg-6Kp" firstAttribute="top" secondItem="sxl-FD-HTb" secondAttribute="bottom" constant="8" id="2d9-Mo-WIr"/>
                             <constraint firstItem="sxl-FD-HTb" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" id="7Cp-VL-P0Z"/>
                             <constraint firstItem="IMs-GD-oqE" firstAttribute="trailing" secondItem="tmZ-Mg-6Kp" secondAttribute="trailing" id="889-1g-2Ck"/>
+                            <constraint firstItem="vzT-Yr-4Pj" firstAttribute="top" secondItem="oDQ-tQ-rDw" secondAttribute="bottom" constant="16" id="Ifn-5w-5IO"/>
                             <constraint firstItem="oDQ-tQ-rDw" firstAttribute="top" secondItem="IMs-GD-oqE" secondAttribute="bottom" id="MyY-WO-lW9"/>
                             <constraint firstItem="IMs-GD-oqE" firstAttribute="leading" secondItem="tmZ-Mg-6Kp" secondAttribute="leading" id="NP6-i7-SFD"/>
                             <constraint firstItem="oDQ-tQ-rDw" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" id="NS6-cv-AqF"/>
-                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="bottom" secondItem="oDQ-tQ-rDw" secondAttribute="bottom" id="Ngv-iE-i4Q"/>
-                            <constraint firstItem="dFe-4p-8Bl" firstAttribute="width" secondItem="IMs-GD-oqE" secondAttribute="width" id="Ost-xi-8cb"/>
+                            <constraint firstItem="vzT-Yr-4Pj" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" constant="16" id="QFQ-zO-d3o"/>
                             <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="oDQ-tQ-rDw" secondAttribute="trailing" id="TaS-qG-rfa"/>
+                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="bottom" secondItem="vzT-Yr-4Pj" secondAttribute="bottom" constant="16" id="VKf-gH-AoH"/>
                             <constraint firstItem="sxl-FD-HTb" firstAttribute="top" secondItem="A6g-7V-Tpb" secondAttribute="top" id="bsI-YJ-JKf"/>
+                            <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="vzT-Yr-4Pj" secondAttribute="trailing" constant="16" id="cq6-FA-A68"/>
                             <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="sxl-FD-HTb" secondAttribute="trailing" id="iy1-0F-Ect"/>
                             <constraint firstItem="A6g-7V-Tpb" firstAttribute="trailing" secondItem="tmZ-Mg-6Kp" secondAttribute="trailing" constant="16" id="mVs-oS-QDE"/>
                             <constraint firstItem="tmZ-Mg-6Kp" firstAttribute="leading" secondItem="A6g-7V-Tpb" secondAttribute="leading" constant="16" id="odu-5Q-U5d"/>
@@ -160,23 +170,15 @@
                         <outlet property="birthdayField" destination="38g-Ci-yOA" id="aQP-L4-4V9"/>
                         <outlet property="firstNameField" destination="dFe-4p-8Bl" id="L3G-QR-mVR"/>
                         <outlet property="lastNameField" destination="6Nk-Gd-qS1" id="trs-Iy-Ecy"/>
+                        <outlet property="layoutConstraintBottomButton" destination="VKf-gH-AoH" id="dzK-kl-R1f"/>
                         <outlet property="primaryButtonContainer" destination="vzT-Yr-4Pj" id="n9C-WS-a5a"/>
                         <outlet property="progressView" destination="sxl-FD-HTb" id="Op0-Xj-T3U"/>
                         <outlet property="scrollView" destination="oDQ-tQ-rDw" id="RFu-VN-Nho"/>
-                        <segue destination="ikb-aY-GZn" kind="show" identifier="enterMobileNumber" id="EC8-k6-Erk"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="NPZ-Fa-q8L" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-47.200000000000003" y="193.5960591133005"/>
-        </scene>
-        <!--KYCEnterPhoneNumberController-->
-        <scene sceneID="i1U-r4-6wf">
-            <objects>
-                <viewControllerPlaceholder storyboardName="KYCEnterPhoneNumberController" id="ikb-aY-GZn" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="BDp-2Y-wKI" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="754" y="81"/>
         </scene>
     </scenes>
 </document>

--- a/Blockchain/Views/ValidationForm/ValidationFormView.swift
+++ b/Blockchain/Views/ValidationForm/ValidationFormView.swift
@@ -14,7 +14,6 @@ import Foundation
 protocol ValidationFormView {
     var validationFields: [ValidationTextField] { get }
     var scrollView: UIScrollView! { get }
-    var keyboard: KeyboardPayload? { get set }
 
     /// This should be called on `viewDidLoad`. It sets the
     /// `becomeFirstResponder` block and handles offseting
@@ -36,24 +35,13 @@ extension ValidationFormView where Self: UIViewController {
         validationFields.forEach { (field) in
             field.becomeFirstResponderBlock = { [weak self] (validationField) in
                 guard let this = self else { return }
-                var offsetHeight = this.keyboard?.endingFrame.height
-                if let field = validationField as? ValidationDateField {
-                    offsetHeight = field.pickerView.frame.height
-                }
-                guard let height = offsetHeight else { return }
-                let insets = UIEdgeInsets(
-                    top: 0.0,
-                    left: 0.0,
-                    bottom: height,
-                    right: 0.0
-                )
-                this.scrollView.contentInset = insets
 
-                let offset = CGPoint(
-                    x: 0.0,
-                    y: validationField.frame.minY
-                )
-                this.scrollView.setContentOffset(offset, animated: true)
+                // Scroll so that the next field is also visible
+                guard let currentIndex = this.validationFields.index(of: validationField) else { return }
+
+                guard let nextField = this.validationFields[safe: currentIndex + 1] else { return }
+
+                this.scrollView.scrollRectToVisible(nextField.frame, animated: true)
             }
         }
     }

--- a/BlockchainTests/Extensions/Collection+HelpersTests.swift
+++ b/BlockchainTests/Extensions/Collection+HelpersTests.swift
@@ -1,0 +1,24 @@
+//
+//  Collection+HelpersTests.swift
+//  BlockchainTests
+//
+//  Created by Chris Arriola on 9/10/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+
+class CollectionHelpersTests: XCTestCase {
+
+    func testSafeIndexInBounds() {
+        let array = [1, 2, 3, 4, 5]
+        XCTAssertNotNil(array[safe: 0])
+    }
+
+    func testSafeIndexOutOfBounds() {
+        let array = [1, 2, 3, 4, 5]
+        XCTAssertNil(array[safe: 100])
+    }
+}


### PR DESCRIPTION
## Objective

UI polish for the KYC personal details screen.

## Description

PR address the following issues:
* add 8pt vertical spacing between input fields
* move next button to bottom of the view
* auto-focus first name when entering screen (IOS-1217)
* allow scrolling up to previous input fields (the issue was that the UIScrollView's contentSize was set to 0 which prevented the UIScrollView's content from being scrollable)
* changing the background of the `UIProgressView` to be the default gray color instead of white
* modified the behavior of `ValidationFormView` so that when a input field is focused (i.e. the handler in `becomeFirstResponderBlock`) instead of scrolling it to the top of the scroll view, it will only scroll if and only if there is another `ValidationTextField` next/below it. Since this PR changes `ValidationFormView`, which also affects `KYCAddressController`, I'll work on updating that view next (which is why this PR has a "don't merge yet" label)

Other changes:
* I added an extension to `Collection` for safe indexing into a collection type. I had written something like this in the past for an `Array`, but saw a more generic solution proposed [here](https://stackoverflow.com/a/30593673) so thought I'd add

Note: I didn't implement showing an alert if the selected date is < 18 years

## How to Test

Pull in changes, go through KYC and mess around with the personal details screen (esp. look at that screen with the keyboard up and scroll around)

## Screenshot/Design assessment

![simulator screen shot - iphone 5s - 2018-09-10 at 22 17 45](https://user-images.githubusercontent.com/38220701/45339741-b09aae00-b548-11e8-884f-e59b50ae3ee9.png)

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [X] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
