### PR TITLE
fix(BlockchainDataRepository): update cache when fetchNabuUser succeeds.

### DIFF
--- a/Blockchain/Data/BlockchainDataRepository.swift
+++ b/Blockchain/Data/BlockchainDataRepository.swift
@@ -53,14 +53,16 @@ import RxSwift
         cachedCountries = BehaviorRelay<Countries?>(value: nil)
     }
 
-    /// Fetches the NabuUser over the network
+    /// Fetches the NabuUser over the network and updates the cached NabuUser if successful
     ///
     /// - Returns: the fetched NabuUser
     func fetchNabuUser() -> Single<NabuUser> {
         return authenticationService.getSessionToken().flatMap { token in
             let headers = [HttpHeaderField.authorization: token.token]
             return KYCNetworkRequest.request(get: .currentUser, headers: headers, type: NabuUser.self)
-        }
+        }.do(onSuccess: { [weak self] response in
+            self?.cachedUser.accept(response)
+        })
     }
 
     // MARK: - Private Methods


### PR DESCRIPTION
## Objective

Update the cached nabu user when `fetchNabuUser()` function succeeds. This way, the cached nabu user is not stale when referenced.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
