### PR TITLE
 feat(Homebrew-Exchange): IOS-1295 update confirm screen with conversion socket message info.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -778,6 +778,7 @@
 		C7343BC4214FF8B1001B1EC9 /* ExchangeDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7343BC3214FF8B1001B1EC9 /* ExchangeDetailPresenter.swift */; };
 		C7343BCF214FF93A001B1EC9 /* ExchangeDetailInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7343BCE214FF93A001B1EC9 /* ExchangeDetailInteractor.swift */; };
 		C7343BD1214FF9D0001B1EC9 /* ExchangeDetailContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7343BD0214FF9D0001B1EC9 /* ExchangeDetailContracts.swift */; };
+		C7343BD8215003E6001B1EC9 /* ExchangeDetailContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7343BD0214FF9D0001B1EC9 /* ExchangeDetailContracts.swift */; };
 		C740FA89210BAF740060292F /* WalletExchangeIntermediateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C740FA88210BAF740060292F /* WalletExchangeIntermediateDelegate.swift */; };
 		C740FA8A210BAF740060292F /* WalletExchangeIntermediateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C740FA88210BAF740060292F /* WalletExchangeIntermediateDelegate.swift */; };
 		C7414E451FD7131C001A89FA /* ConfirmStateViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C7414E441FD7131C001A89FA /* ConfirmStateViewController.m */; };
@@ -7850,6 +7851,7 @@
 				602B9D0C2118E23400BD3D60 /* KYCCoordinator.swift in Sources */,
 				AA7133B8212221D400CB2AA9 /* KYCVerifyPhoneNumberPresenterTests.swift in Sources */,
 				3A91F7E221387A5300CDC3FD /* AnimatablePresentationUpdate.swift in Sources */,
+				C7343BD8215003E6001B1EC9 /* ExchangeDetailContracts.swift in Sources */,
 				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
 				C76143AC211A80D30041411E /* Codable+Coding.swift in Sources */,
 				AA748359211129DF008F2768 /* MockKYCEnterPhoneNumberView.swift in Sources */,

--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -779,6 +779,8 @@
 		C7343BCF214FF93A001B1EC9 /* ExchangeDetailInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7343BCE214FF93A001B1EC9 /* ExchangeDetailInteractor.swift */; };
 		C7343BD1214FF9D0001B1EC9 /* ExchangeDetailContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7343BD0214FF9D0001B1EC9 /* ExchangeDetailContracts.swift */; };
 		C7343BD8215003E6001B1EC9 /* ExchangeDetailContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7343BD0214FF9D0001B1EC9 /* ExchangeDetailContracts.swift */; };
+		C7343C1821516A64001B1EC9 /* ExchangeDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7343BC3214FF8B1001B1EC9 /* ExchangeDetailPresenter.swift */; };
+		C7343C2221516A6F001B1EC9 /* ExchangeDetailInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7343BCE214FF93A001B1EC9 /* ExchangeDetailInteractor.swift */; };
 		C740FA89210BAF740060292F /* WalletExchangeIntermediateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C740FA88210BAF740060292F /* WalletExchangeIntermediateDelegate.swift */; };
 		C740FA8A210BAF740060292F /* WalletExchangeIntermediateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C740FA88210BAF740060292F /* WalletExchangeIntermediateDelegate.swift */; };
 		C7414E451FD7131C001A89FA /* ConfirmStateViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C7414E441FD7131C001A89FA /* ConfirmStateViewController.m */; };
@@ -7732,6 +7734,7 @@
 				AA126DA6212E2C3B005886A3 /* OnfidoCredentials.swift in Sources */,
 				AA7133B621220B7100CB2AA9 /* KYCCountrySelectionPresenter.swift in Sources */,
 				AAFA97AF2115110000D19ED3 /* SettingsTwoStepVC.swift in Sources */,
+				C7343C2221516A6F001B1EC9 /* ExchangeDetailInteractor.swift in Sources */,
 				3A4EABA52140826800081531 /* PlainCell.swift in Sources */,
 				AAA6648B2123426A009C1C64 /* PrimaryButtonContainer.swift in Sources */,
 				51135703209CF5D000056D65 /* AuthenticationTwoFactorType.swift in Sources */,
@@ -7916,6 +7919,7 @@
 				602B9D0D2118E23800BD3D60 /* KYCOnboardingNavigationController.swift in Sources */,
 				AA0A4158214B3A3700807163 /* AssetAccountRepository.swift in Sources */,
 				3A53B950213466580020ECAD /* ExchangeListHeaderView.swift in Sources */,
+				C7343C1821516A64001B1EC9 /* ExchangeDetailPresenter.swift in Sources */,
 				5114EA2420CD8B900098E26E /* UINavigationBar+TitleAttributes.swift in Sources */,
 				AA3CA9B02107F18D00C2AD46 /* Logger.swift in Sources */,
 				3A9B7F122135CF9800754FD6 /* NetworkRequest.swift in Sources */,

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -206,7 +206,7 @@ struct ExchangeServices: ExchangeDependencies {
     }
 
     private func showTradeDetails(trade: ExchangeTradeCellModel) {
-        let detailViewController = ExchangeDetailViewController.make(with: .overview(trade))
+        let detailViewController = ExchangeDetailViewController.make(with: .overview(trade), dependencies: dependencies)
         navigationController?.pushViewController(detailViewController, animated: true)
     }
 

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -200,8 +200,8 @@ struct ExchangeServices: ExchangeDependencies {
             Logger.shared.error("No navigation controller found")
             return
         }
-        let model = ExchangeDetailViewController.PageModel.confirm(orderTransaction, conversion, dependencies.tradeExecution)
-        let confirmController = ExchangeDetailViewController.make(with: model)
+        let model = ExchangeDetailViewController.PageModel.confirm(orderTransaction, conversion)
+        let confirmController = ExchangeDetailViewController.make(with: model, dependencies: dependencies)
         navigationController.pushViewController(confirmController, animated: true)
     }
 

--- a/Blockchain/Homebrew/Exchange/API/ExchangeDetailContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeDetailContracts.swift
@@ -13,6 +13,8 @@ protocol ExchangeDetailInterface: class {
     func navigationBarVisibility(_ visibility: Visibility)
     func updateTitle(_ value: String)
     func loadingVisibility(_ visibility: Visibility, action: ExchangeDetailCoordinator.Action)
+    func updateConfirmDetails(conversion: Conversion)
+    var mostRecentOrderTransaction: OrderTransaction? { set get }
 }
 
 protocol ExchangeDetailInput: class {
@@ -21,6 +23,6 @@ protocol ExchangeDetailInput: class {
 }
 
 protocol ExchangeDetailOutput: class {
-    func conversionReceived()
+    func received(conversion: Conversion)
     func orderSent()
 }

--- a/Blockchain/Homebrew/Exchange/API/ExchangeDetailContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeDetailContracts.swift
@@ -14,7 +14,16 @@ protocol ExchangeDetailInterface: class {
     func updateTitle(_ value: String)
     func loadingVisibility(_ visibility: Visibility, action: ExchangeDetailCoordinator.Action)
     func updateConfirmDetails(conversion: Conversion)
-    var mostRecentOrderTransaction: OrderTransaction? { set get }
+
+    // When live updates are being received, the ExchangeDetailCoordinator
+    // fully reloads each collection view with new cells and doesn't have
+    // a reference to the existing ones, so the most recent order
+    // transaction must be saved to repopulate the fee field.
+    var mostRecentOrderTransaction: OrderTransaction? { get set }
+
+    // Live updates are still being received from the conversion socket,
+    // so the last conversion should be used to create the transaction
+    var mostRecentConversion: Conversion? { get set }
 }
 
 protocol ExchangeDetailInput: class {

--- a/Blockchain/Homebrew/Exchange/API/TradeExecutionAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/TradeExecutionAPI.swift
@@ -10,6 +10,13 @@ import Foundation
 
 protocol TradeExecutionAPI {
     func getTradeLimits(withCompletion: @escaping ((Result<TradeLimits>) -> Void))
+
+    // Build a transaction
     func submitOrder(with conversion: Conversion, success: @escaping ((OrderTransaction, Conversion) -> Void), error: @escaping ((String) -> Void))
+
+    // Send the transaction that was last built
     func sendTransaction(assetType: AssetType, success: @escaping (() -> Void), error: @escaping ((String) -> Void))
+
+    // Build a transaction and send it
+    func submitAndSend(with conversion: Conversion, success: @escaping (() -> Void), error: @escaping ((String) -> Void))
 }

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -17,39 +17,61 @@ protocol ExchangeDetailDelegate: class {
 /// `Exchange Locked`, and `Trade Overview` screen. It contains
 /// a `UICollectionView`.
 class ExchangeDetailViewController: UIViewController {
-    
+
     enum PageModel {
-        case confirm(OrderTransaction, Conversion, TradeExecutionAPI)
+        case confirm(OrderTransaction, Conversion)
         case locked(Trade)
         case overview(ExchangeTradeCellModel)
     }
-    
-    static func make(with model: PageModel) -> ExchangeDetailViewController {
+
+    static func make(with model: PageModel, dependencies: ExchangeDependencies) -> ExchangeDetailViewController {
         let controller = ExchangeDetailViewController.makeFromStoryboard()
         controller.model = model
+        controller.dependencies = dependencies
         return controller
     }
-    
+
+    // MARK: Public Properties
+
+    weak var delegate: ExchangeDetailDelegate?
+    var mostRecentOrderTransaction: OrderTransaction?
+
     // MARK: Private IBOutlets
-    
+
     @IBOutlet fileprivate var collectionView: UICollectionView!
     @IBOutlet fileprivate var layout: UICollectionViewFlowLayout!
-    
+
     // MARK: Private Properties
-    
+
     fileprivate var layoutAttributes: LayoutAttributes!
     fileprivate var model: PageModel!
     fileprivate var cellModels: [ExchangeCellModel]?
     fileprivate var reuseIdentifiers: Set<String> = []
     fileprivate var coordinator: ExchangeDetailCoordinator!
-    
+    fileprivate var presenter: ExchangeDetailPresenter!
+    fileprivate var dependencies: ExchangeDependencies!
+
     // MARK: Lifecycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        coordinator = ExchangeDetailCoordinator(delegate: self, interface: self)
+        coordinator = ExchangeDetailCoordinator(
+            delegate: self,
+            interface: self,
+            dependencies: dependencies
+        )
+        dependenciesSetup()
         setupLayout()
         coordinator.handle(event: .pageLoaded(model))
+        delegate?.onViewLoaded()
+    }
+
+    fileprivate func dependenciesSetup() {
+        let interactor = ExchangeDetailInteractor(dependencies: dependencies)
+        presenter = ExchangeDetailPresenter(interactor: interactor)
+        presenter.interface = self
+        interactor.output = presenter
+        delegate = presenter
     }
     
     fileprivate func setupLayout() {
@@ -149,7 +171,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
         let height = model.heightForProposed(width: width)
         return CGSize(width: width, height: height)
     }
-    
+
     func collectionView(
         _ collectionView: UICollectionView,
         viewForSupplementaryElementOfKind
@@ -158,7 +180,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
     ) -> UICollectionReusableView {
         guard let page = model else { return UICollectionReusableView() }
         switch page {
-        case .confirm(let orderTransaction, let conversion, let tradeExecutionAPI):
+        case .confirm(let orderTransaction, let conversion):
             guard kind == UICollectionElementKindSectionFooter else { return UICollectionReusableView() }
             
             guard let footer = collectionView.dequeueReusableSupplementaryView(
@@ -168,7 +190,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 ) as? ActionableFooterView else { return UICollectionReusableView() }
             footer.title = LocalizationConstants.Exchange.sendNow
             footer.actionBlock = {
-                self.coordinator.handle(event: .confirmExchange(orderTransaction, conversion, tradeExecutionAPI))
+                self.coordinator.handle(event: .confirmExchange(orderTransaction, conversion))
             }
 
             return footer
@@ -262,6 +284,14 @@ extension ExchangeDetailViewController: ExchangeDetailCoordinatorDelegate {
 }
 
 extension ExchangeDetailViewController: ExchangeDetailInterface {
+    func updateConfirmDetails(conversion: Conversion) {
+        guard let orderTransaction = self.mostRecentOrderTransaction else {
+            Logger.shared.error("Missing order transaction - should have been stored after onLoaded ExchangeDetailCoordinator event")
+            return
+        }
+        coordinator.handle(event: .updateConfirmDetails(orderTransaction, conversion))
+    }
+
     func navigationBarVisibility(_ visibility: Visibility) {
         guard let navController = navigationController else { return }
         navController.setNavigationBarHidden(visibility.isHidden, animated: false)

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -35,6 +35,7 @@ class ExchangeDetailViewController: UIViewController {
 
     weak var delegate: ExchangeDetailDelegate?
     var mostRecentOrderTransaction: OrderTransaction?
+    var mostRecentConversion: Conversion?
 
     // MARK: Private IBOutlets
 
@@ -190,7 +191,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 ) as? ActionableFooterView else { return UICollectionReusableView() }
             footer.title = LocalizationConstants.Exchange.sendNow
             footer.actionBlock = {
-                self.coordinator.handle(event: .confirmExchange(orderTransaction, conversion))
+                self.coordinator.handle(event: .confirmExchange)
             }
 
             return footer

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -16,7 +16,8 @@ class ExchangeDetailCoordinator: NSObject {
     
     enum Event {
         case pageLoaded(ExchangeDetailViewController.PageModel)
-        case confirmExchange(OrderTransaction, Conversion, TradeExecutionAPI)
+        case confirmExchange(OrderTransaction, Conversion)
+        case updateConfirmDetails(OrderTransaction, Conversion)
     }
 
     enum Action {
@@ -26,19 +27,24 @@ class ExchangeDetailCoordinator: NSObject {
 
     fileprivate weak var delegate: ExchangeDetailCoordinatorDelegate?
     fileprivate weak var interface: ExchangeDetailInterface?
+    let tradeExecution: TradeExecutionAPI
     
     init(
         delegate: ExchangeDetailCoordinatorDelegate,
-        interface: ExchangeDetailInterface
-        ) {
+        interface: ExchangeDetailInterface,
+        dependencies: ExchangeDependencies
+    ) {
         self.delegate = delegate
         self.interface = interface
+        self.tradeExecution = dependencies.tradeExecution
         super.init()
     }
 
 // swiftlint:disable function_body_length
     func handle(event: Event) {
         switch event {
+        case .updateConfirmDetails(let orderTransaction, let conversion):
+            handle(event: .pageLoaded(.confirm(orderTransaction, conversion)))
         case .pageLoaded(let model):
             
             // TODO: These are placeholder `ViewModels`
@@ -49,7 +55,7 @@ class ExchangeDetailCoordinator: NSObject {
             var cellModels: [ExchangeCellModel] = []
             
             switch model {
-            case .confirm(let orderTransaction, let conversion, _):
+            case .confirm(let orderTransaction, let conversion):
                 
                 interface?.updateBackgroundColor(#colorLiteral(red: 0.89, green: 0.95, blue: 0.97, alpha: 1))
                 interface?.updateTitle("Confirm Exchange")
@@ -106,7 +112,9 @@ class ExchangeDetailCoordinator: NSObject {
                     .text(text)
                     ]
                 )
-                
+
+                interface?.mostRecentOrderTransaction = orderTransaction
+
                 delegate?.coordinator(self, updated: cellModels)
             case .locked(let trade):
                 interface?.updateBackgroundColor(.brandPrimary)
@@ -220,8 +228,8 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 delegate?.coordinator(self, updated: cellModels)
             }
-        case .confirmExchange(let orderTransaction, _, let tradeExecutionAPI):
-            tradeExecutionAPI.sendTransaction(assetType: orderTransaction.to.assetType, success: {
+        case .confirmExchange(let orderTransaction, _):
+            tradeExecution.sendTransaction(assetType: orderTransaction.to.assetType, success: {
                 ExchangeCoordinator.shared.handle(event: .sentTransaction)
             }) { error in
                 AlertViewPresenter.shared.standardError(message: error)

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeDetailInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeDetailInteractor.swift
@@ -15,6 +15,8 @@ class ExchangeDetailInteractor {
     fileprivate let conversions: ExchangeConversionAPI
     fileprivate let tradeExecution: TradeExecutionAPI
 
+    weak var output: ExchangeDetailOutput?
+
     init(dependencies: ExchangeDependencies) {
         self.markets = dependencies.markets
         self.conversions = dependencies.conversions
@@ -29,7 +31,10 @@ class ExchangeDetailInteractor {
 
 extension ExchangeDetailInteractor: ExchangeDetailInput {
     func viewLoaded() {
-
+        disposable = markets.conversions.subscribe(onNext: { [weak self] conversion in
+            guard let this = self else { return }
+            this.output?.received(conversion: conversion)
+        })
     }
 
     func sendOrderTapped() {

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeDetailPresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeDetailPresenter.swift
@@ -19,10 +19,21 @@ class ExchangeDetailPresenter {
 
 extension ExchangeDetailPresenter: ExchangeDetailDelegate {
     func onViewLoaded() {
-
+        interactor.viewLoaded()
     }
     
     func onSendOrderTapped() {
+        interactor.sendOrderTapped()
+    }
+}
+
+extension ExchangeDetailPresenter: ExchangeDetailOutput {
+    func received(conversion: Conversion) {
+        let model = TradingPairView.confirmationModel(for: conversion)
+        interface?.updateConfirmDetails(conversion: conversion)
+    }
+
+    func orderSent() {
 
     }
 }

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -129,6 +129,16 @@ class TradeExecutionService: TradeExecutionAPI {
         wallet.sendOrderTransaction(assetType.legacy, success: success, error: error)
     }
 
+    func submitAndSend(
+        with conversion: Conversion,
+        success: @escaping (() -> Void),
+        error: @escaping ((String) -> Void)
+    ) {
+        submitOrder(with: conversion, success: { [weak self] orderTransaction, conversion in
+            guard let this = self else { return }
+            this.sendTransaction(assetType: orderTransaction.to.assetType, success: success, error: error)
+        }, error: error)
+    }
     // MARK: Private
     
     fileprivate func process(order: Order) -> Single<OrderResult> {


### PR DESCRIPTION
## Objective

Add live updates to the confirm screen.

## Description

On `dev` the `Conversion` currently only live updates on the `ExchangeCreateViewController`. Live updates also need to happen on the confirm exchange screen. Because the `Conversion` is always changing, the transaction is being rebuilt when tapping `Send Now` and sent immediately after.

In this PR, a new transaction will NOT be built with each `Conversion` message arriving.

## How to Test

Run exchange (mocking a deposit/deposit address if possible), create an exchange, then hit send now - the navigation controller should pop to the root view controller and the transaction should be shown as sent in the home transaction screen.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
