### PR TITLE
fix(KYC): remove back button from application completed screen (IOS-1268)

### DIFF
--- a/Blockchain/KYC/KYCApplicationCompleteController.swift
+++ b/Blockchain/KYC/KYCApplicationCompleteController.swift
@@ -27,6 +27,7 @@ final class KYCApplicationCompleteController: KYCBaseViewController, Progressabl
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem()
         setupProgressView()
     }
 

--- a/Blockchain/KYC/KYCApplicationCompleteController.swift
+++ b/Blockchain/KYC/KYCApplicationCompleteController.swift
@@ -27,7 +27,6 @@ final class KYCApplicationCompleteController: KYCBaseViewController, Progressabl
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem()
         setupProgressView()
     }
 

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -118,6 +118,7 @@ protocol KYCCoordinatorDelegate: class {
                 in: self,
                 payload: payload
             )
+            controller.navigationItem.hidesBackButton = (nextPage == .applicationComplete)
             navController.pushViewController(controller, animated: true)
         }
     }


### PR DESCRIPTION
## Objective

Remove the back button from the _Application Completed_ screen.

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
