### PR TITLE
feat(Exchange): IOS-1322 Checking balances when computing min/max

### DIFF
--- a/Blockchain/Accounts/AssetAccount.swift
+++ b/Blockchain/Accounts/AssetAccount.swift
@@ -18,8 +18,6 @@ struct AssetAccount {
     let address: AssetAddress
 
     /// The balance in this account
-    /// For BTC and BCH, this value is in satoshis
-    /// For Eth, this value is in ether
     let balance: Decimal
 
     /// The name of this account

--- a/Blockchain/Accounts/AssetAccountRepository.swift
+++ b/Blockchain/Accounts/AssetAccountRepository.swift
@@ -60,9 +60,7 @@ class AssetAccountRepository {
         return AssetAccount.create(assetType: assetType, index: index, wallet: wallet)
     }
 
-    // MARK: Private Methods
-
-    private func defaultEthereumAccount() -> AssetAccount? {
+    func defaultEthereumAccount() -> AssetAccount? {
         guard let ethereumAddress = wallet.getEtherAddress(), wallet.hasEthAccount() else {
             Logger.shared.debug("This wallet has no ethereum address.")
             return nil
@@ -86,6 +84,8 @@ class AssetAccountRepository {
 
 extension AssetAccount {
 
+    /// Creates a new AssetAccount. This method only supports creating an AssetAccount for
+    /// BTC or BCH. For ETH, use `defaultEthereumAccount`.
     static func create(assetType: AssetType, index: Int32, wallet: Wallet) -> AssetAccount? {
         guard let address = wallet.getReceiveAddress(forAccount: index, assetType: assetType.legacy) else {
             return nil

--- a/Blockchain/Accounts/AssetAccountRepository.swift
+++ b/Blockchain/Accounts/AssetAccountRepository.swift
@@ -46,8 +46,7 @@ class AssetAccountRepository {
 
     func allAccounts() -> [AssetAccount] {
         var allAccounts: [AssetAccount] = []
-        let allTypes: [AssetType] = [.bitcoin, .ethereum, .bitcoinCash]
-        allTypes.forEach {
+        AssetType.all.forEach {
             allAccounts.append(contentsOf: accounts(for: $0))
         }
         return allAccounts
@@ -93,7 +92,12 @@ extension AssetAccount {
         }
         let name = wallet.getLabelForAccount(index, assetType: assetType.legacy)
         let balanceLong = wallet.getBalanceForAccount(index, assetType: assetType.legacy) as? CUnsignedLongLong ?? 0
-        let balance = Decimal(balanceLong)
+        let balance: Decimal
+        if assetType == .bitcoin || assetType == .bitcoinCash {
+            balance = Decimal(balanceLong) / Decimal(Constants.Conversions.satoshi)
+        } else {
+            balance = Decimal(balanceLong)
+        }
         return AssetAccount(
             index: index,
             address: AssetAddressFactory.create(fromAddressString: address, assetType: assetType),

--- a/Blockchain/AssetType.swift
+++ b/Blockchain/AssetType.swift
@@ -20,6 +20,8 @@ extension AssetType {
         "eth": .ethereum,
         "bch": .bitcoinCash
     ]
+
+    static let all: [AssetType] = [.bitcoin, .ethereum, .bitcoinCash]
     
     static func from(legacyAssetType: LegacyAssetType) -> AssetType {
         switch legacyAssetType {

--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -30,8 +30,8 @@ protocol ExchangeCreateInput: NumberKeypadViewDelegate {
     func viewLoaded()
     func displayInputTypeTapped()
     func ratesViewTapped()
-    func useMinimumAmount()
-    func useMaximumAmount()
+    func useMinimumAmount(assetAccount: AssetAccount)
+    func useMaximumAmount(assetAccount: AssetAccount)
     func confirmConversion()
     func changeTradingPair(tradingPair: TradingPair)
 }

--- a/Blockchain/Homebrew/Exchange/API/TradeLimitsAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/TradeLimitsAPI.swift
@@ -6,9 +6,27 @@
 //  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
 //
 
-import Foundation
+import RxSwift
 
+/// Protocol definition for a service that returns the current user's trade limits
 protocol TradeLimitsAPI {
+
+    /// Initializes this instance with the provided fiat currency. This should be called
+    /// upon starting a new exchange so that trading limits, which is provided in fiat,
+    /// can be prefetched.
+    ///
+    /// - Parameter currency: the current in fiat (e.g. "USD")
     func initialize(withFiatCurrency currency: String)
+
+    /// Returns the trade limits in the provided fiat currency.
+    ///
+    /// - Parameters:
+    ///   - currency: the currency to return the limits in
+    ///   - withCompletion: the completion handler invoked when the trading limits are provided.
     func getTradeLimits(withFiatCurrency currency: String, withCompletion: @escaping ((Result<TradeLimits>) -> Void))
+
+    // MARK: - Rx
+
+    /// Rx version of `getTradeLimits(withFiatCurrency: withCompletion:)`
+    func getTradeLimits(withFiatCurrency currency: String) -> Single<TradeLimits>
 }

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -13,8 +13,8 @@ protocol ExchangeCreateDelegate: NumberKeypadViewDelegate {
     func onDisplayRatesTapped()
     func onHideRatesTapped()
     func onKeypadVisibilityUpdated(_ visibility: Visibility, animated: Bool)
-    func onUseMinimumTapped()
-    func onUseMaximumTapped()
+    func onUseMinimumTapped(assetAccount: AssetAccount)
+    func onUseMaximumTapped(assetAccount: AssetAccount)
     func onDisplayInputTypeTapped()
     func onExchangeButtonTapped()
 }
@@ -47,11 +47,11 @@ class ExchangeCreateViewController: UIViewController {
     @IBOutlet private var exchangeButton: UIButton!
 
     @IBAction func useMinimumButtonTapped(_ sender: Any) {
-        delegate?.onUseMinimumTapped()
+        delegate?.onUseMinimumTapped(assetAccount: fromAccount)
     }
 
     @IBAction func useMaximumButtonTapped(_ sender: Any) {
-        delegate?.onUseMaximumTapped()
+        delegate?.onUseMaximumTapped(assetAccount: fromAccount)
     }
 
     // MARK: Action enum

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -71,12 +71,12 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
         interactor.toggleFix()
     }
 
-    func onUseMinimumTapped() {
-        interactor.useMinimumAmount()
+    func onUseMinimumTapped(assetAccount: AssetAccount) {
+        interactor.useMinimumAmount(assetAccount: assetAccount)
     }
 
-    func onUseMaximumTapped() {
-        interactor.useMaximumAmount()
+    func onUseMaximumTapped(assetAccount: AssetAccount) {
+        interactor.useMaximumAmount(assetAccount: assetAccount)
     }
 
     func onDisplayInputTypeTapped() {

--- a/Blockchain/Homebrew/Exchange/Services/TradeLimitsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeLimitsService.swift
@@ -15,7 +15,7 @@ class TradeLimitsService: TradeLimitsAPI {
 
     private let authenticationService: NabuAuthenticationService
     private let socketManager: SocketManager
-    private var cachedLimits = BehaviorRelay<TradeLimits?>(value: nil)
+    private let cachedLimits = BehaviorRelay<TradeLimits?>(value: nil)
 
     init(
         authenticationService: NabuAuthenticationService = NabuAuthenticationService.shared,
@@ -59,11 +59,9 @@ class TradeLimitsService: TradeLimitsAPI {
         _ = disposables.insert(disposable)
     }
 
-    // MARK: - Private
-
-    private func getTradeLimits(withFiatCurrency currency: String) -> Single<TradeLimits> {
+    func getTradeLimits(withFiatCurrency currency: String) -> Single<TradeLimits> {
         return Single.deferred { [unowned self] in
-            guard let cachedLimits = self.cachedLimits.value else {
+            guard let cachedLimits = self.cachedLimits.value, cachedLimits.currency == currency else {
                 return self.getTradeLimitsNetwork(withFiatCurrency: currency)
             }
             return Single.just(cachedLimits)
@@ -71,6 +69,8 @@ class TradeLimitsService: TradeLimitsAPI {
             self?.cachedLimits.accept(response)
         })
     }
+
+    // MARK: - Private
 
     private func getTradeLimitsNetwork(withFiatCurrency currency: String) -> Single<TradeLimits> {
         guard let baseURL = URL(

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -84,8 +84,13 @@ struct ConversionSubscribeParams: Codable {
     let volume: String
 }
 
-struct AllCurrencyPairsSubscribeParams: Codable {
+struct AllCurrencyPairsUnsubscribeParams: Codable {
     let type = "allCurrencyPairs"
+}
+
+struct CurrencyPairsSubscribeParams: Codable {
+    let type = "exchangeRates"
+    let pairs: [String]
 }
 
 // MARK: - Unsubscribing
@@ -104,6 +109,25 @@ struct ConversionPairUnsubscribeParams: Codable {
 }
 
 // MARK: - Received Messages
+
+struct ExchangeRates: SocketMessageCodable {
+    typealias JSONType = ExchangeRates
+
+    let sequenceNumber: Int
+    let channel: String
+    let type: String
+    let rates: [CurrencyPairRate]
+}
+
+extension ExchangeRates {
+    func convert(balance: Decimal, fromCurrency: String, toCurrency: String) -> Decimal {
+        if let matchingPair = rates.first(where: { $0.pair == "\(fromCurrency)-\(toCurrency)" }) {
+            return matchingPair.price * balance
+        }
+        return balance
+    }
+}
+
 struct HeartBeat: SocketMessageCodable {
     typealias JSONType = HeartBeat
     
@@ -159,6 +183,11 @@ extension Conversion {
 }
 
 // MARK: - Associated Models
+
+struct CurrencyPairRate: Codable {
+    let pair: String
+    let price: Decimal
+}
 
 struct Quote: Codable {
     let time: String?

--- a/Blockchain/Network/SocketManager.swift
+++ b/Blockchain/Network/SocketManager.swift
@@ -142,6 +142,9 @@ extension SocketManager: WebSocketAdvancedDelegate {
         switch type {
         case "unsubscribed":
             onAcknowledge("Successfully unsubscribed. Payload: \(text)")
+        case "exchangeRate":
+            Logger.shared.debug("Attempting to decode: \(text)")
+            ExchangeRates.tryToDecode(socketType: socketType, data: data, onSuccess: onSuccess, onError: onError)
         case "currencyRatio":
             Conversion.tryToDecode(socketType: socketType, data: data, onSuccess: onSuccess, onError: onError)
         case "currencyRatioError":


### PR DESCRIPTION
## Objective

Checking account balances when populating min/max value that the user wishes to trade. Please review merge #515 before reviewing/merging this.

## Description

Previously, tapping on min/max will populate the trading limits for the user as provided get `GET /trades/limits`. However, this didn't take into account the balance of the user's account. In this PR, we are now computing the balance in fiat of the crypto the user wishes to trade.

This is done by:
* Getting the best exchange rates from the "exchange_rate" socket channel
* Taking the `AssetAccount` the user is exchanging from to retrieve the balance, followed by using the appropriate exchange rate to compute the balance in fiat.

Note that I exposed Rx methods in `TradeLimitsAPI` and `ExchangeMarketsAPI`. The reason I decided to Rx-ify here is two-fold:
(1) computing the min/max now needs to wait for 2 asynchronous calls (i.e. trading limits and best exchange rates
(2) exchange rates change dynamically, and so with an Rx approach, we can get the user's account balance in fiat as a reactive stream and re-compute it as the rates change

## How to Test

Pull in changes, go to exchange create view, tap min/max.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [X] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
