### PR TITLE
fix(Homebrew-Exchange): IOS-1209 change 'Fees' to 'Estimated fees' and localiz…

### DIFF
--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -59,25 +59,25 @@ class ExchangeDetailCoordinator: NSObject {
                 )
                 
                 let value = ExchangeCellModel.Plain(
-                    description: "Value",
+                    description: LocalizationConstants.Exchange.value,
                     value: "$" + ((conversion.quote.fix == .base || conversion.quote.fix == .baseInFiat) ?
                         conversion.quote.currencyRatio.base.fiat.value :
                         conversion.quote.currencyRatio.counter.fiat.value)
                 )
                 
                 let fees = ExchangeCellModel.Plain(
-                    description: "Fees",
+                    description: LocalizationConstants.Exchange.estimatedFees,
                     value: orderTransaction.fees + " " + orderTransaction.from.address.assetType.symbol
                 )
                 
                 let receive = ExchangeCellModel.Plain(
-                    description: "Receive",
+                    description: LocalizationConstants.Exchange.receive,
                     value: orderTransaction.amountToReceive + " " + TradingPair(string: conversion.quote.pair)!.to.symbol,
                     bold: true
                 )
                 
                 let sendTo = ExchangeCellModel.Plain(
-                    description: "Send to",
+                    description: LocalizationConstants.Exchange.sendTo,
                     value: "My Wallet"
                 )
                 

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -60,9 +60,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let value = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.value,
-                    value: "$" + ((conversion.quote.fix == .base || conversion.quote.fix == .baseInFiat) ?
-                        conversion.quote.currencyRatio.base.fiat.value :
-                        conversion.quote.currencyRatio.counter.fiat.value)
+                    value: "$" + conversion.quote.currencyRatio.counter.fiat.value
                 )
                 
                 let fees = ExchangeCellModel.Plain(

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -367,6 +367,18 @@ struct LocalizationConstants {
             "Exchange %@ for %@",
             comment: "Text displayed on the primary action button for the exchange screen when exchanging between 2 assets."
         )
+        static let receive = NSLocalizedString(
+            "Receive",
+            comment: "Text displayed when reviewing the amount to be received for an exchange order")
+        static let estimatedFees = NSLocalizedString(
+            "Estimated fees",
+            comment: "Text displayed when reviewing the estimated amount of fees to pay for an exchange order")
+        static let value = NSLocalizedString(
+            "Value",
+            comment: "Text displayed when reviewing the fiat value of an exchange order")
+        static let sendTo = NSLocalizedString(
+            "Send to",
+            comment: "Text displayed when reviewing where the result of an exchange order will be sent to")
         static let whatDoYouWantToExchange = NSLocalizedString(
             "What do you want to exchange?",
             comment: "Text displayed on the action sheet that is presented when the user is selecting an account to exchange from."


### PR DESCRIPTION
…e other strings

## Objective

To minimize the frequency of building a transaction (i.e., to minimize the number of calls to `/unspents` which can be expensive), the app will not update the fees each time a `Conversion` socket message is received. The decision was made to rename "Fees" to "Estimated fees".

## Description

Added localized strings for "Send to", "Estimated fees", "Receive", and "Value". Also updated value to reflect the amount to be received.

## How to Test

Go to confirm exchange screen.

## Screenshot/Design assessment

<img width="298" alt="screen shot 2018-09-19 at 9 49 04 am" src="https://user-images.githubusercontent.com/10579422/45758230-23fc8980-bbf3-11e8-8dd9-d35dd7a2102d.png">

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [ ] All unit tests pass. (Fixed in #507)
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
