### PR TITLE
fix(Send-Eth): IOS-1277 use correct delegate method name

### DIFF
--- a/Blockchain/View Controllers/SendEtherViewController.m
+++ b/Blockchain/View Controllers/SendEtherViewController.m
@@ -375,7 +375,7 @@
     }];
 }
 
-- (void)closeButtonClicked
+- (void)closeButtonTapped
 {
     [self.toField resignFirstResponder];
     [self.amountInputView.fiatField resignFirstResponder];


### PR DESCRIPTION
## Objective

Allow closing of the keyboard on the Send Ether screen by tapping the right-hand side "X" button.

## Description

Renamed `closeButtonClicked` to `closeButtonTapped`. All other files that use this delegate method (`PartnerExchangeCreateViewController.m` and `ExchangeCreateView.swift` already implement `closeButtonTapped`.

## How to Test

Open Send Ether screen, tap on any field, and close keyboard with the X button on the input accessory view.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
