### PR TITLE
feat(KYC): IOS-1250 Record selected country

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -513,6 +513,8 @@
 		A2913FA21B31830000DC6C15 /* BackupNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2913FA11B31830000DC6C15 /* BackupNavigationViewController.swift */; };
 		AA0A412C214AD75300807163 /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A412B214AD75300807163 /* DebugSettings.swift */; };
 		AA0A412D214ADD5B00807163 /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A412B214AD75300807163 /* DebugSettings.swift */; };
+		AA0A41AB214C83A800807163 /* KYCCountrySelectionInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A41AA214C83A800807163 /* KYCCountrySelectionInteractor.swift */; };
+		AA0A41AC214C83A800807163 /* KYCCountrySelectionInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A41AA214C83A800807163 /* KYCCountrySelectionInteractor.swift */; };
 		AA126CD8212C94CB005886A3 /* NabuCreateUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CD5212C94CB005886A3 /* NabuCreateUserResponse.swift */; };
 		AA126CD9212C94CB005886A3 /* NabuCreateUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CD5212C94CB005886A3 /* NabuCreateUserResponse.swift */; };
 		AA126CDC212C94CB005886A3 /* NabuSessionTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA126CD7212C94CB005886A3 /* NabuSessionTokenResponse.swift */; };
@@ -3049,6 +3051,7 @@
 		A2AADC071B0B999F0085144B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Backup.strings; sourceTree = "<group>"; };
 		A5185A3368C92DCF1134710A /* Pods_BlockchainTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlockchainTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA0A412B214AD75300807163 /* DebugSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettings.swift; sourceTree = "<group>"; };
+		AA0A41AA214C83A800807163 /* KYCCountrySelectionInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCCountrySelectionInteractor.swift; sourceTree = "<group>"; };
 		AA126CD5212C94CB005886A3 /* NabuCreateUserResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NabuCreateUserResponse.swift; sourceTree = "<group>"; };
 		AA126CD7212C94CB005886A3 /* NabuSessionTokenResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NabuSessionTokenResponse.swift; sourceTree = "<group>"; };
 		AA126CDE212C9735005886A3 /* KYCPageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCPageError.swift; sourceTree = "<group>"; };
@@ -4108,6 +4111,7 @@
 			children = (
 				60B10D432118EC84003F945F /* CountryDataProvider.swift */,
 				602B9CB82118E15200BD3D60 /* KYCCountrySelectionController.swift */,
+				AA0A41AA214C83A800807163 /* KYCCountrySelectionInteractor.swift */,
 				AA7133B421220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift */,
 			);
 			path = CountrySelector;
@@ -7788,6 +7792,7 @@
 				3AB4D91A21309BC8004F0160 /* ExchangeListViewController.swift in Sources */,
 				51C9EBB720DBE4A700AB521D /* UIView+SafeAreaFrame.swift in Sources */,
 				AA126D2B212D23FE005886A3 /* KYCUpdateMobileRequest.swift in Sources */,
+				AA0A41AC214C83A800807163 /* KYCCountrySelectionInteractor.swift in Sources */,
 				AAE94F6A20C75C4E005A3595 /* MockPinView.swift in Sources */,
 				AAE94F6820C75B8D005A3595 /* PinPresenterTests.swift in Sources */,
 				51578AEF20B44AD400B0080A /* KeyImportCoordinator.swift in Sources */,
@@ -8284,6 +8289,7 @@
 				3A1552D82135FFDB00683CEB /* Rates.swift in Sources */,
 				230FD2D91C5BF1A700336683 /* BCQRCodeView.m in Sources */,
 				2322321A1B44D4CB00E5DF26 /* UpgradeViewController.m in Sources */,
+				AA0A41AB214C83A800807163 /* KYCCountrySelectionInteractor.swift in Sources */,
 				3A9B7F012135B68100754FD6 /* RatesService.swift in Sources */,
 				9F1831EE151744EB00FB3D52 /* ReceiveTableCell.m in Sources */,
 				C72D6CBF1EC0B4AB0000F922 /* BCFeeSelectionView.m in Sources */,

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -208,7 +208,7 @@ struct ExchangeServices: ExchangeDependencies {
             if viewController != nil {
                 rootViewController = viewController
             }
-            showCreateExchange(animated: animated, type: .homebrew)
+            showCreateExchange(animated: animated, type: .shapeshift)
         }
     }
 

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionInteractor.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionInteractor.swift
@@ -1,0 +1,45 @@
+//
+//  KYCCountrySelectionInteractor.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 9/14/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import RxSwift
+
+class KYCCountrySelectionInteractor {
+
+    private let authenticationService: NabuAuthenticationService
+    private let walletService: WalletService
+
+    init(
+        authenticationService: NabuAuthenticationService = NabuAuthenticationService.shared,
+        walletService: WalletService = WalletService.shared
+    ) {
+        self.authenticationService = authenticationService
+        self.walletService = walletService
+    }
+
+    func selected(country: KYCCountry, shouldBeNotifiedWhenAvailable: Bool? = nil) -> Disposable {
+        let sessionTokenSingle = authenticationService.getSessionToken()
+        let signedRetailToken = walletService.getSignedRetailToken()
+        return Single.zip(sessionTokenSingle, signedRetailToken, resultSelector: {
+            return ($0, $1)
+        }).flatMapCompletable { (sessionToken, signedRetailToken) -> Completable in
+            var payload = [
+                "jwt": signedRetailToken.token ?? "",
+                "countryCode": country.code
+            ]
+            if let notify = shouldBeNotifiedWhenAvailable {
+                payload["notifyWhenAvailable"] = notify.description
+            }
+            let headers = [HttpHeaderField.authorization: sessionToken.token]
+            return KYCNetworkRequest.request(post: .country, parameters: payload, headers: headers)
+        }.subscribe(onCompleted: {
+            Logger.shared.debug("Successfully notified the server of the selected country.")
+        }, onError: { error in
+            Logger.shared.error("Failed to notify the server of the selected country: \(error)")
+        })
+    }
+}

--- a/Blockchain/KYC/Information/KYCInformationViewModel.swift
+++ b/Blockchain/KYC/Information/KYCInformationViewModel.swift
@@ -29,7 +29,7 @@ extension KYCInformationViewModel {
             title: String(format: LocalizationConstants.KYC.unsupportedCountryTitle, country.name),
             subtitle: nil,
             description: String(format: LocalizationConstants.KYC.unsupportedCountryDescription, country.name),
-            buttonTitle: LocalizationConstants.KYC.backToDashboard,
+            buttonTitle: LocalizationConstants.KYC.messageMeWhenAvailable,
             badge: nil
         )
     }

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -57,13 +57,12 @@ protocol KYCCoordinatorDelegate: class {
 
     private let pageFactory = KYCPageViewFactory()
 
-    private var disposable: Disposable?
+    private let disposables = CompositeDisposable()
 
     private override init() { /* Disallow initializing from outside objects */ }
 
     deinit {
-        disposable?.dispose()
-        disposable = nil
+        disposables.dispose()
     }
 
     // MARK: Public
@@ -78,7 +77,7 @@ protocol KYCCoordinatorDelegate: class {
 
     @objc func start(from viewController: UIViewController) {
         LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.loading)
-        disposable = BlockchainDataRepository.shared.fetchNabuUser()
+        let disposable = BlockchainDataRepository.shared.fetchNabuUser()
             .subscribeOn(MainScheduler.asyncInstance)
             .observeOn(MainScheduler.instance)
             .subscribe(onSuccess: { [unowned self] in
@@ -96,6 +95,7 @@ protocol KYCCoordinatorDelegate: class {
                 LoadingViewPresenter.shared.hideBusyView()
                 AlertViewPresenter.shared.standardError(message: LocalizationConstants.Errors.genericError)
             })
+         _ = disposables.insert(disposable)
     }
 
     func finish() {
@@ -194,8 +194,14 @@ protocol KYCCoordinatorDelegate: class {
                 titleColor: UIColor.gray5,
                 isPrimaryButtonEnabled: true
             )
-            informationViewController.primaryButtonAction = { viewController in
+            informationViewController.primaryButtonAction = { [unowned self] viewController in
                 viewController.presentingViewController?.presentingViewController?.dismiss(animated: true)
+                let interactor = KYCCountrySelectionInteractor()
+                let disposables = interactor.selected(
+                    country: country,
+                    shouldBeNotifiedWhenAvailable: true
+                )
+                _ = self.disposables.insert(disposables)
             }
             presentInNavigationController(informationViewController, in: navController)
         }

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -60,6 +60,7 @@ final class KYCNetworkRequest {
 
         enum POST {
             case createUser
+            case country
             case sessionToken(userId: String)
             case verifications
             case submitVerification
@@ -67,6 +68,7 @@ final class KYCNetworkRequest {
             var path: String {
                 switch self {
                 case .createUser: return "/users"
+                case .country: return "/users/current/country"
                 case .sessionToken: return "/auth"
                 case .verifications: return "/verifications"
                 case .submitVerification: return "/kyc/verifications"
@@ -78,6 +80,7 @@ final class KYCNetworkRequest {
                 case .sessionToken(let userId):
                     return ["userId": userId]
                 case .createUser,
+                     .country,
                      .verifications,
                      .submitVerification:
                         return nil

--- a/Blockchain/KYC/Storyboards/KYCInformationController.storyboard
+++ b/Blockchain/KYC/Storyboards/KYCInformationController.storyboard
@@ -28,7 +28,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="okp-Sf-YF7">
-                                <rect key="frame" x="0.0" y="124.5" width="375" height="290"/>
+                                <rect key="frame" x="0.0" y="123" width="375" height="293"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1cf-8E-ugK">
                                         <rect key="frame" x="53.5" y="0.0" width="268" height="134"/>
@@ -84,7 +84,7 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your information is being reviewed. When all looks good, you're clear to Buy, Sell and Transfer on the Exchange." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" minimumFontSize="12" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rfj-zv-olj">
-                                        <rect key="frame" x="16" y="234" width="343" height="56"/>
+                                        <rect key="frame" x="16" y="234" width="343" height="59"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="16"/>
                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -588,9 +588,9 @@ struct LocalizationConstants {
             "Every country has different rules on how to buy and sell cryptocurrencies. Keep your eyes peeled, we’ll let you know as soon as we launch in %@!",
             comment: "Description text displayed when the selected country by the user is not supported for crypto-to-crypto exchange"
         )
-        static let backToDashboard = NSLocalizedString(
-            "Back to Dashboard",
-            comment: "Text displayed on a button when the user wishes to navigate back to the dashboard view."
+        static let messageMeWhenAvailable = NSLocalizedString(
+            "Message Me When Available",
+            comment: "Text displayed on a button when the user wishes to be notified when crypto-to-crypto exchange is available in their country."
         )
         static let yourHomeAddress = NSLocalizedString(
             "Your Home Address",


### PR DESCRIPTION
## Objective

Notifying server of user's country selection. This is needed for: (1) tracking the user's selection which is useful for us to know where drop-off happens, and (2) giving the user the option to have us notify them when exchange is available in their country.

## How to Test

Go through KYC, select a country, and verify that you see the log statement in the console "Successfully notified the server of the selected country.". Also, test that this log statement is also printed when tapping on "Message Me When Available" when the user selects a unsupported country (e.g. "Philippines") 

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
