### PR TITLE
fix(KYC): only show passport and driver's license options (IOS-1275)

### DIFF
--- a/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
+++ b/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
@@ -60,14 +60,14 @@ final class KYCVerifyIdentityController: KYCBaseViewController {
     // MARK: - Private Methods
 
     private func setUpAndShowDocumentDialog() {
-        let documentDialog = UIAlertController(title: "Which document are you using?", message: nil, preferredStyle: .actionSheet)
-        let passportAction = UIAlertAction(title: "Passport", style: .default, handler: { _ in
+        let documentDialog = UIAlertController(title: LocalizationConstants.KYC.whichDocumentAreYouUsing, message: nil, preferredStyle: .actionSheet)
+        let passportAction = UIAlertAction(title: LocalizationConstants.KYC.passport, style: .default, handler: { _ in
             self.didSelect(.passport)
         })
-        let driversLicenseAction = UIAlertAction(title: "Driver's License", style: .default, handler: { _ in
+        let driversLicenseAction = UIAlertAction(title: LocalizationConstants.KYC.driversLicense, style: .default, handler: { _ in
             self.didSelect(.driversLicense)
         })
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        let cancelAction = UIAlertAction(title: LocalizationConstants.cancel, style: .cancel)
         documentDialog.addAction(passportAction)
         documentDialog.addAction(driversLicenseAction)
         documentDialog.addAction(cancelAction)

--- a/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
+++ b/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
@@ -67,17 +67,9 @@ final class KYCVerifyIdentityController: KYCBaseViewController {
         let driversLicenseAction = UIAlertAction(title: "Driver's License", style: .default, handler: { _ in
             self.didSelect(.driversLicense)
         })
-        let identityCardAction = UIAlertAction(title: "Identity Card", style: .default, handler: { _ in
-            self.didSelect(.identityCard)
-        })
-        let residencePermitCardAction = UIAlertAction(title: "Residence Permit Card", style: .default, handler: { _ in
-            self.didSelect(.residencePermitCard)
-        })
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         documentDialog.addAction(passportAction)
         documentDialog.addAction(driversLicenseAction)
-        documentDialog.addAction(identityCardAction)
-        documentDialog.addAction(residencePermitCardAction)
         documentDialog.addAction(cancelAction)
         present(documentDialog, animated: true)
     }

--- a/Blockchain/KYC/Storyboards/KYCVerifyIdentityController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCVerifyIdentityController.storyboard
@@ -32,23 +32,21 @@
                                 <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wSW-uD-Za7">
-                                <rect key="frame" x="16" y="60" width="343" height="34.333333333333343"/>
-                                <string key="text">Grab your Passport, Driver’s License, Govt
-Issue ID or a Resident Permit Card.</string>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Grab your Passport or Driver's License." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wSW-uD-Za7">
+                                <rect key="frame" x="16" y="60.000000000000007" width="343" height="17.333333333333336"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Light" family="Montserrat" pointSize="14"/>
                                 <color key="textColor" red="0.35686274509999999" green="0.35686274509999999" blue="0.35686274509999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="IdentityVerification" translatesAutoresizingMaskIntoConstraints="NO" id="uin-Bk-g6x">
-                                <rect key="frame" x="47" y="142.33333333333334" width="280" height="150.00000000000003"/>
+                                <rect key="frame" x="47" y="125.33333333333334" width="280" height="150.00000000000003"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="150" id="E5s-Yl-bkf"/>
                                     <constraint firstAttribute="width" constant="280" id="miD-OS-faf"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Once we verify your identity, you are approved to exchange cryptocurrencies on the Blockchain app!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YYL-dK-Xos">
-                                <rect key="frame" x="24" y="328.33333333333331" width="327" height="29.333333333333314"/>
+                                <rect key="frame" x="24" y="311.33333333333331" width="327" height="29.333333333333314"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="12"/>
                                 <color key="textColor" red="0.30588235294117649" green="0.30588235294117649" blue="0.30588235294117649" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -596,6 +596,18 @@ struct LocalizationConstants {
             "Your Home Address",
             comment: "Text displayed on the search bar when adding an address during KYC."
         )
+        static let whichDocumentAreYouUsing = NSLocalizedString(
+            "Which document are you using?",
+            comment: ""
+        )
+        static let passport = NSLocalizedString(
+            "Passport",
+            comment: "The title of the UIAlertAction for the passport option."
+        )
+        static let driversLicense = NSLocalizedString(
+            "Driver's License",
+            comment: "The title of the UIAlertAction for the driver's license option."
+        )
     }
 }
 


### PR DESCRIPTION
## Objective

Only show supported document types during identity verification step (passport and driver's license). Note that other document types are still in the code in case we add support at a later point.

## How to Test

Launch KYC flow and proceed to identity verification step. Verify that the there are only two supported document types.

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
