### PR TITLE
feat(Homebrew-Shapeshift): IOS-1176 trading pair view progress

### DIFF
--- a/Blockchain/AssetType.swift
+++ b/Blockchain/AssetType.swift
@@ -95,7 +95,7 @@ extension AssetType {
         case .ethereum:
             return UIColor(red:0.28, green:0.23, blue:0.8, alpha:1)
         case .bitcoinCash:
-            return UIColor(red:1, green:0.61, blue:0.13, alpha:1)
+            return UIColor(red:0.24, green:0.86, blue:0.54, alpha:1)
         }
     }
 }

--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -13,6 +13,7 @@ protocol ExchangeCreateInterface: class {
     func updateInputLabels(primary: String?, primaryDecimal: String?, secondary: String?)
     func updateRateLabels(first: String, second: String, third: String)
     func updateTradingPairViewValues(left: String, right: String)
+    func updateTradingPairView(pair: TradingPair)
 }
 
 // Conforms to NumberKeypadViewDelegate to avoid redundancy of keypad input methods
@@ -28,4 +29,5 @@ protocol ExchangeCreateOutput: class {
     func updatedInput(primary: String?, primaryDecimal: String?, secondary: String?)
     func updatedRates(first: String, second: String, third: String)
     func updateTradingPairValues(left: String, right: String)
+    func updateTradingPair(pair: TradingPair)
 }

--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -13,7 +13,7 @@ protocol ExchangeCreateInterface: class {
     func updateInputLabels(primary: String?, primaryDecimal: String?, secondary: String?)
     func updateRateLabels(first: String, second: String, third: String)
     func updateTradingPairViewValues(left: String, right: String)
-    func updateTradingPairView(pair: TradingPair)
+    func updateTradingPairView(pair: TradingPair, fix: Fix)
 }
 
 // Conforms to NumberKeypadViewDelegate to avoid redundancy of keypad input methods
@@ -29,5 +29,5 @@ protocol ExchangeCreateOutput: class {
     func updatedInput(primary: String?, primaryDecimal: String?, secondary: String?)
     func updatedRates(first: String, second: String, third: String)
     func updateTradingPairValues(left: String, right: String)
-    func updateTradingPair(pair: TradingPair)
+    func updateTradingPair(pair: TradingPair, fix: Fix)
 }

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -59,12 +59,6 @@ class ExchangeCreateViewController: UIViewController {
         dependenciesSetup()
         delegate?.onViewLoaded()
 
-        // Debug code - will be removed in later PR
-        let demo = Trade.demo()
-        let model = TradingPairView.confirmationModel(for: demo)
-        tradingPairView.apply(model: model)
-        // End debug code
-
         [primaryAmountLabel, primaryDecimalLabel, secondaryAmountLabel].forEach {
             $0?.textColor = UIColor.brandPrimary
         }
@@ -96,7 +90,7 @@ class ExchangeCreateViewController: UIViewController {
         let interactor = ExchangeCreateInteractor(
             dependencies: dependencies,
             model: MarketsModel(
-                pair: TradingPair(from: .bitcoin, to: .ethereum)!,
+                pair: TradingPair(from: .ethereum, to: .bitcoinCash)!,
                 fiatCurrency: "USD",
                 fix: .base,
                 volume: "0")
@@ -137,7 +131,7 @@ extension ExchangeCreateViewController: NumberKeypadViewDelegate {
 }
 
 extension ExchangeCreateViewController: ExchangeCreateInterface {
-    
+
     func ratesViewVisibility(_ visibility: Visibility) {
 
     }
@@ -147,6 +141,35 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
         primaryDecimalLabel.text = primaryDecimal
         decimalLabelSpacingConstraint.constant = primaryDecimal == nil ? 0 : 2
         secondaryAmountLabel.text = secondary
+    }
+
+    func updateTradingPairView(pair: TradingPair) {
+        let fromAsset = pair.from
+        let toAsset = pair.to
+
+        let transitionUpdate = TradingPairView.TradingTransitionUpdate(
+            transitions: [
+                          .images(left: fromAsset.brandImage, right: toAsset.brandImage),
+                          .titles(left: "", right: "")
+            ],
+            transition: .none
+        )
+
+        let presentationUpdate = TradingPairView.TradingPresentationUpdate(
+            animations: [
+                .backgroundColors(left: fromAsset.brandColor, right: toAsset.brandColor),
+                .leftStatusVisibility(.hidden),
+                .rightStatusVisibility(.hidden),
+                .swapTintColor(#colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)),
+                .titleColor(#colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0))
+            ],
+            animation: .none
+        )
+        let model = TradingPairView.Model(
+            transitionUpdate: transitionUpdate,
+            presentationUpdate: presentationUpdate
+        )
+        tradingPairView.apply(model: model)
     }
 
     func updateTradingPairViewValues(left: String, right: String) {

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -90,7 +90,7 @@ class ExchangeCreateViewController: UIViewController {
         let interactor = ExchangeCreateInteractor(
             dependencies: dependencies,
             model: MarketsModel(
-                pair: TradingPair(from: .ethereum, to: .bitcoinCash)!,
+                pair: TradingPair(from: .bitcoin, to: .ethereum)!,
                 fiatCurrency: "USD",
                 fix: .base,
                 volume: "0")

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -143,14 +143,18 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
         secondaryAmountLabel.text = secondary
     }
 
-    func updateTradingPairView(pair: TradingPair) {
+    func updateTradingPairView(pair: TradingPair, fix: Fix) {
         let fromAsset = pair.from
         let toAsset = pair.to
 
+        let isUsingBase = fix == .base || fix == .baseInFiat
+        let leftVisibility: TradingPairView.ViewUpdate = .leftStatusVisibility(isUsingBase ? .visible : .hidden)
+        let rightVisibility: TradingPairView.ViewUpdate = .rightStatusVisibility(isUsingBase ? .hidden : .visible)
+
         let transitionUpdate = TradingPairView.TradingTransitionUpdate(
             transitions: [
-                          .images(left: fromAsset.brandImage, right: toAsset.brandImage),
-                          .titles(left: "", right: "")
+                .images(left: fromAsset.brandImage, right: toAsset.brandImage),
+                .titles(left: "", right: "")
             ],
             transition: .none
         )
@@ -158,10 +162,11 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
         let presentationUpdate = TradingPairView.TradingPresentationUpdate(
             animations: [
                 .backgroundColors(left: fromAsset.brandColor, right: toAsset.brandColor),
-                .leftStatusVisibility(.hidden),
-                .rightStatusVisibility(.hidden),
-                .swapTintColor(#colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)),
-                .titleColor(#colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0))
+                leftVisibility,
+                rightVisibility,
+                .statusTintColor(#colorLiteral(red: 0.01176470588, green: 0.662745098, blue: 0.4470588235, alpha: 1)),
+                .swapTintColor(#colorLiteral(red: 0, green: 0.2901960784, blue: 0.4862745098, alpha: 1)),
+                .titleColor(#colorLiteral(red: 0, green: 0.2901960784, blue: 0.4862745098, alpha: 1))
             ],
             animation: .none
         )

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -11,15 +11,17 @@ import RxSwift
 
 class ExchangeCreateInteractor {
     var disposable: Disposable?
-    weak var output: ExchangeCreateOutput?
+    weak var output: ExchangeCreateOutput? {
+        didSet {
+            didSetModel()
+        }
+    }
     fileprivate let inputs: ExchangeInputsAPI
     fileprivate let markets: ExchangeMarketsAPI
     fileprivate let conversions: ExchangeConversionAPI
     private var model: MarketsModel? {
         didSet {
-            if markets.hasAuthenticated {
-                updateMarketsConversion()
-            }
+            didSetModel()
         }
     }
 
@@ -30,6 +32,15 @@ class ExchangeCreateInteractor {
         self.inputs = dependencies.inputs
         self.conversions = dependencies.conversions
         self.model = model
+    }
+
+    func didSetModel() {
+        if let model = model {
+            output?.updateTradingPair(pair: model.pair)
+        }
+        if markets.hasAuthenticated {
+            updateMarketsConversion()
+        }
     }
 
     deinit {

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -70,7 +70,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     func subscribeToConversions() {
         disposable = markets.conversions.subscribe(onNext: { [weak self] conversion in
             guard let this = self else { return }
-            guard let model = this.model, model.pair.stringRepresentation == conversion.pair else {
+            guard let model = this.model, model.pair.stringRepresentation == conversion.quote.pair else {
                 Logger.shared.error("Pair returned from conversion is different from model pair")
                 return
             }

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -13,7 +13,9 @@ class ExchangeCreateInteractor {
     var disposable: Disposable?
     weak var output: ExchangeCreateOutput? {
         didSet {
-            didSetModel()
+            // output is not set during ExchangeCreateInteractor initialization,
+            // so the first update to the trading pair view is done here
+            didSetModel(oldModel: nil)
         }
     }
     fileprivate let inputs: ExchangeInputsAPI
@@ -21,7 +23,7 @@ class ExchangeCreateInteractor {
     fileprivate let conversions: ExchangeConversionAPI
     private var model: MarketsModel? {
         didSet {
-            didSetModel()
+            didSetModel(oldModel: oldValue)
         }
     }
 
@@ -34,9 +36,14 @@ class ExchangeCreateInteractor {
         self.model = model
     }
 
-    func didSetModel() {
+    func didSetModel(oldModel: MarketsModel?) {
+        // Only update TradingPair in Trading Pair View if it is different
+        // from the old TradingPair
         if let model = model {
-            output?.updateTradingPair(pair: model.pair)
+            if oldModel == nil ||
+               (oldModel != nil && oldModel!.pair != model.pair) {
+                output?.updateTradingPair(pair: model.pair)
+            }
         }
         if markets.hasAuthenticated {
             updateMarketsConversion()
@@ -63,6 +70,10 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     func subscribeToConversions() {
         disposable = markets.conversions.subscribe(onNext: { [weak self] conversion in
             guard let this = self else { return }
+            guard let model = this.model, model.pair.stringRepresentation == conversion.pair else {
+                Logger.shared.error("Pair returned from conversion is different from model pair")
+                return
+            }
 
             // Use conversions service to determine new input/output
             this.conversions.update(with: conversion)
@@ -82,7 +93,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
             // Update input labels
             this.updateOutput()
 
-            // Update trading pair view
+            // Update trading pair view values
             this.updateTradingValues(left: this.conversions.baseOutput, right: this.conversions.counterOutput)
         }, onError: { error in
             Logger.shared.error("Error subscribing to quote with trading pair")

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -42,7 +42,7 @@ class ExchangeCreateInteractor {
         if let model = model {
             if oldModel == nil ||
                (oldModel != nil && oldModel!.pair != model.pair) {
-                output?.updateTradingPair(pair: model.pair)
+                output?.updateTradingPair(pair: model.pair, fix: model.fix)
             }
         }
         if markets.hasAuthenticated {

--- a/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
@@ -44,3 +44,12 @@ extension MarketsModel {
         }
     }
 }
+
+extension MarketsModel: Equatable {
+    static func ==(lhs: MarketsModel, rhs: MarketsModel) -> Bool {
+        return lhs.pair == rhs.pair &&
+            lhs.fiatCurrency == rhs.fiatCurrency &&
+            lhs.fix == rhs.fix &&
+            lhs.volume == rhs.volume
+    }
+}

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -40,6 +40,10 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
 }
 
 extension ExchangeCreatePresenter: ExchangeCreateOutput {
+    func updateTradingPair(pair: TradingPair) {
+        interface?.updateTradingPairView(pair: pair)
+    }
+
     func updatedInput(primary: String?, primaryDecimal: String?, secondary: String?) {
         interface?.updateInputLabels(primary: primary, primaryDecimal: primaryDecimal, secondary: secondary)
     }

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -40,8 +40,8 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
 }
 
 extension ExchangeCreatePresenter: ExchangeCreateOutput {
-    func updateTradingPair(pair: TradingPair) {
-        interface?.updateTradingPairView(pair: pair)
+    func updateTradingPair(pair: TradingPair, fix: Fix) {
+        interface?.updateTradingPairView(pair: pair, fix: fix)
     }
 
     func updatedInput(primary: String?, primaryDecimal: String?, secondary: String?) {

--- a/Blockchain/Homebrew/Exchange/Views/TradingPairView.swift
+++ b/Blockchain/Homebrew/Exchange/Views/TradingPairView.swift
@@ -57,9 +57,7 @@ class TradingPairView: NibBasedView {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        
-        leftButton.layer.cornerRadius = 4.0
-        rightButton.layer.cornerRadius = 4.0
+        configureButtons()
     }
     
     // MARK: Actions
@@ -162,6 +160,19 @@ class TradingPairView: NibBasedView {
             leftButton.setTitle(leftTitle, for: .normal)
             rightButton.setTitle(rightTitle, for: .normal)
         }
+    }
+
+    func configureButtons() {
+        leftButton.layer.cornerRadius = Constants.Measurements.buttonCornerRadius
+        rightButton.layer.cornerRadius = Constants.Measurements.buttonCornerRadius
+
+        let numberOfLines = 1
+        leftButton.titleLabel?.numberOfLines = numberOfLines
+        rightButton.titleLabel?.numberOfLines = numberOfLines
+
+        let edgeInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
+        leftButton.titleEdgeInsets = edgeInsets
+        rightButton.titleEdgeInsets = edgeInsets
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/Views/TradingPairView.xib
+++ b/Blockchain/Homebrew/Exchange/Views/TradingPairView.xib
@@ -67,7 +67,7 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="KVO-Wl-0DT">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KVO-Wl-0DT">
                     <rect key="frame" x="209" y="18" width="166" height="138"/>
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="16"/>
                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="-5" maxY="0.0"/>
@@ -76,7 +76,7 @@
                         <action selector="rightButtonTapped:" destination="-1" eventType="touchUpInside" id="GZZ-xC-Cea"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="GNR-OY-3hz">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GNR-OY-3hz">
                     <rect key="frame" x="0.0" y="18" width="165" height="138"/>
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="16"/>
                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="-5" maxY="0.0"/>


### PR DESCRIPTION
## Objective

Progress PR for TradingPairView and some other improvements - not yet complete, but will save QA some overhead in creating tickets.

## Description

- Added `guard` to ensure that conversion pair matches the model pair before replacing input/output
- Added color for BCH
- Added edge insets for `TradingPairView` buttons
- Limit `TradingPairView` button `titleLabel`s to 1 line
- Truncate `TradingPairView` button `titleLabel`s on longer texts (as opposed to shrinking the font size)

## How to Test

Same as in #485

## Screenshot/Design assessment

Getting closer to design spec but not quite there yet. The `titleEdgeInsets` are not ideal at this point though - if the `left` is too big, the ETH value here is too far to the right, but if it's too small or 0, the BTC value is super close to the BTC icon.
<img width="302" alt="screen shot 2018-09-13 at 1 03 24 pm" src="https://user-images.githubusercontent.com/10579422/45503664-7a7e4980-b755-11e8-87aa-8dd736b84ae7.png">

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)