### PR TITLE
feat(Homebrew-Exchange): IOS-1311 update order detail model and cells

### DIFF
--- a/Blockchain/Accounts/AssetAccountRepository.swift
+++ b/Blockchain/Accounts/AssetAccountRepository.swift
@@ -114,3 +114,13 @@ extension AssetAccount {
         )
     }
 }
+
+extension AssetAccountRepository {
+    func nameOfAccountContaining(address: String) -> String {
+        let accounts = allAccounts()
+
+        // TICKET: IOS-1326 - Destination Name on Exchange Locked Screen Should Match Withdrawal Address
+        let destination = accounts.filter({ return $0.address.address == address }).first
+        return destination?.name ?? ""
+    }
+}

--- a/Blockchain/Blockchain-Bridging-Header.h
+++ b/Blockchain/Blockchain-Bridging-Header.h
@@ -64,3 +64,4 @@
 #import "UIView+ChangeFrameAttribute.h"
 
 #import "UILabel+CGRectForSubstring.h"
+#import "UILabel+Animations.h"

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -233,7 +233,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 withReuseIdentifier: ExchangeDetailHeaderView.identifier,
                 for: indexPath
                 ) as? ExchangeDetailHeaderView else { return UICollectionReusableView() }
-            header.title = trade.amountReceivedDisplayValue
+            header.title = trade.amountReceivedCryptoValue + " " + trade.amountReceivedCryptoSymbol
             return header
         }
     }
@@ -253,7 +253,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 height: ExchangeLockedHeaderView.estimatedHeight()
             )
         case .overview(let trade):
-            let title = trade.amountReceivedDisplayValue
+            let title = trade.amountReceivedCryptoValue
             let height = ExchangeDetailHeaderView.height(for: title)
             return CGSize(
                 width: collectionView.bounds.width,

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -237,11 +237,21 @@ class ExchangeDetailCoordinator: NSObject {
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
 
-                let orderId = ExchangeCellModel.Plain(
+                var orderId = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.orderID,
                     value: trade.identifier,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
+                orderId.descriptionActionBlock = {
+                    guard let text = $0.text else { return }
+                    UIPasteboard.general.string = text
+                    $0.animate(
+                        fromText: LocalizationConstants.Exchange.orderID,
+                        toIntermediateText: LocalizationConstants.copiedToClipboard,
+                        speed: 1,
+                        gestureReceiver: $0
+                    )
+                }
                 
                 cellModels.append(contentsOf: [
                     .plain(status),

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -234,7 +234,7 @@ class ExchangeDetailCoordinator: NSObject {
                     guard let text = $0.text else { return }
                     UIPasteboard.general.string = text
                     $0.animate(
-                        fromText: LocalizationConstants.Exchange.orderID,
+                        fromText: trade.identifier,
                         toIntermediateText: LocalizationConstants.copiedToClipboard,
                         speed: 1,
                         gestureReceiver: $0

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -69,12 +69,10 @@ class ExchangeDetailCoordinator: NSObject {
                 let pair = ExchangeCellModel.TradingPair(
                     model: TradingPairView.confirmationModel(for: conversion)
                 )
-                
-                let symbol = conversion.quote.currencyRatio.counter.fiat.symbol
-                
+
                 let value = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.value,
-                    value: symbol + conversion.quote.currencyRatio.counter.fiat.value
+                    value: valueString(for: conversion.quote.currencyRatio.counter.fiat.value, currencyCode: conversion.quote.currencyRatio.counter.fiat.symbol)
                 )
                 
                 let fees = ExchangeCellModel.Plain(
@@ -132,11 +130,9 @@ class ExchangeDetailCoordinator: NSObject {
                     model: TradingPairView.confirmationModel(for: conversion)
                 )
                 
-                let symbol = conversion.quote.currencyRatio.counter.fiat.symbol
-                
                 let value = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.value,
-                    value: symbol + conversion.quote.currencyRatio.counter.fiat.value
+                    value: valueString(for: conversion.quote.currencyRatio.counter.fiat.value, currencyCode: conversion.quote.currencyRatio.counter.fiat.symbol)
                 )
                 
                 let fees = ExchangeCellModel.Plain(
@@ -196,7 +192,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let value = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.value,
-                    value: trade.amountFiatSymbol + trade.amountFiatValue,
+                    value: valueString(for: trade.amountFiatValue, currencyCode: trade.amountFiatSymbol),
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
                 
@@ -268,3 +264,16 @@ class ExchangeDetailCoordinator: NSObject {
     }
 }
 // swiftlint:enable function_body_length
+
+extension ExchangeDetailCoordinator {
+    // TICKET: IOS-1328 Find a better place for this
+    func valueString(for amount: String, currencyCode: String) -> String {
+        if let currencySymbol =  BlockchainSettings.sharedAppInstance().fiatSymbolFromCode(currencyCode: currencyCode) {
+            // $2.34
+            return currencySymbol + amount
+        } else {
+            // 2.34 USD
+            return amount + " " + currencyCode
+        }
+    }
+}

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -217,7 +217,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let sendTo = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.sendTo,
-                    value: accountRepository.nameOfAccountContaining(address: trade.depositAddress),
+                    value: accountRepository.nameOfAccountContaining(address: trade.withdrawalAddress),
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
 

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -88,15 +88,9 @@ class ExchangeDetailCoordinator: NSObject {
                     bold: true
                 )
                 
-                let accounts = accountRepository.allAccounts()
-                
-                // TICKET: IOS-1326 - Destination Name on Exchange Locked Screen Should Match Withdrawal Address
-                let destination = accounts.filter({ return $0.address.address == orderTransaction.to.address }).first
-                let destinationName = destination?.name ?? ""
-                
                 let sendTo = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.sendTo,
-                    value: destinationName
+                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.to.address)
                 )
                 
                 let paragraphStyle = NSMutableParagraphStyle()
@@ -156,15 +150,9 @@ class ExchangeDetailCoordinator: NSObject {
                     bold: true
                 )
                 
-                let accounts = accountRepository.allAccounts()
-                
-                // TICKET: IOS-1326 - Destination Name on Exchange Locked Screen Should Match Withdrawal Address
-                let destination = accounts.filter({ return $0.address.address == orderTransaction.to.address }).first
-                let destinationName = destination?.name ?? ""
-                
                 let sendTo = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.sendTo,
-                    value: destinationName
+                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.to.address)
                 )
                 
                 let paragraphStyle = NSMutableParagraphStyle()
@@ -227,13 +215,13 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let fees = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.fees,
-                    value: "0.000414 BTC",
+                    value: trade.amountFeeSymbol + " " + trade.amountFeeValue,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
                 
                 let sendTo = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.sendTo,
-                    value: "My Wallet",
+                    value: accountRepository.nameOfAccountContaining(address: trade.depositAddress),
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
 

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -196,7 +196,7 @@ class ExchangeDetailCoordinator: NSObject {
                 delegate?.coordinator(self, updated: cellModels)
             case .overview(let trade):
                 interface?.updateBackgroundColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))
-                interface?.updateTitle(LocalizationConstants.Exchange.orderID + " " + trade.identifier)
+                interface?.updateTitle(trade.amountReceivedCryptoValue + LocalizationConstants.Exchange.orderID + " " + trade.identifier)
                 interface?.navigationBarVisibility(.visible)
                 
                 let status = ExchangeCellModel.Plain(
@@ -208,19 +208,19 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let value = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.value,
-                    value: "$1,642.50",
+                    value: trade.amountFiatSymbol + trade.amountFiatValue,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
                 
                 let exchange = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.exchange,
-                    value: "$0.25 BTC",
+                    value: trade.amountDepositedCryptoValue + " " + trade.amountDepositedCryptoSymbol,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
                 
                 let receive = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.receive,
-                    value: "5.668586",
+                    value: trade.amountReceivedCryptoValue + " " + trade.amountReceivedCryptoSymbol,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1),
                     bold: true
                 )
@@ -236,6 +236,12 @@ class ExchangeDetailCoordinator: NSObject {
                     value: "My Wallet",
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
+
+                let orderId = ExchangeCellModel.Plain(
+                    description: LocalizationConstants.Exchange.orderID,
+                    value: trade.identifier,
+                    backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
+                )
                 
                 cellModels.append(contentsOf: [
                     .plain(status),
@@ -243,7 +249,8 @@ class ExchangeDetailCoordinator: NSObject {
                     .plain(exchange),
                     .plain(receive),
                     .plain(fees),
-                    .plain(sendTo)
+                    .plain(sendTo),
+                    .plain(orderId)
                     ]
                 )
                 

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -88,7 +88,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let sendTo = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.sendTo,
-                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.to.address)
+                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.destination)
                 )
                 
                 let paragraphStyle = NSMutableParagraphStyle()
@@ -148,7 +148,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let sendTo = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.sendTo,
-                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.to.address)
+                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.destination)
                 )
                 
                 let paragraphStyle = NSMutableParagraphStyle()

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -211,7 +211,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let fees = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.fees,
-                    value: trade.amountFeeSymbol + " " + trade.amountFeeValue,
+                    value: trade.amountFeeValue + " " + trade.amountFeeSymbol,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
                 

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeCellModel.swift
@@ -18,13 +18,17 @@ enum ExchangeCellModel {
     case text(Text)
     case tradingPair(TradingPair)
     
+    typealias LabelAction = ((UILabel) -> Void)
+
     struct Plain {
         let description: String
         let value: String
         let backgroundColor: UIColor
         let statusVisibility: Visibility
         let bold: Bool
-        
+
+        var descriptionActionBlock: LabelAction?
+
         init(description: String, value: String, backgroundColor: UIColor = .white, statusVisibility: Visibility = .hidden, bold: Bool = false) {
             self.description = description
             self.value = value

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -73,13 +73,13 @@ enum ExchangeTradeModel {
 }
 
 extension ExchangeTradeModel {
-    var depositAddress: String {
+    var withdrawalAddress: String {
         switch self {
         case .partner:
             // Not in ExchangeTableViewCell
             return ""
         case .homebrew(let model):
-            return model.depositAddress
+            return model.withdrawalAddress
         }
     }
 

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -73,20 +73,57 @@ enum ExchangeTradeModel {
 }
 
 extension ExchangeTradeModel {
+    var amountFiatValue: String {
+        switch self {
+        case .partner(_):
+            // Currently calculated in ExchangeTableViewCell based on latest rates
+            return ""
+        case .homebrew(let model):
+            return model.fiatValue.value
+        }
+    }
     
-    var amountDepositedDisplayValue: String {
+    var amountFiatSymbol: String {
+        switch self {
+        case .partner(_):
+            // Currently calculated in ExchangeTableViewCell cell based on latest rates
+            return ""
+        case .homebrew(let model):
+            return model.fiatValue.symbol
+        }
+    }
+
+    var amountDepositedCryptoValue: String {
         switch self {
         case .partner(let model):
-            return model.amountDepositedDisplayValue
+            return model.amountDepositedCryptoValue
         case .homebrew(let model):
             return model.deposit.value
         }
     }
     
-    var amountReceivedDisplayValue: String {
+    var amountDepositedCryptoSymbol: String {
         switch self {
         case .partner(let model):
-            return model.amountReceivedDisplayValue
+            return model.pair.from.symbol
+        case .homebrew(let model):
+            return model.deposit.symbol
+        }
+    }
+
+    var amountReceivedCryptoSymbol: String {
+        switch self {
+        case .partner(let model):
+            return model.pair.to.symbol
+        case .homebrew(let model):
+            return model.withdrawal.symbol
+        }
+    }
+
+    var amountReceivedCryptoValue: String {
+        switch self {
+        case .partner(let model):
+            return model.amountReceivedCryptoValue
         case .homebrew(let model):
             return model.withdrawal.value
         }
@@ -138,8 +175,8 @@ struct PartnerTrade {
     let assetType: AssetType
     let pair: TradingPair
     let transactionDate: Date
-    let amountReceivedDisplayValue: String
-    let amountDepositedDisplayValue: String
+    let amountReceivedCryptoValue: String
+    let amountDepositedCryptoValue: String
     
     init(with trade: ExchangeTrade) {
         identifier = trade.orderID
@@ -152,13 +189,13 @@ struct PartnerTrade {
         }
         
         if let value = trade.inboundDisplayAmount() {
-            amountReceivedDisplayValue = value
+            amountReceivedCryptoValue = value
         } else {
             fatalError("Failed to map \(trade.inboundDisplayAmount() ?? "")")
         }
         
         if let value = trade.outboundDisplayAmount() {
-            amountDepositedDisplayValue = value
+            amountDepositedCryptoValue = value
         } else {
             fatalError("Failed to map \(trade.outboundDisplayAmount() ?? "")")
         }

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -73,9 +73,39 @@ enum ExchangeTradeModel {
 }
 
 extension ExchangeTradeModel {
+    var depositAddress: String {
+        switch self {
+        case .partner:
+            // Not in ExchangeTableViewCell
+            return ""
+        case .homebrew(let model):
+            return model.depositAddress
+        }
+    }
+
+    var amountFeeSymbol: String {
+        switch self {
+        case .partner:
+            // Not in ExchangeTableViewCell
+            return ""
+        case .homebrew(let model):
+            return model.withdrawalFee.symbol
+        }
+    }
+
+    var amountFeeValue: String {
+        switch self {
+        case .partner:
+            // Not in ExchangeTableViewCell
+            return ""
+        case .homebrew(let model):
+            return model.withdrawalFee.value
+        }
+    }
+
     var amountFiatValue: String {
         switch self {
-        case .partner(_):
+        case .partner:
             // Currently calculated in ExchangeTableViewCell based on latest rates
             return ""
         case .homebrew(let model):
@@ -85,7 +115,7 @@ extension ExchangeTradeModel {
     
     var amountFiatSymbol: String {
         switch self {
-        case .partner(_):
+        case .partner:
             // Currently calculated in ExchangeTableViewCell cell based on latest rates
             return ""
         case .homebrew(let model):

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -263,9 +263,9 @@ struct ExchangeTradeCellModel: Decodable {
     enum CodingKeys: String, CodingKey {
         case identifier = "id"
         case status = "state"
-        case createdAt = "createdAt"
-        case updatedAt = "insertedAt"
-        case pair = "pair"
+        case createdAt
+        case updatedAt
+        case pair
         case refundAddress
         case rate
         case depositAddress

--- a/Blockchain/Homebrew/Exchange/Models/Order.swift
+++ b/Blockchain/Homebrew/Exchange/Models/Order.swift
@@ -72,6 +72,11 @@ struct OrderResult: Codable {
 }
 
 struct OrderTransaction {
+    // The destination is where the user will ultimately receive
+    // funds from the exchange.
+    let destination: String
+
+    // Details of payment constructed in Wallet JS
     let from: AssetAccount
     let to: AssetAddress
     let amountToSend: String

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -90,6 +90,7 @@ class TradeExecutionService: TradeExecutionAPI {
                     let fromAddress = AssetAddressFactory.create(fromAddressString: addressString!, assetType: assetType)
                     let to = AssetAddressFactory.create(fromAddressString: orderTransactionLegacy.to, assetType: assetType)
                     let orderTransaction = OrderTransaction(
+                        destination: payload.withdrawalAddress,
                         from: AssetAccount(
                             index: 0,
                             address: fromAddress,

--- a/Blockchain/Homebrew/Exchange/Views/Cells/DetailCollectionViewCells/Plain/PlainCell.swift
+++ b/Blockchain/Homebrew/Exchange/Views/Cells/DetailCollectionViewCells/Plain/PlainCell.swift
@@ -18,7 +18,11 @@ class PlainCell: ExchangeDetailCell {
     @IBOutlet fileprivate var subject: UILabel!
     @IBOutlet fileprivate var descriptionLabel: UILabel!
     @IBOutlet fileprivate var statusImageView: UIImageView!
-    
+
+    // MARK: Private Properties
+
+    fileprivate var tapActionBlock: ExchangeCellModel.LabelAction?
+
     // MARK: Overrides
     
     override func configure(with model: ExchangeCellModel) {
@@ -33,6 +37,13 @@ class PlainCell: ExchangeDetailCell {
         subject.textColor = payload.bold ? .darkGray : #colorLiteral(red: 0.64, green: 0.64, blue: 0.64, alpha: 1)
         statusImageView.alpha = payload.statusVisibility.defaultAlpha
         statusImageView.tintColor = .green
+
+        if let action = payload.descriptionActionBlock {
+            tapActionBlock = action
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(descriptionLabelTapped(sender:)))
+            descriptionLabel.isUserInteractionEnabled = true
+            descriptionLabel.addGestureRecognizer(tapGesture)
+        }
     }
     
     override class func heightForProposedWidth(_ width: CGFloat, model: ExchangeCellModel) -> CGFloat {
@@ -71,5 +82,11 @@ class PlainCell: ExchangeDetailCell {
                 ofSize: 16,
                 weight: .regular
         )
+    }
+
+    @objc private func descriptionLabelTapped(sender: UITapGestureRecognizer) {
+        if let action = tapActionBlock, let label = sender.view as? UILabel {
+            action(label)
+        }
     }
 }

--- a/Blockchain/Homebrew/Exchange/Views/Cells/DetailCollectionViewCells/Plain/PlainCell.xib
+++ b/Blockchain/Homebrew/Exchange/Views/Cells/DetailCollectionViewCells/Plain/PlainCell.xib
@@ -49,6 +49,7 @@
             <constraints>
                 <constraint firstItem="S4B-a6-Y1K" firstAttribute="centerY" secondItem="bHQ-2I-DWr" secondAttribute="centerY" id="1L7-Fb-DXr"/>
                 <constraint firstItem="cwq-wf-eG2" firstAttribute="leading" secondItem="An4-ti-8es" secondAttribute="leading" constant="16" id="BKG-ad-ALL"/>
+                <constraint firstItem="bHQ-2I-DWr" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cwq-wf-eG2" secondAttribute="trailing" constant="8" id="RdM-cv-JEF"/>
                 <constraint firstAttribute="trailing" secondItem="bHQ-2I-DWr" secondAttribute="trailing" constant="16" id="UWl-4X-6bl"/>
                 <constraint firstItem="bHQ-2I-DWr" firstAttribute="leading" secondItem="S4B-a6-Y1K" secondAttribute="trailing" constant="4" id="ocM-MH-Vus"/>
                 <constraint firstItem="bHQ-2I-DWr" firstAttribute="centerY" secondItem="5LF-w3-Spa" secondAttribute="centerY" id="oiN-xt-TVB"/>

--- a/Blockchain/Homebrew/Exchange/Views/Cells/ExchangeListViewCell.swift
+++ b/Blockchain/Homebrew/Exchange/Views/Cells/ExchangeListViewCell.swift
@@ -24,8 +24,8 @@ class ExchangeListViewCell: UITableViewCell {
 
     func configure(with cellModel: ExchangeTradeModel) {
         timestamp.text = cellModel.formattedDate
-        depositAmount.text = "-" + cellModel.amountDepositedDisplayValue
-        receivedAmount.text = cellModel.amountReceivedDisplayValue
+        depositAmount.text = "-" + cellModel.amountDepositedCryptoValue
+        receivedAmount.text = cellModel.amountReceivedCryptoValue
         
         status.text = cellModel.status.displayValue
 
@@ -33,7 +33,7 @@ class ExchangeListViewCell: UITableViewCell {
     }
 
     class func estimatedHeight(for model: ExchangeTradeModel) -> CGFloat {
-        let received = model.amountReceivedDisplayValue
+        let received = model.amountReceivedCryptoValue
         let status = model.status.displayValue
         
         guard let receivedFont = UIFont(name: Constants.FontNames.montserratRegular, size: 16) else { return 0.0 }

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -63,6 +63,10 @@ struct LocalizationConstants {
         "Loading",
         comment: "Text displayed when there is an asynchronous action that needs to complete before the user can take further action."
     )
+    static let copiedToClipboard = NSLocalizedString(
+        "Copied to clipboard",
+        comment: "Text displayed when a user has tapped on an item to copy its text."
+    )
 
     struct Errors {
         static let genericError = NSLocalizedString(

--- a/Blockchain/Settings/BlockchainSettings.swift
+++ b/Blockchain/Settings/BlockchainSettings.swift
@@ -141,6 +141,13 @@ final class BlockchainSettings: NSObject {
             return WalletManager.shared.latestMultiAddressResponse?.symbol_local.code
         }
 
+        @objc func fiatSymbolFromCode(currencyCode: String) -> String?  {
+            guard let currencyCodeDict = WalletManager.shared.wallet.btcRates[currencyCode] as? [String: Any] else {
+                return nil
+            }
+            return currencyCodeDict["symbol"] as? String
+        }
+
         /// The first 5 characters of SHA256 hash of the user's password
         @objc var passwordPartHash: String? {
             get {


### PR DESCRIPTION
## Objective

Update the detail screen for the Exchange List view controller.

## Description

- Updated model and cells for order detail.
- Minor fixes and refactoring in the `ExchangeDetailCoordinator`.
- Added tap gesture and small animation to copy order ID to clipboard.

## How to Test

Go to Exchange List controller and tap on a transaction. If server is down, cherry-pick 3975b4c74 to show a mock transaction.

## Screenshot/Design assessment

Not there 100%, but the essential data is there. (Put your own address as `withdrawalAddress` in the mock data to test Send To)
![simulator screen shot - iphone 5s - 2018-09-22 at 11 32 32](https://user-images.githubusercontent.com/10579422/45918890-485a9f00-be5b-11e8-92e6-1db2ec2c49d5.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
