### PR TITLE
feat(Exchange): IOS-1195 swap fix.

### DIFF
--- a/Blockchain/Homebrew/Exchange/API/ExchangeInputsAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeInputsAPI.swift
@@ -31,7 +31,8 @@ protocol ExchangeInputsAPI: class {
     
     func add(character: String)
     func add(delimiter: String)
-    
+
+    func clear()
     func backspace()
     func toggleInput(withOutput output: String)
 }

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -18,10 +18,10 @@ class ExchangeCreateViewController: UIViewController {
     
     // MARK: Private Static Properties
     
-    static let primaryFontName: String = Constants.FontNames.montserratRegular
+    static let primaryFontName: String = Constants.FontNames.montserratMedium
     static let primaryFontSize: CGFloat = Constants.FontSizes.Huge
-    static let secondaryFontName: String = Constants.FontNames.montserratRegular
-    static let secondaryFontSize: CGFloat = Constants.FontSizes.SmallMedium
+    static let secondaryFontName: String = Constants.FontNames.montserratMedium
+    static let secondaryFontSize: CGFloat = Constants.FontSizes.MediumLarge
 
     // MARK: - IBOutlets
 
@@ -109,9 +109,6 @@ class ExchangeCreateViewController: UIViewController {
 
         tradingPairView.delegate = self
         exchangeButton.layer.cornerRadius = Constants.Measurements.buttonCornerRadius
-
-        setAmountLabelFont(label: primaryAmountLabel, size: Constants.FontSizes.Huge)
-        setAmountLabelFont(label: secondaryAmountLabel, size: Constants.FontSizes.MediumLarge)
     }
 
     fileprivate func dependenciesSetup() {
@@ -147,10 +144,6 @@ extension ExchangeCreateViewController {
         viewToEdit.layer.cornerRadius = 4.0
         viewToEdit.layer.borderWidth = 1.0
         viewToEdit.layer.borderColor = UIColor.brandPrimary.cgColor
-    }
-
-    private func setAmountLabelFont(label: UILabel, size: CGFloat) {
-        label.font = UIFont(name: Constants.FontNames.montserratRegular, size: size)
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/DataProviders/ExchangeInputComponent.swift
+++ b/Blockchain/Homebrew/Exchange/DataProviders/ExchangeInputComponent.swift
@@ -106,4 +106,3 @@ struct ExchangeInputComponents {
         return wholeValue + "." + fractionalValue
     }
 }
-

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -22,7 +22,7 @@ class ExchangeCreateInteractor {
     fileprivate let markets: ExchangeMarketsAPI
     fileprivate let conversions: ExchangeConversionAPI
     fileprivate let tradeExecution: TradeExecutionAPI
-    private var model: MarketsModel? {
+    private(set) var model: MarketsModel? {
         didSet {
             didSetModel(oldModel: oldValue)
         }
@@ -39,18 +39,21 @@ class ExchangeCreateInteractor {
     }
 
     func didSetModel(oldModel: MarketsModel?) {
-        // Only update TradingPair in Trading Pair View if it is different
-        // from the old TradingPair
-        if let model = model {
-            if oldModel == nil ||
-               (oldModel != nil && oldModel!.pair != model.pair) {
-                output?.updateTradingPair(pair: model.pair, fix: model.fix)
-            }
-        }
-
         // TICKET: IOS-1287 - This should be called after user has stopped typing
         if markets.hasAuthenticated {
             updateMarketsConversion()
+        }
+
+        // Only update TradingPair in Trading Pair View if it is different
+        // from the old TradingPair
+        guard let model = model else { return }
+
+        if let oldModel = oldModel {
+            if oldModel.pair != model.pair || oldModel.fix != model.fix {
+                output?.updateTradingPair(pair: model.pair, fix: model.fix)
+            }
+        } else {
+            output?.updateTradingPair(pair: model.pair, fix: model.fix)
         }
     }
 
@@ -169,6 +172,12 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     func useMaximumAmount() {
         
     }
+
+    func toggleFix() {
+        guard let model = model else { return }
+        model.toggleFix()
+        output?.updateTradingPair(pair: model.pair, fix: model.fix)
+    }
     
     func onBackspaceTapped() {
         guard inputs.canBackspace() else {
@@ -225,7 +234,10 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     }
 
     func changeTradingPair(tradingPair: TradingPair) {
-        model?.pair = tradingPair
+        guard let model = model else { return }
+        model.pair = tradingPair
+        updatedInput()
+        output?.updateTradingPair(pair: model.pair, fix: model.fix)
     }
 
     func confirmConversion() {

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -179,7 +179,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         model.toggleFix()
         model.lastConversion = nil
         inputs.clear()
-        conversions.clear()
+        clearConversions()
         updatedInput()
         output?.updateTradingPair(pair: model.pair, fix: model.fix)
     }
@@ -189,10 +189,22 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
             output?.entryRejected()
             return
         }
+
         inputs.backspace()
+
+        // Clear conversions if the user backspaced all the way to 0
+        if !inputs.canBackspace() {
+            clearConversions()
+        }
+
         updatedInput()
     }
-    
+
+    private func clearConversions() {
+        conversions.clear()
+        output?.updateTradingPairValues(left: "", right: "")
+    }
+
     func onAddInputTapped(value: String) {
         guard model != nil else {
             Logger.shared.error("Updating conversion with no model")

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -139,11 +139,12 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         let secondaryAmount = conversions.output.count == 0 ? "0.00": conversions.output
         let secondaryResult = model.isUsingFiat ? (secondaryAmount + " " + suffix) : (symbol + secondaryAmount)
 
-        if model.isUsingFiat == true {
+        if model.isUsingFiat {
             let primary = inputs.primaryFiatAttributedString()
             output.updatedInput(primary: primary, secondary: conversions.output)
         } else {
-            let symbol = model.pair.from.symbol
+            let assetType = model.isUsingBase ? model.pair.from : model.pair.to
+            let symbol = assetType.symbol
             let primary = inputs.primaryAssetAttributedString(symbol: symbol)
             output.updatedInput(primary: primary, secondary: secondaryResult)
         }
@@ -176,6 +177,8 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     func toggleFix() {
         guard let model = model else { return }
         model.toggleFix()
+        inputs.clear()
+        updatedInput()
         output?.updateTradingPair(pair: model.pair, fix: model.fix)
     }
     
@@ -189,7 +192,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     }
     
     func onAddInputTapped(value: String) {
-        guard let _ = model else {
+        guard model != nil else {
             Logger.shared.error("Updating conversion with no model")
             return
         }

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -177,7 +177,9 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     func toggleFix() {
         guard let model = model else { return }
         model.toggleFix()
+        model.lastConversion = nil
         inputs.clear()
+        conversions.clear()
         updatedInput()
         output?.updateTradingPair(pair: model.pair, fix: model.fix)
     }

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -138,7 +138,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         
         let secondaryAmount = conversions.output.count == 0 ? "0.00": conversions.output
         let secondaryResult = model.isUsingFiat ? (secondaryAmount + " " + suffix) : (symbol + secondaryAmount)
-        
+
         if model.isUsingFiat == true {
             let primary = inputs.primaryFiatAttributedString()
             output.updatedInput(primary: primary, secondary: conversions.output)

--- a/Blockchain/Homebrew/Exchange/Models/Fix.swift
+++ b/Blockchain/Homebrew/Exchange/Models/Fix.swift
@@ -16,3 +16,18 @@ enum Fix: String, Codable {
     case counter
     case counterInFiat
 }
+
+extension Fix {
+    func toggledFix() -> Fix {
+        switch self {
+        case .base:
+            return .counter
+        case .baseInFiat:
+            return .counterInFiat
+        case .counter:
+            return .base
+        case .counterInFiat:
+            return .baseInFiat
+        }
+    }
+}

--- a/Blockchain/Homebrew/Exchange/Models/InputComponent.swift
+++ b/Blockchain/Homebrew/Exchange/Models/InputComponent.swift
@@ -108,7 +108,7 @@ extension Array where Element == InputComponent {
         return count > 1
     }
     
-    func drop() -> Array<Element> {
+    func drop() -> [Element] {
         if count > 1 {
             return Array(dropLast())
         }

--- a/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
@@ -44,6 +44,10 @@ extension MarketsModel {
             fix = .counter
         }
     }
+
+    func toggleFix() {
+        fix = fix.toggledFix()
+    }
 }
 
 extension MarketsModel: Equatable {

--- a/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
@@ -32,6 +32,10 @@ extension MarketsModel {
         return fix == .baseInFiat || fix == .counterInFiat
     }
 
+    var isUsingBase: Bool {
+        return fix == .base || fix == .baseInFiat
+    }
+
     func toggleFiatInput() {
         switch fix {
         case .base:

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 class ExchangeCreatePresenter {
-    fileprivate let interactor: ExchangeCreateInput
+    fileprivate let interactor: ExchangeCreateInteractor
     weak var interface: ExchangeCreateInterface?
 
-    init(interactor: ExchangeCreateInput) {
+    init(interactor: ExchangeCreateInteractor) {
         self.interactor = interactor
     }
 }
@@ -33,9 +33,13 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
     func onBackspaceTapped() {
         interactor.onBackspaceTapped()
     }
-    
-    func onContinueButtonTapped() {
-        
+
+    func changeTradingPair(tradingPair: TradingPair) {
+        interactor.changeTradingPair(tradingPair: tradingPair)
+    }
+
+    func onToggleFixTapped() {
+        interactor.toggleFix()
     }
 
     func onDisplayInputTypeTapped() {
@@ -44,10 +48,6 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
 
     func onExchangeButtonTapped() {
         interactor.confirmConversion()
-    }
-
-    func onTradingPairChanged(tradingPair: TradingPair) {
-        interactor.changeTradingPair(tradingPair: tradingPair)
     }
 
     func confirmConversion() {

--- a/Blockchain/Homebrew/Exchange/Services/ExchangeConversionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/ExchangeConversionService.swift
@@ -27,6 +27,9 @@ protocol ExchangeConversionAPI {
     // Method used to remove trailing zeros and decimals for true value comparison
     // Primariy used to allow the user to keep typing uninterrupted
     func removeInsignificantCharacters(input: String) -> String
+
+    /// Clears the conversion values
+    func clear()
 }
 
 class ExchangeConversionService: ExchangeConversionAPI {
@@ -34,6 +37,13 @@ class ExchangeConversionService: ExchangeConversionAPI {
     private(set) var output: String = "0"
     private(set) var baseOutput: String = ""
     private(set) var counterOutput: String = ""
+
+    func clear() {
+        input = "0"
+        output = "0"
+        baseOutput = ""
+        counterOutput = ""
+    }
 
     func update(with conversion: Conversion) {
         let quote = conversion.quote

--- a/Blockchain/Homebrew/Exchange/Services/ExchangeInputsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/ExchangeInputsService.swift
@@ -18,9 +18,7 @@ class ExchangeInputsService: ExchangeInputsAPI {
     }
     
     var activeInput: String {
-        get {
-            return inputComponents.numericalString
-        }
+        return inputComponents.numericalString
     }
     
     var inputComponents: ExchangeInputComponents
@@ -141,5 +139,11 @@ class ExchangeInputsService: ExchangeInputsAPI {
     
     func toggleInput(withOutput output: String) {
         inputComponents.convertComponents(with: output)
+    }
+
+    func clear() {
+        while canBackspace() {
+            backspace()
+        }
     }
 }


### PR DESCRIPTION
## Objective

Fixing behavior of tapping on the swap button in `TradingPairView` to toggle the `Fix` value, and not the trading pairs.

## Description

**Primary Changes:**
* Added the appropriate methods in `MarketsModel`, `ExchangeCreatePresenter` and `ExchangeCreateInteractor` to toggle the Fix.

**Related Changes:**
* refactored the way the trading pairs are selected and refreshed in the views so that it propagates from the view controller, to the presenter, to the interactor, and back.

**Other notes:**
I noticed a few bugs and architecture issues that I didn't address to avoid blowing up the scope but wanted to call out. Namely:

(1) The didSet property observer method in `ExchangeCreateInteractor` for the property `model` might not be working as intended. Specifically, this block of code:

```
private(set) var model: MarketsModel? {
        didSet {
            didSetModel(oldModel: oldValue)
        }
    }
```

The didSet method will only be invoked _if the property itself was changed_. So, if somewhere within `ExchangeCreateInteractor` a method did something like:

```
func foo() {
    model = MarketsModel()
}
```

...only then would the `didSetModel` be invoked. However, if you changed a property within model, such as:

```
func foo() {
    model.property = Property1()
}
```

...`didSet` won't be invoked. 

But there is an exception: If `MarketsModel` was a struct then `didSet` would actually be invoked. The reason this exception happens is because structs are _value types_, which is different from classes which are _referenced types_. This means that changing a property within a struct will actually create a new struct, whereas with classes, changing a property won't create a whole new class, only the property is changed.

(2) The `ExchangeCreateInteractor` has a few oddities which I think break the interactor pattern and make using it a bit confusing. The interactor is supposed to be independent of any UI. All it should do is provide methods that perform CRUD operations to the underlying entities/models. At the moment, this isn't the case and has some verbs like "show", "tapped", it also uses `AlertViewPresenter`, etc. Instead, it seems like it's also taking the role of the presenter which is ultimately the component in charge of taking actions like that. This isn't really a big issue but thought I'd bring up to help think about this pattern (need a reminder for myself, too).

## How to Test

Launch exchange and toggle.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
