### PR TITLE
fix(NetworkRequest): error if bad response or status code

### DIFF
--- a/Blockchain/Homebrew/Exchange/Models/Order.swift
+++ b/Blockchain/Homebrew/Exchange/Models/Order.swift
@@ -17,30 +17,22 @@ struct Order: Encodable {
     let quote: Quote
 }
 
-// Backend is currently configured to return two types of responses:
-// a normal (success) response and an error response
 struct OrderResult: Codable {
-    // Success
-    let id: String?
-    let createdAt: String?
-    let updatedAt: String?
-    let pair: String?
-    let quantity: String?
-    let currency: String?
-    let refundAddress: String?
-    let price: String?
-    let depositAddress: String?
-    let depositQuantity: String?
-    let withdrawalAddress: String?
-    let withdrawalQuantity: String?
-    let state: String?
-
-    // Error
-    let type: String?
-    let description: String?
+    let id: String
+    let createdAt: String
+    let updatedAt: String
+    let pair: String
+    let quantity: String
+    let currency: String
+    let refundAddress: String
+    let price: String
+    let depositAddress: String
+    let depositQuantity: String
+    let withdrawalAddress: String
+    let withdrawalQuantity: String
+    let state: String
 
     private enum CodingKeys: CodingKey {
-        // Success
         case id
         case createdAt
         case updatedAt
@@ -54,10 +46,6 @@ struct OrderResult: Codable {
         case withdrawalAddress
         case withdrawalQuantity
         case state
-        
-        // Error
-        case type
-        case description
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/Models/Order.swift
+++ b/Blockchain/Homebrew/Exchange/Models/Order.swift
@@ -19,33 +19,33 @@ struct Order: Encodable {
 
 struct OrderResult: Codable {
     let id: String
+    let state: String
     let createdAt: String
     let updatedAt: String
     let pair: String
-    let quantity: String
-    let currency: String
     let refundAddress: String
-    let price: String
+    let rate: String
     let depositAddress: String
-    let depositQuantity: String
+    let deposit: SymbolValue
     let withdrawalAddress: String
-    let withdrawalQuantity: String
-    let state: String
+    let withdrawal: SymbolValue
+    let withdrawalFee: SymbolValue
+    let fiatValue: SymbolValue
 
     private enum CodingKeys: CodingKey {
         case id
+        case state
         case createdAt
         case updatedAt
         case pair
-        case quantity
-        case currency
         case refundAddress
-        case price
+        case rate
         case depositAddress
-        case depositQuantity
+        case deposit
         case withdrawalAddress
-        case withdrawalQuantity
-        case state
+        case withdrawal
+        case withdrawalFee
+        case fiatValue
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -182,7 +182,7 @@ class TradeExecutionService: TradeExecutionAPI {
             : TradingPair(string: orderResult.pair)!.from
         #else
         let depositAddress = orderResult.depositAddress
-        let depositQuantity = orderResult.depositQuantity
+        let depositQuantity = orderResult.deposit.value
         let pair = TradingPair(string: orderResult.pair)
         let assetType = pair!.from
         #endif

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -112,7 +112,7 @@ class TradeExecutionService: TradeExecutionAPI {
                         ),
                         to: to,
                         amountToSend: orderTransactionLegacy.amount,
-                        amountToReceive: payload.withdrawalQuantity ?? "Unavailable",
+                        amountToReceive: payload.withdrawalQuantity,
                         fees: orderTransactionLegacy.fees!
                     )
                     success(orderTransaction, conversion)
@@ -171,11 +171,11 @@ class TradeExecutionService: TradeExecutionAPI {
     ) {
         #if DEBUG
         let settings = DebugSettings.shared
-        let depositAddress = settings.mockExchangeOrderDepositAddress ?? orderResult.depositAddress!
-        let depositQuantity = settings.mockExchangeDeposit ? settings.mockExchangeDepositQuantity! : orderResult.depositQuantity!
+        let depositAddress = settings.mockExchangeOrderDepositAddress ?? orderResult.depositAddress
+        let depositQuantity = settings.mockExchangeDeposit ? settings.mockExchangeDepositQuantity! : orderResult.depositQuantity
         let assetType = settings.mockExchangeDeposit ?
             AssetType(stringValue: settings.mockExchangeDepositAssetTypeString!)!
-            : TradingPair(string: orderResult.pair!)!.from
+            : TradingPair(string: orderResult.pair)!.from
         #else
         let depositAddress = orderResult.depositAddress!
         let depositQuantity = orderResult.depositQuantity!

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -113,7 +113,7 @@ class TradeExecutionService: TradeExecutionAPI {
                         ),
                         to: to,
                         amountToSend: orderTransactionLegacy.amount,
-                        amountToReceive: payload.withdrawalQuantity,
+                        amountToReceive: payload.withdrawal.value,
                         fees: orderTransactionLegacy.fees!
                     )
                     success(orderTransaction, conversion)
@@ -176,7 +176,7 @@ class TradeExecutionService: TradeExecutionAPI {
         #if DEBUG
         let settings = DebugSettings.shared
         let depositAddress = settings.mockExchangeOrderDepositAddress ?? orderResult.depositAddress
-        let depositQuantity = settings.mockExchangeDeposit ? settings.mockExchangeDepositQuantity! : orderResult.depositQuantity
+        let depositQuantity = settings.mockExchangeDeposit ? settings.mockExchangeDepositQuantity! : orderResult.deposit.value
         let assetType = settings.mockExchangeDeposit ?
             AssetType(stringValue: settings.mockExchangeDepositAssetTypeString!)!
             : TradingPair(string: orderResult.pair)!.from

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -55,6 +55,7 @@ class TradeExecutionService: TradeExecutionAPI {
     }
 
     // TICKET: IOS-1291 Refactor this
+    // swiftlint:disable function_body_length
     func submitOrder(
         with conversion: Conversion,
         success: @escaping ((OrderTransaction, Conversion) -> Void),
@@ -118,12 +119,15 @@ class TradeExecutionService: TradeExecutionAPI {
                     success(orderTransaction, conversion)
                 }
                 this.createOrder(from: payload, success: createOrderCompletion, error: error)
+        }, onError: { requestError in
+            guard let httpRequestError = requestError as? HTTPRequestError else {
+                error(requestError.localizedDescription)
+                return
+            }
+            error(httpRequestError.debugDescription)
         })
-        // Can't figure out error: Extra argument 'onError' in call
-//        , onError: { error in
-//            withCompletion(.error(error))
-//        })
     }
+    // swiftlint:enable function_body_length
 
     func sendTransaction(assetType: AssetType, success: @escaping (() -> Void), error: @escaping ((String) -> Void)) {
         wallet.sendOrderTransaction(assetType.legacy, success: success, error: error)
@@ -140,7 +144,7 @@ class TradeExecutionService: TradeExecutionAPI {
         }, error: error)
     }
     // MARK: Private
-    
+
     fileprivate func process(order: Order) -> Single<OrderResult> {
         guard let baseURL = URL(
             string: BlockchainAPI.shared.retailCoreUrl) else {

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -177,9 +177,9 @@ class TradeExecutionService: TradeExecutionAPI {
             AssetType(stringValue: settings.mockExchangeDepositAssetTypeString!)!
             : TradingPair(string: orderResult.pair)!.from
         #else
-        let depositAddress = orderResult.depositAddress!
-        let depositQuantity = orderResult.depositQuantity!
-        let pair = TradingPair(string: orderResult.pair!)
+        let depositAddress = orderResult.depositAddress
+        let depositQuantity = orderResult.depositQuantity
+        let pair = TradingPair(string: orderResult.pair)
         let assetType = pair!.from
         #endif
         let legacyAssetType = assetType.legacy

--- a/Blockchain/Network/Models/Result.swift
+++ b/Blockchain/Network/Models/Result.swift
@@ -16,3 +16,8 @@ enum Result<A> {
     case success(A)
     case error(Error?)
 }
+
+enum HTTPRequestResult<A> {
+    case success(A)
+    case error(HTTPRequestError?)
+}

--- a/Blockchain/Network/Models/Result.swift
+++ b/Blockchain/Network/Models/Result.swift
@@ -16,8 +16,3 @@ enum Result<A> {
     case success(A)
     case error(Error?)
 }
-
-enum HTTPRequestResult<A> {
-    case success(A)
-    case error(HTTPRequestError?)
-}

--- a/Blockchain/Network/NetworkRequest.swift
+++ b/Blockchain/Network/NetworkRequest.swift
@@ -65,7 +65,7 @@ struct NetworkRequest {
     }
     
     fileprivate mutating func execute<T: Decodable>(expecting: T.Type, withCompletion: @escaping ((Result<T>, _ responseCode: Int) -> Void)) {
-        var responseCode: Int = 0
+        let responseCode: Int = 0
         
         guard let urlRequest = URLRequest() else {
             withCompletion(.error(nil), responseCode)

--- a/Blockchain/Network/NetworkRequest.swift
+++ b/Blockchain/Network/NetworkRequest.swift
@@ -64,7 +64,7 @@ struct NetworkRequest {
         return request.copy() as? URLRequest
     }
     
-    fileprivate mutating func execute<T: Decodable>(expecting: T.Type, withCompletion: @escaping ((Result<T>, _ responseCode: Int) -> Void)) {
+    fileprivate mutating func execute<T: Decodable>(expecting: T.Type, withCompletion: @escaping ((HTTPRequestResult<T>, _ responseCode: Int) -> Void)) {
         var responseCode: Int = 0
         
         guard let urlRequest = URLRequest() else {
@@ -99,13 +99,10 @@ struct NetworkRequest {
                     decoder.dateDecodingStrategy = .secondsSince1970
                     let final = try decoder.decode(T.self, from: payload)
                     withCompletion(.success(final), responseCode)
-                } catch let err {
-                    withCompletion(.error(err), responseCode)
+                } catch let decodingError {
+                    Logger.shared.debug("Payload decoding error: \(decodingError)")
+                    withCompletion(.error(HTTPRequestPayloadError.badData), responseCode)
                 }
-            }
-            
-            if let error = error {
-                withCompletion(.error(error), responseCode)
             }
         }
         


### PR DESCRIPTION
## Objective

- Handle errors in a way similar to `KYCNetworkRequest`.
- Make `OrderResult` (the response from the trades endpoint) non-optional.
- Update `OrderResult` properties to match server response.

## Description

- Added error handling to `NetworkRequest`'s `execute` method.
- Removed optionals and error-related properties from `OrderResult`.
- Removed force unwraps of `OrderResult` properties from `TradeExecutionService`.

## How to Test

Hit a bad endpoint and see an error instead of an attempt to decode to a certain type.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
