### PR TITLE
fix(KYC): update country selection screen title (IOS-1283)

### DIFF
--- a/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCCountrySelectionController.storyboard
@@ -116,7 +116,9 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Z4F-OY-daj"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Select Your Country" id="lqm-oI-6In"/>
+                    <navigationItem key="navigationItem" title="Country of Residence" id="lqm-oI-6In">
+                        <barButtonItem key="backBarButtonItem" id="iN0-fe-UEY"/>
+                    </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="progressView" destination="DD7-KN-SsY" id="48v-s6-3Ce"/>


### PR DESCRIPTION
## Objective

Update the title of the country selection screen.

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
