### PR TITLE
fix(Exchange): unsubscribe from unused currency pair.

### DIFF
--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -95,12 +95,8 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
 
             guard model.pair.stringRepresentation == conversion.quote.pair else {
                 Logger.shared.warning(
-                    """
-                    Pair '\(conversion.quote.pair)' is different from model pair '\(model.pair.stringRepresentation)'.
-                    Unsubscribing from pair '\(conversion.quote.pair)'
-                    """
+                    "Pair '\(conversion.quote.pair)' is different from model pair '\(model.pair.stringRepresentation)'."
                 )
-                this.markets.unsubscribeToCurrencyPair(pair: conversion.quote.pair)
                 return
             }
 
@@ -259,6 +255,12 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
 
     func changeTradingPair(tradingPair: TradingPair) {
         guard let model = model else { return }
+
+        // Unsubscribe from old pair conversions
+        Logger.shared.debug("Unsubscribing from old currency pair '\(model.pair.stringRepresentation)'")
+        markets.unsubscribeToCurrencyPair(pair: model.pair.stringRepresentation)
+
+        // Update to new pair
         model.pair = tradingPair
         updatedInput()
         output?.updateTradingPair(pair: model.pair, fix: model.fix)

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -90,8 +90,17 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     func subscribeToConversions() {
         disposable = markets.conversions.subscribe(onNext: { [weak self] conversion in
             guard let this = self else { return }
-            guard let model = this.model, model.pair.stringRepresentation == conversion.quote.pair else {
-                Logger.shared.error("Pair returned from conversion is different from model pair")
+
+            guard let model = this.model else { return }
+
+            guard model.pair.stringRepresentation == conversion.quote.pair else {
+                Logger.shared.warning(
+                    """
+                    Pair '\(conversion.quote.pair)' is different from model pair '\(model.pair.stringRepresentation)'.
+                    Unsubscribing from pair '\(conversion.quote.pair)'
+                    """
+                )
+                this.markets.unsubscribeToCurrencyPair(pair: conversion.quote.pair)
                 return
             }
 

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -88,6 +88,21 @@ struct AllCurrencyPairsSubscribeParams: Codable {
     let type = "allCurrencyPairs"
 }
 
+// MARK: - Unsubscribing
+
+struct Unsubscription<UnsubscribeParams: Codable>: SocketMessageCodable {
+    typealias JSONType = Unsubscription
+
+    let channel: String
+    let operation = "unsubscribe"
+    let params: UnsubscribeParams
+}
+
+struct ConversionPairUnsubscribeParams: Codable {
+    let type = "conversionPair"
+    let pair: String
+}
+
 // MARK: - Received Messages
 struct HeartBeat: SocketMessageCodable {
     typealias JSONType = HeartBeat
@@ -143,7 +158,7 @@ extension Conversion {
     }
 }
 
-// MARK - Associated Models
+// MARK: - Associated Models
 
 struct Quote: Codable {
     let time: String?


### PR DESCRIPTION
## Objective

Unsubscribe to rates for currency pairs that are different from the pair the user is trying to exchange in.

## Description

Prevents chatty/extraneous websocket messages where conversion rates are still being received from previous currency pairs. This can happen if the user was previously trying to exchange in a currency pair (e.g. "BTC-ETH") but then changed to a different pair (e.g. "BCH-ETH"). 

## How to Test

Pull in changes, go to create exchange flow, change currency pairs, and verify that you see the logged message: "Pair <old pair> is different from model pair <new pair>"

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
