### PR TITLE
fix(Notifications): restore device registration for push notifications

### DIFF
--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -246,8 +246,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
-        NetworkManager.registerDeviceForPushNotifications(withDeviceToken: token)
+        if !application.isRegisteredForRemoteNotifications {
+            let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+            NetworkManager.registerDeviceForPushNotifications(withDeviceToken: token)
+        }
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -246,10 +246,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        if !application.isRegisteredForRemoteNotifications {
-            let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
-            NetworkManager.registerDeviceForPushNotifications(withDeviceToken: token)
-        }
+        let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+        NetworkManager.registerDeviceForPushNotifications(withDeviceToken: token)
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -245,6 +245,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         )
     }
 
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+        NetworkManager.registerDeviceForPushNotifications(withDeviceToken: token)
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        // TICKET: IOS-1329 - Push Notifications | Implement didFailToRegisterForRemoteNotificationsWithError
+    }
+
     // MARK: - State Checks
 
     func checkForNewInstall() {

--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -251,7 +251,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        // TICKET: IOS-1329 - Push Notifications | Implement didFailToRegisterForRemoteNotificationsWithError
+        // TICKET: IOS-1329 - Implement didFailToRegisterForRemoteNotificationsWithError
     }
 
     // MARK: - State Checks

--- a/Blockchain/Network/Extensions/NetworkManager+PushNotifications.swift
+++ b/Blockchain/Network/Extensions/NetworkManager+PushNotifications.swift
@@ -29,13 +29,11 @@ extension NetworkManager {
                 Logger.shared.error("Error registering device with backend: \(error!.localizedDescription)")
                 return
             }
-            guard
-                let httpResponse = response as? HTTPURLResponse,
+            guard let httpResponse = response as? HTTPURLResponse,
                 (200...299).contains(httpResponse.statusCode) else {
                     return
             }
-            guard
-                let json = try? JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: AnyObject],
+            guard let json = try? JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: AnyObject],
                 let success = json!["success"] as? Bool, success == true else {
                     return
             }


### PR DESCRIPTION
## Objective

Restore the ability to register the device for push notifications with the back-end.

## Description

Implemented `didRegisterForRemoteNotificationsWithDeviceToken` to get the device token and make a call to `registerDeviceForPushNotifications` in `NetworkManager`.

## How to Test

On device only, create a new wallet and accept the push notification permission alert.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
