### PR TITLE
fix(KYC): correctly present ExchangeCoordinator

### DIFF
--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -53,6 +53,8 @@ protocol KYCCoordinatorDelegate: class {
 
     private(set) var country: KYCCountry?
 
+    private var rootViewController: UIViewController?
+
     fileprivate var navController: KYCOnboardingNavigationController!
 
     private let pageFactory = KYCPageViewFactory()
@@ -76,6 +78,7 @@ protocol KYCCoordinatorDelegate: class {
     }
 
     @objc func start(from viewController: UIViewController) {
+        rootViewController = viewController
         LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.loading)
         let disposable = BlockchainDataRepository.shared.fetchNabuUser()
             .subscribeOn(MainScheduler.asyncInstance)
@@ -131,7 +134,11 @@ protocol KYCCoordinatorDelegate: class {
             switch status {
             case .approved:
                 viewController.dismiss(animated: true) {
-                    ExchangeCoordinator.shared.start()
+                    guard let viewController = self.rootViewController else {
+                        Logger.shared.error("View controller to present on is nil.")
+                        return
+                    }
+                    ExchangeCoordinator.shared.start(rootViewController: viewController)
                 }
             case .pending:
                 PushNotificationManager.shared.requestAuthorization()

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -53,7 +53,7 @@ protocol KYCCoordinatorDelegate: class {
 
     private(set) var country: KYCCountry?
 
-    private var rootViewController: UIViewController?
+    private weak var rootViewController: UIViewController?
 
     fileprivate var navController: KYCOnboardingNavigationController!
 


### PR DESCRIPTION
## Objective

Correctly present the `ExchangeCoordinator` on the _account approved_ screen, when the user taps on **Get Started**.

## Description

By storing a reference to the rootViewController, the `ExchangeCoordinator` is able to be presented correctly.

## How to Test

Using a verified user, open Settings and tap on the _Identity Verification_ cell. On the _Account Approved_ screen, tap **Get Started**. Observe that it presents the Exchange correctly.

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
