### PR TITLE
fix(HB): Exchange List Shown Always

### DIFF
--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
@@ -59,12 +59,7 @@ extension ExchangeListPresenter: ExchangeListOutput {
     
     func loadedTrades(_ trades: [ExchangeTradeModel]) {
         interface?.refreshControlVisibility(.hidden)
-        if trades.count == 0 {
-            interface?.showNewExchange(animated: false)
-        } else {
-            interface?.enablePullToRefresh()
-            interface?.display(results: trades)
-        }
+        interface?.display(results: trades)
     }
     
     func appendTrades(_ trades: [ExchangeTradeModel]) {


### PR DESCRIPTION
## Objective

The user's exchange history should be shown always, even if there aren't any trades.

## Description

Fixes the issue where tapping back showed a white screen on the `Create Exchange` view.

## How to Test

1. Build and run
2. Go to the exchange with no trades in your history.
3. It should show an empty exchange history screen. 
4. Tap New Exchange
5. Tap the back button
6. You should return to the empty exchange history screen. 

## Screenshot/Design assessment

![simulator screen shot - iphone x - 2018-09-21 at 13 13 49](https://user-images.githubusercontent.com/41585563/45898645-323bd880-bda0-11e8-9e1c-139847641562.png)

**NOTE: We are still waiting on copy for an empty history**

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
