### PR TITLE
feat(Homebrew-Exchange): use fiat symbol from wallet settings

### DIFF
--- a/Blockchain/Homebrew/Exchange/API/ExchangeInputsAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeInputsAPI.swift
@@ -16,7 +16,7 @@ protocol ExchangeInputsAPI: class {
     
     func setup(with template: ExchangeStyleTemplate, usingFiat: Bool)
     
-    func primaryFiatAttributedString() -> NSAttributedString
+    func primaryFiatAttributedString(currencySymbol: String) -> NSAttributedString
     func primaryAssetAttributedString(symbol: String) -> NSAttributedString
     
     func maxFiatFractional() -> Int

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -128,7 +128,8 @@ class ExchangeCreateViewController: UIViewController {
             dependencies: dependencies,
             model: MarketsModel(
                 pair: TradingPair(from: fromAccount.address.assetType, to: toAccount.address.assetType)!,
-                fiatCurrency: BlockchainSettings.sharedAppInstance().fiatCurrencySymbol ?? "USD",
+                fiatCurrencyCode: BlockchainSettings.sharedAppInstance().fiatCurrencyCode ?? "USD",
+                fiatCurrencySymbol: BlockchainSettings.sharedAppInstance().fiatCurrencySymbol ?? "$",
                 fix: .base,
                 volume: "0"
             )

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -128,7 +128,7 @@ class ExchangeCreateViewController: UIViewController {
             dependencies: dependencies,
             model: MarketsModel(
                 pair: TradingPair(from: fromAccount.address.assetType, to: toAccount.address.assetType)!,
-                fiatCurrency: "USD",
+                fiatCurrency: BlockchainSettings.sharedAppInstance().fiatCurrencySymbol ?? "USD",
                 fix: .base,
                 volume: "0"
             )

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -70,7 +70,7 @@ class ExchangeDetailCoordinator: NSObject {
                     model: TradingPairView.confirmationModel(for: conversion)
                 )
                 
-                let symbol = NumberFormatter.localCurrencyFormatter.currencySymbol ?? ""
+                let symbol = conversion.quote.currencyRatio.counter.fiat.symbol
                 
                 let value = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.value,
@@ -138,7 +138,7 @@ class ExchangeDetailCoordinator: NSObject {
                     model: TradingPairView.confirmationModel(for: conversion)
                 )
                 
-                let symbol = NumberFormatter.localCurrencyFormatter.currencySymbol ?? ""
+                let symbol = conversion.quote.currencyRatio.counter.fiat.symbol
                 
                 let value = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.value,

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -312,7 +312,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         let tradingLimitsSingle = tradeLimitService.getTradeLimits(withFiatCurrency: model.fiatCurrencyCode)
         let balanceFiatValue = markets.fiatBalance(
             forAssetAccount: assetAccount,
-            fiatCurrencySymbol: model.fiatCurrencySymbol
+            fiatCurrencyCode: model.fiatCurrencyCode
         )
 
         tradingLimitDisposable = Single.zip(tradingLimitsSingle, balanceFiatValue.take(1).asSingle()) {

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -85,7 +85,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         updatedInput()
         
         markets.setup()
-        tradeLimitService.initialize(withFiatCurrency: model.fiatCurrency)
+        tradeLimitService.initialize(withFiatCurrency: model.fiatCurrencyCode)
 
         // Authenticate, then listen for conversions
         markets.authenticate(completion: { [unowned self] in
@@ -151,7 +151,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         // Update the inputs in crypto and fiat
         guard let output = output else { return }
         guard let model = model else { return }
-        let symbol = model.fiatCurrency
+        let symbol = model.fiatCurrencySymbol
         let suffix = model.pair.from.symbol
         
         let secondaryAmount = conversions.output.count == 0 ? "0.00": conversions.output
@@ -309,10 +309,10 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         output?.updateTradingPair(pair: model.pair, fix: model.fix)
 
         // Compute trading limit and take into account user's balance
-        let tradingLimitsSingle = tradeLimitService.getTradeLimits(withFiatCurrency: model.fiatCurrency)
+        let tradingLimitsSingle = tradeLimitService.getTradeLimits(withFiatCurrency: model.fiatCurrencyCode)
         let balanceFiatValue = markets.fiatBalance(
             forAssetAccount: assetAccount,
-            fiatCurrencySymbol: model.fiatCurrency
+            fiatCurrencySymbol: model.fiatCurrencySymbol
         )
 
         tradingLimitDisposable = Single.zip(tradingLimitsSingle, balanceFiatValue.take(1).asSingle()) {

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -151,14 +151,14 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         // Update the inputs in crypto and fiat
         guard let output = output else { return }
         guard let model = model else { return }
-        let symbol = NumberFormatter.localCurrencyFormatter.currencySymbol ?? "$"
+        let symbol = model.fiatCurrency
         let suffix = model.pair.from.symbol
         
         let secondaryAmount = conversions.output.count == 0 ? "0.00": conversions.output
         let secondaryResult = model.isUsingFiat ? (secondaryAmount + " " + suffix) : (symbol + secondaryAmount)
 
         if model.isUsingFiat {
-            let primary = inputs.primaryFiatAttributedString()
+            let primary = inputs.primaryFiatAttributedString(currencySymbol: symbol)
             output.updatedInput(primary: primary, secondary: conversions.output)
         } else {
             let assetType = model.isUsingBase ? model.pair.from : model.pair.to

--- a/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
@@ -11,17 +11,20 @@ import Foundation
 // State model for interacting with the MarketsService
 class MarketsModel {
     var pair: TradingPair
-    var fiatCurrency: String
+    var fiatCurrencyCode: String
+    var fiatCurrencySymbol: String
     var fix: Fix
     var volume: String
     var lastConversion: Conversion?
 
     init(pair: TradingPair,
-         fiatCurrency: String,
+         fiatCurrencyCode: String,
+         fiatCurrencySymbol: String,
          fix: Fix,
          volume: String) {
         self.pair = pair
-        self.fiatCurrency = fiatCurrency
+        self.fiatCurrencyCode = fiatCurrencyCode
+        self.fiatCurrencySymbol = fiatCurrencySymbol
         self.fix = fix
         self.volume = volume
     }
@@ -58,7 +61,8 @@ extension MarketsModel: Equatable {
     // Do not compare lastConversion
     static func == (lhs: MarketsModel, rhs: MarketsModel) -> Bool {
         return lhs.pair == rhs.pair &&
-        lhs.fiatCurrency == rhs.fiatCurrency &&
+        lhs.fiatCurrencyCode == rhs.fiatCurrencyCode &&
+        lhs.fiatCurrencySymbol == rhs.fiatCurrencySymbol &&
         lhs.fix == rhs.fix &&
         lhs.volume == rhs.volume
     }

--- a/Blockchain/Homebrew/Exchange/Services/ExchangeInputsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/ExchangeInputsService.swift
@@ -35,11 +35,10 @@ class ExchangeInputsService: ExchangeInputsAPI {
         isUsingFiat = usingFiat
     }
     
-    func primaryFiatAttributedString() -> NSAttributedString {
+    func primaryFiatAttributedString(currencySymbol: String) -> NSAttributedString {
         guard components.count > 0 else { return NSAttributedString(string: "NaN")}
-        guard let symbol = NumberFormatter.localCurrencyFormatter.currencySymbol else { return NSAttributedString(string: "NaN") }
         let symbolComponent = InputComponent(
-            value: symbol,
+            value: currencySymbol,
             type: .symbol
         )
         return inputComponents.primaryFiatAttributedString(symbolComponent)

--- a/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
@@ -161,7 +161,7 @@ extension MarketsService: ExchangeMarketsAPI {
             let params = ConversionSubscribeParams(
                 type: "conversionSpecification",
                 pair: model.pair.stringRepresentation,
-                fiatCurrency: model.fiatCurrency,
+                fiatCurrency: model.fiatCurrencyCode,
                 fix: model.fix,
                 volume: model.volume)
             let quote = Subscription(channel: "conversion", params: params)

--- a/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
@@ -24,9 +24,9 @@ protocol ExchangeMarketsAPI {
     ///
     /// - Parameters:
     ///   - assetAccount: the AssetAccount
-    ///   - fiatCurrencySymbol: the currency symbol to compute the balance in (e.g. "USD")
+    ///   - fiatCurrencyCode: the currency code to compute the balance in (e.g. "USD")
     /// - Returns: an Observable returning the fiat balance
-    func fiatBalance(forAssetAccount assetAccount: AssetAccount, fiatCurrencySymbol: String) -> Observable<Decimal>
+    func fiatBalance(forAssetAccount assetAccount: AssetAccount, fiatCurrencyCode: String) -> Observable<Decimal>
 
     var hasAuthenticated: Bool { get }
     var conversions: Observable<Conversion> { get }
@@ -123,7 +123,7 @@ extension MarketsService: ExchangeMarketsAPI {
         })
     }
 
-    func fiatBalance(forAssetAccount assetAccount: AssetAccount, fiatCurrencySymbol: String) -> Observable<Decimal> {
+    func fiatBalance(forAssetAccount assetAccount: AssetAccount, fiatCurrencyCode: String) -> Observable<Decimal> {
 
         // Don't need to get exchange rates if the account balance is 0
         guard assetAccount.balance != 0 else {
@@ -132,7 +132,7 @@ extension MarketsService: ExchangeMarketsAPI {
 
         // Send exchange_rates socket message - get exchange rates for all possible pairs
         let allPairs = AssetType.all.map {
-            return "\($0.symbol)-\(fiatCurrencySymbol)"
+            return "\($0.symbol)-\(fiatCurrencyCode)"
         }
         let params = CurrencyPairsSubscribeParams(pairs: allPairs)
         let subscribe = Subscription(channel: "exchange_rate", params: params)
@@ -150,7 +150,7 @@ extension MarketsService: ExchangeMarketsAPI {
             return rates.convert(
                 balance: assetAccount.balance,
                 fromCurrency: assetAccount.address.assetType.symbol,
-                toCurrency: fiatCurrencySymbol
+                toCurrency: fiatCurrencyCode
             )
         }
     }

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -160,7 +160,7 @@ struct Conversion: SocketMessageCodable {
 
 extension Conversion {
     var baseToFiatDescription: String {
-        let fiatSymbol = NumberFormatter.localCurrencyFormatter.currencySymbol ?? ""
+        let fiatSymbol = quote.currencyRatio.base.fiat.symbol
         let base = "1" + " " + quote.currencyRatio.base.crypto.symbol
         let fiat = fiatSymbol + quote.currencyRatio.baseToFiatRate
         return base + " = " + fiat
@@ -175,7 +175,7 @@ extension Conversion {
     
     var counterToFiatDescription: String {
         let counterSymbol = quote.currencyRatio.counter.crypto.symbol
-        let fiatSymbol = NumberFormatter.localCurrencyFormatter.currencySymbol ?? ""
+        let fiatSymbol = quote.currencyRatio.counter.fiat.symbol
         let counter = "1" + " " + counterSymbol
         let fiat = fiatSymbol + quote.currencyRatio.counterToFiatRate
         return counter + " = " + fiat

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -133,6 +133,10 @@ final class BlockchainSettings: NSObject {
             }
         }
 
+        @objc var fiatCurrencySymbol: String? {
+            return WalletManager.shared.latestMultiAddressResponse?.symbol_local.symbol
+        }
+
         /// The first 5 characters of SHA256 hash of the user's password
         @objc var passwordPartHash: String? {
             get {

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -137,6 +137,10 @@ final class BlockchainSettings: NSObject {
             return WalletManager.shared.latestMultiAddressResponse?.symbol_local.symbol
         }
 
+        @objc var fiatCurrencyCode: String? {
+            return WalletManager.shared.latestMultiAddressResponse?.symbol_local.code
+        }
+
         /// The first 5 characters of SHA256 hash of the user's password
         @objc var passwordPartHash: String? {
             get {


### PR DESCRIPTION
## Objective

Use correct fiat symbols in the exchange flow.

## Description

- Used fiat symbol from wallet object through `BlockchainSettings` instead of USD.
- Used the `fiatCurrency` stored in `MarketsModel` instead of `NumberFormatter`'s `currencySymbol`
- Used `fiat.value` from `conversion.quote.currencyRatio`'s `base` or `counter` for display
- Replaced the ambiguous `fiatCurrency` property on `MarketsModel` with `fiatCurrencySymbol` ($, £) and `fiatCurrencyCode` (USD, GBP).

## How to Test

- Go to Exchange with a few different Local Currency options set in Settings. See the currency symbol displayed in the input labels.
- Go to the confirm screen and see that the appropriate currency symbol is displayed.

## Screenshot/Design assessment

Not able to test at the moment due to server issues.
Brazil Real as an example:
<img width="294" alt="screen shot 2018-09-21 at 11 47 25 am" src="https://user-images.githubusercontent.com/10579422/45891660-20eccf00-bd94-11e8-8640-8d90861b4ce2.png">


## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
