### PR TITLE
fix(KYC): take user directly to status screen (IOS-1266)

### DIFF
--- a/Blockchain/KYC/Information/KYCInformationController.swift
+++ b/Blockchain/KYC/Information/KYCInformationController.swift
@@ -43,7 +43,7 @@ final class KYCInformationController: KYCBaseViewController {
     // MARK: - IBActions
 
     @IBAction func dismiss(_ sender: Any) {
-        dismiss(animated: false, completion: {
+        dismiss(animated: true, completion: {
             self.coordinator.finish()
         })
     }

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -85,8 +85,12 @@ protocol KYCCoordinatorDelegate: class {
                 Logger.shared.debug("Got user with ID: \($0.personalDetails?.identifier ?? "")")
                 LoadingViewPresenter.shared.hideBusyView()
                 self.user = $0
-                self.initializeNavigationStack(viewController)
-                self.restoreToMostRecentPageIfNeeded()
+                if self.pageTypeForUser() == .accountStatus {
+                    self.presentAccountStatusView(for: self.user!.status, in: viewController)
+                } else {
+                    self.initializeNavigationStack(viewController)
+                    self.restoreToMostRecentPageIfNeeded()
+                }
             }, onError: { error in
                 Logger.shared.error("Failed to get user: \(error.localizedDescription)")
                 LoadingViewPresenter.shared.hideBusyView()
@@ -96,6 +100,7 @@ protocol KYCCoordinatorDelegate: class {
 
     func finish() {
         // TODO: if applicable, persist state, do housekeeping, etc...
+        if navController == nil { return }
         navController.dismiss(animated: true)
     }
 
@@ -241,6 +246,6 @@ protocol KYCCoordinatorDelegate: class {
 
         guard currentUser.status != .none else { return .verifyIdentity }
 
-        return .applicationComplete
+        return .accountStatus
     }
 }

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -86,7 +86,7 @@ protocol KYCCoordinatorDelegate: class {
                 LoadingViewPresenter.shared.hideBusyView()
                 self.user = $0
                 if self.pageTypeForUser() == .accountStatus {
-                    self.presentAccountStatusView(for: self.user!.status, in: viewController)
+                    self.presentAccountStatusView(for: $0.status, in: viewController)
                 } else {
                     self.initializeNavigationStack(viewController)
                     self.restoreToMostRecentPageIfNeeded()


### PR DESCRIPTION
## Objective

Upon KYC completion, take the user back to the status screen instead of showing the _Application Completed_ screen.

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
