### PR TITLE
feat(Exchange): present trade details when tapping on a trade item in exchange history

### DIFF
--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -205,12 +205,18 @@ struct ExchangeServices: ExchangeDependencies {
         navigationController.pushViewController(confirmController, animated: true)
     }
 
+    private func showTradeDetails(trade: ExchangeTradeCellModel) {
+        let detailViewController = ExchangeDetailViewController.make(with: .overview(trade))
+        navigationController?.pushViewController(detailViewController, animated: true)
+    }
+
     // MARK: - Event handling
     enum ExchangeCoordinatorEvent {
         case createHomebrewExchange(animated: Bool, viewController: UIViewController?)
         case createPartnerExchange(animated: Bool, viewController: UIViewController?)
         case confirmExchange(orderTransaction: OrderTransaction, conversion: Conversion)
         case sentTransaction
+        case showTradeDetails(trade: ExchangeTradeCellModel)
     }
 
     func handle(event: ExchangeCoordinatorEvent) {
@@ -229,6 +235,8 @@ struct ExchangeServices: ExchangeDependencies {
             showConfirmExchange(orderTransaction: orderTransaction, conversion: conversion)
         case .sentTransaction:
             navigationController?.popToRootViewController(animated: true)
+        case .showTradeDetails(let trade):
+            showTradeDetails(trade: trade)
         }
     }
 

--- a/Blockchain/Homebrew/Exchange/API/ExchangeListContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeListContracts.swift
@@ -15,6 +15,7 @@ protocol ExchangeListInterface: class {
     func append(results: [ExchangeTradeCellModel])
     func enablePullToRefresh()
     func showNewExchange(animated: Bool)
+    func showTradeDetails(trade: ExchangeTradeCellModel)
 }
 
 protocol ExchangeListInput: class {

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
@@ -84,7 +84,7 @@ extension ExchangeListViewController: ExchangeListInterface {
     }
     
     func display(results: [ExchangeTradeCellModel]) {
-        dataProvider?.append(tradeModels: results)
+        dataProvider?.set(tradeModels: results)
     }
     
     func append(results: [ExchangeTradeCellModel]) {

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol ExchangeListDelegate: class {
     func onAppeared()
     func onNextPageRequest(_ identifier: String)
+    func onTradeCellTapped(_ trade: ExchangeTradeCellModel)
     func onNewOrderTapped()
     func onPullToRefresh()
 }
@@ -70,6 +71,10 @@ class ExchangeListViewController: UIViewController {
 }
 
 extension ExchangeListViewController: ExchangeListInterface {
+    func showTradeDetails(trade: ExchangeTradeCellModel) {
+        coordinator.handle(event: .showTradeDetails(trade: trade))
+    }
+
     func paginationActivityIndicatorVisibility(_ visibility: Visibility) {
         dataProvider?.isPaging = visibility == .visible
     }
@@ -97,7 +102,7 @@ extension ExchangeListViewController: ExchangeListInterface {
 
 extension ExchangeListViewController: ExchangeListDataProviderDelegate {
     func dataProvider(_ dataProvider: ExchangeListDataProvider, didSelect trade: ExchangeTradeCellModel) {
-        // TODO: Show order detail screen for trade.
+        delegate?.onTradeCellTapped(trade)
     }
     
     func refreshControlTriggered(_ dataProvider: ExchangeListDataProvider) {

--- a/Blockchain/Homebrew/Exchange/DataProviders/ExchangeListDataProvider.swift
+++ b/Blockchain/Homebrew/Exchange/DataProviders/ExchangeListDataProvider.swift
@@ -92,6 +92,11 @@ class ExchangeListDataProvider: NSObject {
         tableView?.refreshControl = refreshControl
     }
 
+    func set(tradeModels: [ExchangeTradeCellModel]) {
+        models = tradeModels
+        tableView?.reloadData()
+    }
+
     func append(tradeModels: [ExchangeTradeCellModel]) {
         if var current = models {
             current.append(contentsOf: tradeModels)

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
@@ -37,6 +37,10 @@ extension ExchangeListPresenter: ExchangeListDelegate {
         interface?.refreshControlVisibility(.visible)
         interactor.refresh()
     }
+
+    func onTradeCellTapped(_ trade: ExchangeTradeCellModel) {
+        interface?.showTradeDetails(trade: trade)
+    }
 }
 
 extension ExchangeListPresenter: ExchangeListOutput {


### PR DESCRIPTION
## Objective

Present trade details view. Also fixed a bug wherein pulling to refresh would keep appending the same items.

## How to Test

Go to exchange, see past trades, tap on a trade.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
