### PR TITLE
feat(HB): IOS-1312 - All currencies should show when selecting source

### DIFF
--- a/Blockchain/Accounts/AssetAccount.swift
+++ b/Blockchain/Accounts/AssetAccount.swift
@@ -23,3 +23,12 @@ struct AssetAccount {
     /// The name of this account
     let name: String
 }
+
+extension AssetAccount: Equatable {
+    static func == (lhs: AssetAccount, rhs: AssetAccount) -> Bool {
+        return lhs.index == rhs.index &&
+        lhs.address.address == rhs.address.address &&
+        lhs.balance == rhs.balance &&
+        lhs.name == rhs.name
+    }
+}

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -366,11 +366,11 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
 
 extension ExchangeCreateViewController: TradingPairViewDelegate {
     func onLeftButtonTapped(_ view: TradingPairView, title: String) {
-        assetAccountListPresenter.presentPicker(excludingAssetType: toAccount.address.assetType, for: .exchanging)
+        assetAccountListPresenter.presentPicker(excludingAssetType: nil, for: .exchanging)
     }
 
     func onRightButtonTapped(_ view: TradingPairView, title: String) {
-        assetAccountListPresenter.presentPicker(excludingAssetType: fromAccount.address.assetType, for: .receiving)
+        assetAccountListPresenter.presentPicker(excludingAssetType: nil, for: .receiving)
     }
 
     func onSwapButtonTapped(_ view: TradingPairView) {
@@ -390,8 +390,10 @@ extension ExchangeCreateViewController: ExchangeAssetAccountListView {
                 Logger.shared.debug("Selected account titled: '\(account.name)' of type: '\(account.address.assetType.symbol)'")
                 switch action {
                 case .exchanging:
+                    self.toAccount = account == self.toAccount ? self.fromAccount : self.toAccount
                     self.fromAccount = account
                 case .receiving:
+                    self.fromAccount = account == self.fromAccount ? self.toAccount : self.fromAccount
                     self.toAccount = account
                 }
                 self.onTradingPairChanged()

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -296,7 +296,7 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
                 .images(left: fromAsset.brandImage, right: toAsset.brandImage),
                 .titles(left: "", right: "")
             ],
-            transition: .none
+            transition: .crossFade(duration: 0.2)
         )
 
         let presentationUpdate = TradingPairView.TradingPresentationUpdate(
@@ -366,11 +366,11 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
 
 extension ExchangeCreateViewController: TradingPairViewDelegate {
     func onLeftButtonTapped(_ view: TradingPairView, title: String) {
-        assetAccountListPresenter.presentPicker(excludingAssetType: nil, for: .exchanging)
+        assetAccountListPresenter.presentPicker(excludingAssetType: fromAccount.address.assetType, for: .exchanging)
     }
 
     func onRightButtonTapped(_ view: TradingPairView, title: String) {
-        assetAccountListPresenter.presentPicker(excludingAssetType: nil, for: .receiving)
+        assetAccountListPresenter.presentPicker(excludingAssetType: toAccount.address.assetType, for: .receiving)
     }
 
     func onSwapButtonTapped(_ view: TradingPairView) {


### PR DESCRIPTION
## Objective

All currency options should show when selecting a trade option. 

## Description

We're no longer filtering against the selected asset. Also, if they select the asset that matches the other asset in the pair, we swap the two assets. 

## How to Test

1. Build and run
2. Go to the exchange
3. Tap either asset
4. All asset types should be shown

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
