### PR TITLE
feat(Debug): IOS-1263 optionally allow prefilled fields per QA request

### DIFF
--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -17,6 +17,9 @@ struct Constants {
         static let duration = 0.2
         static let durationLong = 0.5
     }
+    struct DebugKeys {
+        static let createWalletPrefill = "createWalletPrefill"
+    }
     struct Measurements {
         static let DefaultHeaderHeight: CGFloat = 65
         // TODO: remove this once we use autolayout
@@ -124,6 +127,10 @@ struct Constants {
     @objc class func animationDuration() -> Double { return Constants.Animation.duration }
 
     @objc class func animationDurationLong() -> Double { return Constants.Animation.durationLong }
+
+    @objc class func debugKeyCreateWalletPrefill() -> String {
+        return Constants.DebugKeys.createWalletPrefill
+    }
 
     @objc class func notificationKeyModalViewDismissed() -> String {
         return Constants.NotificationKeys.modalViewDismissed.rawValue

--- a/Blockchain/Modal Content Views/BCCreateWalletView.m
+++ b/Blockchain/Modal Content Views/BCCreateWalletView.m
@@ -112,7 +112,7 @@
     }
 }
 
-#pragma mark - BCModalContentView Lifecyle methods
+#pragma mark - BCModalContentView Lifecycle methods
 
 - (void)prepareForModalPresentation
 {
@@ -121,13 +121,6 @@
     password2TextField.delegate = self;
     
     [self clearSensitiveTextFields];
-
-#ifdef DEBUG
-    emailTextField.text = @"test@doesnotexist.com";
-    passwordTextField.text = @"testpassword!";
-    password2TextField.text = @"testpassword!";
-    [self checkPasswordStrength];
-#endif
     
     _recoveryPhraseView.recoveryPassphraseTextField.delegate = self;
     

--- a/Blockchain/Modal Content Views/BCCreateWalletView.m
+++ b/Blockchain/Modal Content Views/BCCreateWalletView.m
@@ -122,6 +122,7 @@
     
     [self clearSensitiveTextFields];
 
+    // TICKET: IOS-1281 avoid interacting directly with user defaults
 #ifdef DEBUG
     if ([[NSUserDefaults standardUserDefaults] boolForKey:[ConstantsObjcBridge debugKeyCreateWalletPrefill]]) {
         emailTextField.text = @"test@doesnotexist.com";

--- a/Blockchain/Modal Content Views/BCCreateWalletView.m
+++ b/Blockchain/Modal Content Views/BCCreateWalletView.m
@@ -112,7 +112,7 @@
     }
 }
 
-#pragma mark - BCModalContentView Lifecycle methods
+#pragma mark - BCModalContentView Lifecyle methods
 
 - (void)prepareForModalPresentation
 {
@@ -121,6 +121,15 @@
     password2TextField.delegate = self;
     
     [self clearSensitiveTextFields];
+
+#ifdef DEBUG
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:[ConstantsObjcBridge debugKeyCreateWalletPrefill]]) {
+        emailTextField.text = @"test@doesnotexist.com";
+        passwordTextField.text = @"testpassword!";
+        password2TextField.text = @"testpassword!";
+        [self checkPasswordStrength];
+    }
+#endif
     
     _recoveryPhraseView.recoveryPassphraseTextField.delegate = self;
     

--- a/Blockchain/View Controllers/DebugTableViewController.m
+++ b/Blockchain/View Controllers/DebugTableViewController.m
@@ -22,8 +22,8 @@ typedef NS_ENUM(NSInteger, DebugTableViewRow) {
     RowSecurityReminderTimer,
     RowZeroTickerValue,
     RowKYC,
+    RowCreateWalletPrefill,
     RowTotalCount,
-    RowCreateWalletPrefill
 };
 
 typedef enum {

--- a/Blockchain/View Controllers/DebugTableViewController.m
+++ b/Blockchain/View Controllers/DebugTableViewController.m
@@ -205,6 +205,7 @@ typedef enum {
         }
         case RowKYC: {
             cell.textLabel.text = @"Launch KYC";
+            break;
         }
         case RowCreateWalletPrefill: {
             cell.textLabel.text = @"Create wallet prefill";
@@ -213,6 +214,7 @@ typedef enum {
             prefillToggle.on = prefillOn;
             [prefillToggle addTarget:self action:@selector(toggleCreateWalletPrefill) forControlEvents:UIControlEventTouchUpInside];
             cell.accessoryView = prefillToggle;
+            break;
         }
         default:
             break;

--- a/Blockchain/View Controllers/DebugTableViewController.m
+++ b/Blockchain/View Controllers/DebugTableViewController.m
@@ -22,7 +22,8 @@ typedef NS_ENUM(NSInteger, DebugTableViewRow) {
     RowSecurityReminderTimer,
     RowZeroTickerValue,
     RowKYC,
-    RowTotalCount
+    RowTotalCount,
+    RowCreateWalletPrefill
 };
 
 typedef enum {
@@ -129,6 +130,12 @@ typedef enum {
     [[NSUserDefaults standardUserDefaults] setBool:!zeroTickerOn forKey:USER_DEFAULTS_KEY_DEBUG_SIMULATE_ZERO_TICKER];
 }
 
+- (void)toggleCreateWalletPrefill
+{
+    BOOL prefillOn = [[NSUserDefaults standardUserDefaults] boolForKey:[ConstantsObjcBridge debugKeyCreateWalletPrefill]];
+    [[NSUserDefaults standardUserDefaults] setBool:!prefillOn forKey:[ConstantsObjcBridge debugKeyCreateWalletPrefill]];
+}
+
 - (void)showFilteredWalletJSON
 {
     UIViewController *viewController = [[UIViewController alloc] init];
@@ -198,6 +205,14 @@ typedef enum {
         }
         case RowKYC: {
             cell.textLabel.text = @"Launch KYC";
+        }
+        case RowCreateWalletPrefill: {
+            cell.textLabel.text = @"Create wallet prefill";
+            UISwitch *prefillToggle = [[UISwitch alloc] init];
+            BOOL prefillOn = [[NSUserDefaults standardUserDefaults] boolForKey:[ConstantsObjcBridge debugKeyCreateWalletPrefill]];
+            prefillToggle.on = prefillOn;
+            [prefillToggle addTarget:self action:@selector(toggleCreateWalletPrefill) forControlEvents:UIControlEventTouchUpInside];
+            cell.accessoryView = prefillToggle;
         }
         default:
             break;


### PR DESCRIPTION
## Objective

Optionally allow prefilled fields for the Create Wallet View in Debug mode.

## Description

Added Debug menu entry for enabling prefilled fields for the Create Wallet View.

## How to Test

Run app in a debug scheme, go to Create Wallet screen, see that fields are not pre-populated. Go to Debug menu, toggle the Create Wallet Prefill option ON, and see that fields are pre-populated.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
