### PR TITLE
feat(Exchange): IOS-1195 swap currencies

### DIFF
--- a/Blockchain/Homebrew/Exchange/Views/TradingPairView.swift
+++ b/Blockchain/Homebrew/Exchange/Views/TradingPairView.swift
@@ -173,6 +173,9 @@ class TradingPairView: NibBasedView {
         let edgeInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
         leftButton.titleEdgeInsets = edgeInsets
         rightButton.titleEdgeInsets = edgeInsets
+
+        let swapImage = UIImage(named: "Icon-Exchange")?.withRenderingMode(.alwaysTemplate)
+        swapButton.setImage(swapImage, for: .normal)
     }
 }
 


### PR DESCRIPTION
## Objective

Ability to swap currencies in the exchange create screen

## Description

Functionality was already there but you couldn't see the swap button because it was white on a white background (the tint wasn't being applied). This PR fixes that and now shows the swap button with the  tint color provided in `.swapTintColor` (i.e. the blockchain blue-ish gray color) which matches the color in the design spec.

## How to Test

Go to exchange create view

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
