### PR TITLE
fix(HB): Fixes issue where tapping New Exchange showed exchange details.

### DIFF
--- a/Blockchain/Homebrew/Exchange/DataProviders/ExchangeListDataProvider.swift
+++ b/Blockchain/Homebrew/Exchange/DataProviders/ExchangeListDataProvider.swift
@@ -191,6 +191,7 @@ extension ExchangeListDataProvider: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let items = models else { return }
+        guard indexPath.section == 1 else { return }
         guard items.count > indexPath.row else { return }
         let model = items[indexPath.row]
         delegate?.dataProvider(self, didSelect: model)

--- a/Blockchain/Homebrew/Exchange/Views/Cells/NewOrderTableViewCell.xib
+++ b/Blockchain/Homebrew/Exchange/Views/Cells/NewOrderTableViewCell.xib
@@ -15,7 +15,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="96" id="xHD-ko-GKd" customClass="NewOrderTableViewCell" customModule="Blockchain" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="96" id="xHD-ko-GKd" customClass="NewOrderTableViewCell" customModule="Blockchain" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="375" height="96"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xHD-ko-GKd" id="pho-YZ-fLA">


### PR DESCRIPTION
## Objective

Fixes the selection style of `NewOrderTableViewCell` and fixes selecting the incorrect `indexPath` shows the `ExchangeOverview` screen. 

## How to Test

1. Build and run
2. Go to the new exchange flow
3. Select the `New Order` cell (but don't tap the button). 
4. It should not show a selection style and it should not show the `ExchangeOverview` screen

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
