### PR TITLE
fix(KYC): IOS-1246 address UI polish

### DIFF
--- a/Blockchain/KYC/Search/LocationSuggestionCoordinator.swift
+++ b/Blockchain/KYC/Search/LocationSuggestionCoordinator.swift
@@ -69,7 +69,7 @@ extension LocationSuggestionCoordinator: SearchControllerDelegate {
 
     func onSelection(_ selection: SearchSelection) {
         if let input = selection as? LocationSuggestion {
-            interface?.searchFieldText("\(input.title) \(input.subtitle)")
+            interface?.searchFieldText("")
             interface?.suggestionsList(.hidden)
             interface?.primaryButton(.visible)
             interface?.updateActivityIndicator(.visible)


### PR DESCRIPTION
## Objective

Polishing address entry screen in KYC flow.

## Description

* make UIScrollView scrollable (#475 is no longer blocked)
* don't show cancel button in search bar
* clearing search bar when tapping on result

Note: there is another polish task though which I was having trouble resolving (i.e. Pressing search on an empty input gives you an empty page (i.e. handle no results state)).

## How to Test

Launch KYC and go through address screen

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
