### PR TITLE
fix(KYC): fetch the latest nabu user when entering settings.

### DIFF
--- a/Blockchain/Settings/Settings+Table.swift
+++ b/Blockchain/Settings/Settings+Table.swift
@@ -125,7 +125,7 @@ extension SettingsTableViewController {
     }
 
     func getUserVerificationStatus(handler: @escaping (NabuUser?, Bool) -> Void) {
-        disposable = BlockchainDataRepository.shared.nabuUser
+        disposable = BlockchainDataRepository.shared.fetchNabuUser()
             .subscribeOn(MainScheduler.asyncInstance) // network call will be performed off the main thread
             .observeOn(MainScheduler.instance) // closures passed in subscribe will be on the main thread
             .subscribe(onSuccess: { user in


### PR DESCRIPTION
## Objective

Fetch the latest nabu user when entering settings so we are displaying the most up-to-date info. Previously, we were displaying the cached nabu user which may be stale.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
