### PR TITLE
 feat(Exchange): IOS-1199 set use min/max text in create view.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -618,6 +618,10 @@
 		AA63F87820A39DCF002B719B /* AppFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87620A39DCF002B719B /* AppFeature.swift */; };
 		AA63F87A20A3A198002B719B /* AppFeatureConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87920A3A198002B719B /* AppFeatureConfigurator.swift */; };
 		AA63F87B20A3A198002B719B /* AppFeatureConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA63F87920A3A198002B719B /* AppFeatureConfigurator.swift */; };
+		AA68F42F2151A9CE0099BB83 /* TradeLimitsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA68F42E2151A9CD0099BB83 /* TradeLimitsAPI.swift */; };
+		AA68F4302151A9CE0099BB83 /* TradeLimitsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA68F42E2151A9CD0099BB83 /* TradeLimitsAPI.swift */; };
+		AA68F43B2151AA1F0099BB83 /* TradeLimitsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA68F43A2151AA1F0099BB83 /* TradeLimitsService.swift */; };
+		AA68F43C2151AA1F0099BB83 /* TradeLimitsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA68F43A2151AA1F0099BB83 /* TradeLimitsService.swift */; };
 		AA69118420D0967300DDB541 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69118320D0967300DDB541 /* NetworkError.swift */; };
 		AA69118520D0967300DDB541 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69118320D0967300DDB541 /* NetworkError.swift */; };
 		AA6911A120D18B6E00DDB541 /* MockWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6911A020D18B6E00DDB541 /* MockWalletService.swift */; };
@@ -3130,6 +3134,8 @@
 		AA63F87320A39D8D002B719B /* AppFeatureConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureConfiguration.swift; sourceTree = "<group>"; };
 		AA63F87620A39DCF002B719B /* AppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeature.swift; sourceTree = "<group>"; };
 		AA63F87920A3A198002B719B /* AppFeatureConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureConfigurator.swift; sourceTree = "<group>"; };
+		AA68F42E2151A9CD0099BB83 /* TradeLimitsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeLimitsAPI.swift; sourceTree = "<group>"; };
+		AA68F43A2151AA1F0099BB83 /* TradeLimitsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeLimitsService.swift; sourceTree = "<group>"; };
 		AA69118320D0967300DDB541 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		AA6911A020D18B6E00DDB541 /* MockWalletService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWalletService.swift; sourceTree = "<group>"; };
 		AA69F6582086A2720054EFCE /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -3526,18 +3532,18 @@
 		3A26AF6721274EEA003A8A08 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				C7FF10E92141AAB300CBA3CB /* MarketsModel.swift */,
-				C7FF10DE2141A89500CBA3CB /* Fix.swift */,
-				C7FF110E2141E24000CBA3CB /* InputsState.swift */,
-				3A26D5172140404100D79BDD /* CellModels */,
-				C7C0DC05212F6594000EFE71 /* TradingPair.swift */,
-				3A1552D72135FFDB00683CEB /* Rates.swift */,
-				3A1552E6213600B400683CEB /* TradingPairConfiguration.swift */,
-				3A1552EC2136EAF000683CEB /* TradeLimits.swift */,
-				3A91F7952137067400CDC3FD /* Order.swift */,
-				3ABB80BA213F0CD300AD57BE /* Limit.swift */,
-				3ADFE6F8214AE0E300E7E2D5 /* InputComponent.swift */,
 				3ADFE6FE214AE1E100E7E2D5 /* ExchangeStyleTemplate.swift */,
+				C7FF10DE2141A89500CBA3CB /* Fix.swift */,
+				3ADFE6F8214AE0E300E7E2D5 /* InputComponent.swift */,
+				C7FF110E2141E24000CBA3CB /* InputsState.swift */,
+				3ABB80BA213F0CD300AD57BE /* Limit.swift */,
+				C7FF10E92141AAB300CBA3CB /* MarketsModel.swift */,
+				3A91F7952137067400CDC3FD /* Order.swift */,
+				3A1552D72135FFDB00683CEB /* Rates.swift */,
+				3A1552EC2136EAF000683CEB /* TradeLimits.swift */,
+				C7C0DC05212F6594000EFE71 /* TradingPair.swift */,
+				3A1552E6213600B400683CEB /* TradingPairConfiguration.swift */,
+				3A26D5172140404100D79BDD /* CellModels */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3558,13 +3564,14 @@
 		3A26AF78212B0CB6003A8A08 /* API */ = {
 			isa = PBXGroup;
 			children = (
+				C7CE25A92135E3B500DCC43B /* ExchangeCreateContracts.swift */,
 				C7343BD0214FF9D0001B1EC9 /* ExchangeDetailContracts.swift */,
 				C72AC7012134A90B001DA48B /* ExchangeInputsAPI.swift */,
-				C7CE25A92135E3B500DCC43B /* ExchangeCreateContracts.swift */,
-				3A26AF79212B0CCB003A8A08 /* PartnerExchangeAPI.swift */,
 				3AB4D901212F4A0E004F0160 /* ExchangeListContracts.swift */,
+				3A26AF79212B0CCB003A8A08 /* PartnerExchangeAPI.swift */,
 				3A1552E32136000F00683CEB /* RatesAPI.swift */,
 				3A1552EF2136FFE200683CEB /* TradeExecutionAPI.swift */,
+				AA68F42E2151A9CD0099BB83 /* TradeLimitsAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -3573,13 +3580,14 @@
 			isa = PBXGroup;
 			children = (
 				C75817B52146FC5F00AA6A04 /* ExchangeConversionService.swift */,
+				3ADFE6FB214AE17600E7E2D5 /* ExchangeInputsService.swift */,
+				3A26AFA3212C9F88003A8A08 /* ExchangeService.swift */,
+				3A26AF9E212B51C0003A8A08 /* HomebrewExchangeService.swift */,
 				C7FA9B58212F499D00B98EBF /* MarketsService.swift */,
 				3A26AF7C212B13FA003A8A08 /* PartnerExchangeService.swift */,
-				3A26AF9E212B51C0003A8A08 /* HomebrewExchangeService.swift */,
-				3A26AFA3212C9F88003A8A08 /* ExchangeService.swift */,
 				3A9B7F002135B68100754FD6 /* RatesService.swift */,
 				3A1552E92136EA8D00683CEB /* TradeExecutionService.swift */,
-				3ADFE6FB214AE17600E7E2D5 /* ExchangeInputsService.swift */,
+				AA68F43A2151AA1F0099BB83 /* TradeLimitsService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -3909,11 +3917,12 @@
 		511356FF209CEE9900056D65 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				AA69118320D0967300DDB541 /* NetworkError.swift */,
 				AA1E523C2097E6AC0099BD10 /* PinStoreResponse.swift */,
 				51135700209CEEB900056D65 /* PushNotificationAuthPayload.swift */,
-				C7BEE14920C9775B0096003B /* WalletOptions.swift */,
-				AA69118320D0967300DDB541 /* NetworkError.swift */,
 				3AB4D9112130693F004F0160 /* Result.swift */,
+				C76143A4211A80380041411E /* SocketMessage.swift */,
+				C7BEE14920C9775B0096003B /* WalletOptions.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -6165,7 +6174,6 @@
 		9F765F3A14BC7C3100048EFB /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				C76143A4211A80380041411E /* SocketMessage.swift */,
 				6780DB961A40BDF40048EED2 /* AccountInOut.h */,
 				6780DB901A40BDA70048EED2 /* AddressInOut.h */,
 				C7CE34B51F4DB8C100032806 /* Assets.h */,
@@ -7742,6 +7750,7 @@
 				AAC9FCEF20AE456400E28B7A /* WalletTransactionDelegate.swift in Sources */,
 				AA63F84C20A12AE9002B719B /* URLs.swift in Sources */,
 				3AAEF96221421C6F005852D1 /* TextCell.swift in Sources */,
+				AA68F4302151A9CE0099BB83 /* TradeLimitsAPI.swift in Sources */,
 				C77C19B920C580E5005CB600 /* WalletSecondPasswordDelegate.swift in Sources */,
 				519435A1208E61F3001EF882 /* BlockchainTests.swift in Sources */,
 				AA0A412D214ADD5B00807163 /* DebugSettings.swift in Sources */,
@@ -7895,6 +7904,7 @@
 				AACE3134209121B800B7B806 /* WalletManager.swift in Sources */,
 				C76143AC211A80D30041411E /* Codable+Coding.swift in Sources */,
 				AA748359211129DF008F2768 /* MockKYCEnterPhoneNumberView.swift in Sources */,
+				AA68F43C2151AA1F0099BB83 /* TradeLimitsService.swift in Sources */,
 				3AAEF9582141B04F005852D1 /* ActionableFooterView.swift in Sources */,
 				AA9B30D220F6D85000A7F809 /* WalletUpgradeDelegate.swift in Sources */,
 				C774A1272102B87300DCCC17 /* ExchangeRate.swift in Sources */,
@@ -8082,6 +8092,7 @@
 				3A49B2B92130B5610068F443 /* NewOrderTableViewCell.swift in Sources */,
 				C7CE25AA2135E3B500DCC43B /* ExchangeCreateContracts.swift in Sources */,
 				AA0A4157214B3A3700807163 /* AssetAccountRepository.swift in Sources */,
+				AA68F42F2151A9CE0099BB83 /* TradeLimitsAPI.swift in Sources */,
 				C7EEB8451EA95505002F28B9 /* UIView+ChangeFrameAttribute.m in Sources */,
 				C774A1262102B87300DCCC17 /* ExchangeRate.swift in Sources */,
 				AA0A412C214AD75300807163 /* DebugSettings.swift in Sources */,
@@ -8179,6 +8190,7 @@
 				3A3D5DCD211C9C6500E6C241 /* PersonalDetailsService.swift in Sources */,
 				9F0CBAD81513CA2600CD945D /* BCFadeView.m in Sources */,
 				602B9CFA2118E15300BD3D60 /* KYCWelcomeController.swift in Sources */,
+				AA68F43B2151AA1F0099BB83 /* TradeLimitsService.swift in Sources */,
 				C78893EE20A4D690003C0A8F /* WalletSendBitcoinDelegate.swift in Sources */,
 				C787180120A22362000CC46E /* WalletAddressesDelegate.swift in Sources */,
 				3AAEF9572141B04F005852D1 /* ActionableFooterView.swift in Sources */,

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -17,6 +17,7 @@ protocol ExchangeDependencies {
     var rates: RatesAPI { get }
     var tradeExecution: TradeExecutionAPI { get }
     var assetAccountRepository: AssetAccountRepository { get }
+    var tradeLimits: TradeLimitsAPI { get }
 }
 
 struct ExchangeServices: ExchangeDependencies {
@@ -27,6 +28,7 @@ struct ExchangeServices: ExchangeDependencies {
     let rates: RatesAPI
     let tradeExecution: TradeExecutionAPI
     let assetAccountRepository: AssetAccountRepository
+    let tradeLimits: TradeLimitsAPI
     
     init() {
         rates = RatesService()
@@ -36,6 +38,7 @@ struct ExchangeServices: ExchangeDependencies {
         inputs = ExchangeInputsService()
         tradeExecution = TradeExecutionService()
         assetAccountRepository = AssetAccountRepository.shared
+        tradeLimits = TradeLimitsService()
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/API/TradeExecutionAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/TradeExecutionAPI.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 protocol TradeExecutionAPI {
-    func getTradeLimits(withCompletion: @escaping ((Result<TradeLimits>) -> Void))
 
     // Build a transaction
     func submitOrder(with conversion: Conversion, success: @escaping ((OrderTransaction, Conversion) -> Void), error: @escaping ((String) -> Void))

--- a/Blockchain/Homebrew/Exchange/API/TradeLimitsAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/TradeLimitsAPI.swift
@@ -1,0 +1,13 @@
+//
+//  TradeLimitsAPI.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 9/18/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+protocol TradeLimitsAPI {
+    func getTradeLimits(withCompletion: @escaping ((Result<TradeLimits>) -> Void))
+}

--- a/Blockchain/Homebrew/Exchange/API/TradeLimitsAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/TradeLimitsAPI.swift
@@ -9,5 +9,6 @@
 import Foundation
 
 protocol TradeLimitsAPI {
-    func getTradeLimits(withCompletion: @escaping ((Result<TradeLimits>) -> Void))
+    func initialize(withFiatCurrency currency: String)
+    func getTradeLimits(withFiatCurrency currency: String, withCompletion: @escaping ((Result<TradeLimits>) -> Void))
 }

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -39,6 +39,9 @@
                                         <state key="normal" title="0.05 BTC Min">
                                             <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                         </state>
+                                        <connections>
+                                            <action selector="useMinimumButtonTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="D8v-2W-2Gs"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kyX-88-NsD">
                                         <rect key="frame" x="179.5" y="0.0" width="163.5" height="44"/>
@@ -46,6 +49,9 @@
                                         <state key="normal" title="1.48 BTC Max">
                                             <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                         </state>
+                                        <connections>
+                                            <action selector="useMaximumButtonTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="EB8-o2-qlv"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <constraints>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -13,6 +13,8 @@ protocol ExchangeCreateDelegate: NumberKeypadViewDelegate {
     func onDisplayRatesTapped()
     func onHideRatesTapped()
     func onKeypadVisibilityUpdated(_ visibility: Visibility, animated: Bool)
+    func onUseMinimumTapped()
+    func onUseMaximumTapped()
     func onDisplayInputTypeTapped()
     func onExchangeButtonTapped()
 }
@@ -43,6 +45,14 @@ class ExchangeCreateViewController: UIViewController {
     @IBOutlet private var useMaximumButton: UIButton!
     @IBOutlet private var conversionView: UIView!
     @IBOutlet private var exchangeButton: UIButton!
+
+    @IBAction func useMinimumButtonTapped(_ sender: Any) {
+        delegate?.onUseMinimumTapped()
+    }
+
+    @IBAction func useMaximumButtonTapped(_ sender: Any) {
+        delegate?.onUseMaximumTapped()
+    }
 
     // MARK: Action enum
     enum Action {
@@ -99,6 +109,8 @@ class ExchangeCreateViewController: UIViewController {
             $0?.textColor = UIColor.brandPrimary
         }
 
+        useMinimumButton.setTitle(LocalizationConstants.Exchange.useMin, for: .normal)
+        useMaximumButton.setTitle(LocalizationConstants.Exchange.useMax, for: .normal)
         [useMaximumButton, useMinimumButton, conversionView, hideRatesButton].forEach {
             addStyleToView($0)
         }

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -284,7 +284,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         model.lastConversion = nil
         inputs.isUsingFiat = true
         clearInputs()
-        updatedInput()
+        output?.updateTradingPair(pair: model.pair, fix: model.fix)
 
         tradeLimitService.getTradeLimits(withFiatCurrency: model.fiatCurrency) { [weak self] limitsResult in
             guard let strongSelf = self else { return }

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -22,19 +22,19 @@ class ExchangeCreateInteractor {
     fileprivate let markets: ExchangeMarketsAPI
     fileprivate let conversions: ExchangeConversionAPI
     fileprivate let tradeExecution: TradeExecutionAPI
+    fileprivate let tradeLimitService: TradeLimitsAPI
     private(set) var model: MarketsModel? {
         didSet {
             didSetModel(oldModel: oldValue)
         }
     }
 
-    init(dependencies: ExchangeDependencies,
-         model: MarketsModel
-    ) {
+    init(dependencies: ExchangeDependencies, model: MarketsModel) {
         self.markets = dependencies.markets
         self.inputs = dependencies.inputs
         self.conversions = dependencies.conversions
         self.tradeExecution = dependencies.tradeExecution
+        self.tradeLimitService = dependencies.tradeLimits
         self.model = model
     }
 
@@ -73,6 +73,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         updatedInput()
         
         markets.setup()
+        tradeLimitService.initialize(withFiatCurrency: model.fiatCurrency)
 
         // Authenticate, then listen for conversions
         markets.authenticate(completion: { [unowned self] in

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -175,11 +175,17 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     }
     
     func useMinimumAmount() {
-        
+        guard let model = model else { return }
+
+        inputs.clear()
+        clearConversions()
+        updatedInput()
+
+        // TODO
     }
     
     func useMaximumAmount() {
-        
+        // TODO
     }
 
     func toggleFix() {

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -72,11 +72,11 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
     }
 
     func onUseMinimumTapped() {
-        // TODO
+        interactor.useMinimumAmount()
     }
 
     func onUseMaximumTapped() {
-        // TODO
+        interactor.useMaximumAmount()
     }
 
     func onDisplayInputTypeTapped() {

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -71,6 +71,14 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
         interactor.toggleFix()
     }
 
+    func onUseMinimumTapped() {
+        // TODO
+    }
+
+    func onUseMaximumTapped() {
+        // TODO
+    }
+
     func onDisplayInputTypeTapped() {
         interactor.displayInputTypeTapped()
     }

--- a/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
@@ -99,7 +99,7 @@ extension MarketsService: ExchangeMarketsAPI {
                 fiatCurrency: model.fiatCurrency,
                 fix: model.fix,
                 volume: model.volume)
-            let quote = Subscription(channel: "conversion", operation: "subscribe", params: params)
+            let quote = Subscription(channel: "conversion", params: params)
             let message = SocketMessage(type: .exchange, JSONMessage: quote)
             SocketManager.shared.send(message: message)
         case .rest:
@@ -130,7 +130,7 @@ private extension MarketsService {
         let authenticationDisposable = authentication.getSessionToken()
             .map { tokenResponse -> Subscription<AuthSubscribeParams> in
                 let params = AuthSubscribeParams(type: "auth", token: tokenResponse.token)
-                return Subscription(channel: "auth", operation: "subscribe", params: params)
+                return Subscription(channel: "auth", params: params)
             }.map { message in
                 return SocketMessage(type: .exchange, JSONMessage: message)
             }.subscribe(onSuccess: { socketMessage in

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -21,10 +21,6 @@ class TradeExecutionService: TradeExecutionAPI {
         static let trades = PathComponents(
             components: ["trades"]
         )
-        
-        static let limits = PathComponents(
-            components: ["trades", "limits"]
-        )
     }
     
     private let authentication: NabuAuthenticationService
@@ -42,17 +38,6 @@ class TradeExecutionService: TradeExecutionAPI {
     }
     
     // MARK: TradeExecutionAPI
-    
-    func getTradeLimits(withCompletion: @escaping ((Result<TradeLimits>) -> Void)) {
-        disposable = limits()
-            .subscribeOn(MainScheduler.asyncInstance)
-            .observeOn(MainScheduler.instance)
-            .subscribe(onSuccess: { (payload) in
-                withCompletion(.success(payload))
-            }, onError: { error in
-                withCompletion(.error(error))
-            })
-    }
 
     // TICKET: IOS-1291 Refactor this
     func submitOrder(
@@ -200,28 +185,5 @@ class TradeExecutionService: TradeExecutionAPI {
             success(orderTransactionLegacy)
         }
         wallet.createOrderPayment(withOrderTransaction: orderTransactionLegacy, success: createOrderPaymentSuccess, error: error)
-    }
-
-    fileprivate func limits() -> Single<TradeLimits> {
-        guard let baseURL = URL(
-            string: BlockchainAPI.shared.retailCoreUrl) else {
-                return .error(TradeExecutionAPIError.generic)
-        }
-        
-        guard let endpoint = URL.endpoint(
-            baseURL,
-            pathComponents: PathComponents.limits.components,
-            queryParameters: nil) else {
-                return .error(TradeExecutionAPIError.generic)
-        }
-        
-        return authentication.getSessionToken().flatMap { token in
-            return NetworkRequest.GET(
-                url: endpoint,
-                body: nil,
-                token: token.token,
-                type: TradeLimits.self
-            )
-        }
     }
 }

--- a/Blockchain/Homebrew/Exchange/Services/TradeLimitsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeLimitsService.swift
@@ -1,0 +1,80 @@
+//
+//  TradeLimitsService.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 9/18/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import RxSwift
+
+class TradeLimitsService: TradeLimitsAPI {
+
+    private var disposable: Disposable?
+
+    private let authenticationService: NabuAuthenticationService
+    private let socketManager: SocketManager
+
+    init(
+        authenticationService: NabuAuthenticationService = NabuAuthenticationService.shared,
+        socketManager: SocketManager = SocketManager.shared
+    ) {
+        self.authenticationService = authenticationService
+        self.socketManager = socketManager
+    }
+
+    enum TradeLimitsAPIError: Error {
+        case generic
+    }
+
+    deinit {
+        disposable?.dispose()
+        disposable = nil
+    }
+
+    func getTradeLimits(withCompletion: @escaping ((Result<TradeLimits>) -> Void)) {
+        disposable = getTradeLimits()
+            .subscribeOn(MainScheduler.asyncInstance)
+            .observeOn(MainScheduler.instance)
+            .subscribe(onSuccess: { (payload) in
+                withCompletion(.success(payload))
+            }, onError: { error in
+                withCompletion(.error(error))
+            })
+    }
+
+    func subscribeToAllExchangeRates() {
+
+        // Send subscribe message
+        let params = AllCurrencyPairsSubscribeParams()
+        let subscriptionMessage = Subscription(channel: "exchange_rate", params: params)
+        let socketMessage = SocketMessage(type: .exchange, JSONMessage: subscriptionMessage)
+        socketManager.send(message: socketMessage)
+    }
+
+    func getTradeLimits() -> Single<TradeLimits> {
+        // TODO: can be cached
+        guard let baseURL = URL(
+            string: BlockchainAPI.shared.retailCoreUrl
+        ) else {
+            return .error(TradeLimitsAPIError.generic)
+        }
+
+        guard let endpoint = URL.endpoint(
+            baseURL,
+            pathComponents: ["trades", "limits"],
+            queryParameters: nil
+        ) else {
+            return .error(TradeLimitsAPIError.generic)
+        }
+
+        return authenticationService.getSessionToken().flatMap { token in
+            return NetworkRequest.GET(
+                url: endpoint,
+                body: nil,
+                token: token.token,
+                type: TradeLimits.self
+            )
+        }
+    }
+}

--- a/Blockchain/Homebrew/Exchange/Views/ExchangeCreateView.swift
+++ b/Blockchain/Homebrew/Exchange/Views/ExchangeCreateView.swift
@@ -258,7 +258,7 @@ private extension ExchangeCreateView {
         useMinButton.titleLabel?.font = buttonFont
         useMinButton.backgroundColor = UIColor.white
         useMinButton.setTitleColor(UIColor.brandSecondary, for: .normal)
-        useMinButton.setTitle(LocalizationConstants.Exchange.useMinimum, for: .normal)
+        useMinButton.setTitle(LocalizationConstants.Exchange.useMin, for: .normal)
         useMinButton.addTarget(self, action: #selector(self.useMinButtonTapped), for: .touchUpInside)
         buttonsView.addSubview(useMinButton)
 
@@ -272,7 +272,7 @@ private extension ExchangeCreateView {
         useMaxButton.titleLabel?.font = buttonFont
         useMaxButton.backgroundColor = UIColor.white
         useMaxButton.setTitleColor(UIColor.brandSecondary, for: .normal)
-        useMaxButton.setTitle(LocalizationConstants.Exchange.useMaximum, for: .normal)
+        useMaxButton.setTitle(LocalizationConstants.Exchange.useMax, for: .normal)
         useMaxButton.addTarget(self, action: #selector(self.useMaxButtonTapped), for: .touchUpInside)
         buttonsView.addSubview(useMaxButton)
     }

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -370,12 +370,12 @@ struct LocalizationConstants {
         static let loadingTransactions = NSLocalizedString("Loading transactions", comment: "")
         static let gettingQuote = NSLocalizedString("Getting quote", comment: "")
         static let confirming = NSLocalizedString("Confirming", comment: "")
-        static let useMinimum = NSLocalizedString(
-            "Use minimum",
+        static let useMin = NSLocalizedString(
+            "Use min",
             comment: "Text displayed on button for user to tap to create a trade with the minimum amount of crypto allowed"
         )
-        static let useMaximum = NSLocalizedString(
-            "Use maximum",
+        static let useMax = NSLocalizedString(
+            "Use max",
             comment: "Text displayed on button for user to tap to create a trade with the maximum amount of crypto allowed"
         )
         static let to = NSLocalizedString("To", comment: "Label for exchanging to a specific type of crypto")

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+// TICKET: IOS-1318
+// Move structs into separate files
+
 enum SocketType: String {
     case unassigned
     case exchange
@@ -58,7 +61,7 @@ struct Subscription<SubscribeParams: Codable>: SocketMessageCodable {
     typealias JSONType = Subscription
     
     let channel: String
-    let operation: String
+    let operation = "subscribe"
     let params: SubscribeParams
 
     private enum CodingKeys: CodingKey {
@@ -79,6 +82,10 @@ struct ConversionSubscribeParams: Codable {
     let fiatCurrency: String
     let fix: Fix
     let volume: String
+}
+
+struct AllCurrencyPairsSubscribeParams: Codable {
+    let type = "allCurrencyPairs"
 }
 
 // MARK: - Received Messages
@@ -135,6 +142,8 @@ extension Conversion {
         return counter + " = " + fiat
     }
 }
+
+// MARK - Associated Models
 
 struct Quote: Codable {
     let time: String?


### PR DESCRIPTION
## Objective

Fetching trade limits and allowing the user to tap "Use min"/"Use max".

## Description

Tapping on "Use min"/"Use max" will:
* change the selected fix to `.baseInFiat`
* display the min/max based on the fiat value that is provided by `GET /trades/limits`

TODOs on my next PR:
* Pull in user's balance from the selected account and compare that balance against the trade limits
* Displaying error when user tries to proceed with trade but the amount is out of tradable bounds 

Other issue I found:
* ~Note that tapping on min/max will sometimes show the primary label incorrectly (i.e. if the min is 
"$1.16", it may show up as "$116". looks like `ExchangeInputService` sometimes doesn't report the entered text as `.fractionalInput`? Not entirely sure as I haven't spent too much time looking into it. Any ideas @thisisalexmcgregor ?)~
EDIT: looks like I just had to set `inputs.isUsingFiat = true`

## How to Test

Go to create exchange view and tap on "Use min"/"Use max". Only tested this on dev so far.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [X] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
