### PR TITLE
fix(Exchange): show SS exchange if country is supported by shapeshift

### DIFF
--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -157,7 +157,7 @@ struct ExchangeServices: ExchangeDependencies {
                 title: LocalizationConstants.Exchange.navigationTitle
             )
             viewController.present(navigationController!, animated: true)
-        default:
+        case .shapeshift:
             guard let viewController = rootViewController else {
                 Logger.shared.error("View controller to present on is nil")
                 return
@@ -188,8 +188,9 @@ struct ExchangeServices: ExchangeDependencies {
             } else {
                 navigationController?.pushViewController(exchangeCreateViewController, animated: animated)
             }
+        case .shapeshift:
+            showExchange(type: .shapeshift)
         default:
-            // show shapeshift
             Logger.shared.debug("Not yet implemented")
         }
     }

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -191,7 +191,7 @@ struct ExchangeServices: ExchangeDependencies {
         case .shapeshift:
             showExchange(type: .shapeshift)
         default:
-            Logger.shared.debug("Not yet implemented")
+            Logger.shared.warning("showCreateExchange not implemented for ExchangeType")
         }
     }
 


### PR DESCRIPTION
## Objective

Show shapeshift exchange if the user taps on a shapeshift supported country.

## Description

Fixes the issue wherein tapping on a country that is supported by shapeshift in the country selection screen does nothing.

## How to Test

Tap on exchange, go to the country selection screen, tap "United States", verify that you are taken to the old partner/shapeshift exchange flow.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
