### PR TITLE
fix(JS): add BCH prefix if using BCH address for exchanging

### DIFF
--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -3171,7 +3171,7 @@ MyWalletPhone.tradeExecution = {
             // Currently cannot send from BCH addresses
             let bchAccount = MyWallet.wallet.bch.accounts[from];
             currentBitcoinCashPayment = bchAccount.createPayment();
-            currentBitcoinCashPayment.to(to);
+            MyWalletPhone.bch.changePaymentToAddress(to);
             currentBitcoinCashPayment.amount(amount);
 
             let options = walletOptions.getValue()


### PR DESCRIPTION
## Objective

Fix sending for a BCH exchange order.

## Description

Had JS add the `bitcoincash:` prefix required by the payment if the address is a BCH address.

## How to Test

Exchange from BCH - payment construction and send should go through.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
