### PR TITLE
feat(HB): Adding `BounceButton`

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -225,6 +225,8 @@
 		3AE92BDD2110DF33008D7BDC /* NotificationCenter+Conveniences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE92BDC2110DF33008D7BDC /* NotificationCenter+Conveniences.swift */; };
 		3AE92BDE2110DF33008D7BDC /* NotificationCenter+Conveniences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE92BDC2110DF33008D7BDC /* NotificationCenter+Conveniences.swift */; };
 		3AEF9E8C21091B72006B1CF9 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AEF9E8B21091B71006B1CF9 /* MapKit.framework */; };
+		3AFB65EE215585DF00EBFF30 /* BounceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFB65ED215585DF00EBFF30 /* BounceButton.swift */; };
+		3AFB65EF215585DF00EBFF30 /* BounceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFB65ED215585DF00EBFF30 /* BounceButton.swift */; };
 		3AFD18AD21221D40007145EA /* KYCBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8B229E2122117A0091E706 /* KYCBaseViewController.swift */; };
 		3AFD18AF21221D95007145EA /* KYCPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFD18AE21221D95007145EA /* KYCPageModel.swift */; };
 		51058EFE212F327E00AD8719 /* KYCApplicationCompleteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51058EFD212F327E00AD8719 /* KYCApplicationCompleteController.swift */; };
@@ -1406,6 +1408,7 @@
 		3AE92BDA2110DB3C008D7BDC /* KeyboardPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPayload.swift; sourceTree = "<group>"; };
 		3AE92BDC2110DF33008D7BDC /* NotificationCenter+Conveniences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationCenter+Conveniences.swift"; sourceTree = "<group>"; };
 		3AEF9E8B21091B71006B1CF9 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
+		3AFB65ED215585DF00EBFF30 /* BounceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BounceButton.swift; sourceTree = "<group>"; };
 		3AFD18AE21221D95007145EA /* KYCPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCPageModel.swift; sourceTree = "<group>"; };
 		404A01EFD6ABF02E4F6F337A /* Pods-Blockchain.debug production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Blockchain.debug production.xcconfig"; path = "Pods/Target Support Files/Pods-Blockchain/Pods-Blockchain.debug production.xcconfig"; sourceTree = "<group>"; };
 		51058EFD212F327E00AD8719 /* KYCApplicationCompleteController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KYCApplicationCompleteController.swift; sourceTree = "<group>"; };
@@ -3838,6 +3841,14 @@
 				3AE92BDA2110DB3C008D7BDC /* KeyboardPayload.swift */,
 			);
 			path = Keyboard;
+			sourceTree = "<group>";
+		};
+		3AFB65E3215585B500EBFF30 /* Buttons */ = {
+			isa = PBXGroup;
+			children = (
+				3AFB65ED215585DF00EBFF30 /* BounceButton.swift */,
+			);
+			path = Buttons;
 			sourceTree = "<group>";
 		};
 		51042C8820B1FDA600B022DE /* PrivateKeyReader */ = {
@@ -7017,6 +7028,7 @@
 		C9D4B2B2193E032200EDA9EA /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				3AFB65E3215585B500EBFF30 /* Buttons */,
 				C70576B1212CFFFC0027C6AA /* Nibable.swift */,
 				C78238CF2131FA34008FCCAD /* Keypad */,
 				3A76F8FC211A0665002F7946 /* ValidationForm */,
@@ -7970,6 +7982,7 @@
 				C7343C1821516A64001B1EC9 /* ExchangeDetailPresenter.swift in Sources */,
 				5114EA2420CD8B900098E26E /* UINavigationBar+TitleAttributes.swift in Sources */,
 				AA3CA9B02107F18D00C2AD46 /* Logger.swift in Sources */,
+				3AFB65EF215585DF00EBFF30 /* BounceButton.swift in Sources */,
 				3A9B7F122135CF9800754FD6 /* NetworkRequest.swift in Sources */,
 				AA126CE6212C99FF005886A3 /* KYCPageViewFactory.swift in Sources */,
 				3AB4D91B21309BCC004F0160 /* ExchangeListDataProvider.swift in Sources */,
@@ -8105,6 +8118,7 @@
 				84FC02FD19815F1B00B97D5B /* crypto_scrypt-nosse.c in Sources */,
 				602B9CE82118E15300BD3D60 /* LocationSuggestion.swift in Sources */,
 				AA447BC82127679A00EC0FA0 /* SideMenuViewController.swift in Sources */,
+				3AFB65EE215585DF00EBFF30 /* BounceButton.swift in Sources */,
 				C73406221F54791C00143100 /* EtherAmountInputViewController.m in Sources */,
 				51A7349320891EB3009727D5 /* NetworkManager.swift in Sources */,
 				606399EA2110FC2D005B6DF5 /* SRDelegateController.m in Sources */,

--- a/Blockchain/Views/Buttons/BounceButton.swift
+++ b/Blockchain/Views/Buttons/BounceButton.swift
@@ -1,0 +1,67 @@
+//
+//  BounceButton.swift
+//  Blockchain
+//
+//  Created by AlexM on 9/21/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+class BounceButton: UIButton {
+    
+    fileprivate var scaleUpAnimationDuration: TimeInterval = 0.05
+    
+    fileprivate var scaleDownAnimationDuration: TimeInterval = 0.02
+    
+    fileprivate var selectedScale: CGAffineTransform = {
+        return CGAffineTransform(scaleX: 1.5, y: 1.5)
+    }()
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        scaleUp()
+    }
+    
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesMoved(touches, with: event)
+        guard let touch = touches.first else { return }
+        let point = touch.location(in: self)
+        bounds.contains(point) ? scaleUp() : scaleDown()
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        scaleDown()
+    }
+    
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event)
+        scaleDown()
+    }
+    
+    // MARK: Private
+    
+    fileprivate func scaleUp(_ block: (() -> Void)? = nil) {
+        guard transform != selectedScale else { return }
+        UIView.animate(
+            withDuration: scaleUpAnimationDuration,
+            delay: 0.0,
+            options: [.curveEaseIn],
+            animations: {
+                self.transform = self.selectedScale
+        },
+            completion: nil)
+    }
+    
+    fileprivate func scaleDown() {
+        guard transform != .identity else { return }
+        UIView.animate(
+            withDuration: scaleDownAnimationDuration,
+            delay: 0.0,
+            options: [],
+            animations: {
+                self.transform = .identity
+        }, completion: nil
+        )
+    }
+    
+}

--- a/Blockchain/Views/Keypad/NumberKeypadView.xib
+++ b/Blockchain/Views/Keypad/NumberKeypadView.xib
@@ -41,31 +41,40 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qpy-Gp-51b">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="75"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NCn-ay-Eff">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NCn-ay-Eff" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="119.5" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="1">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
                                     <connections>
-                                        <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="xkC-zv-REz"/>
+                                        <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="YFz-Rp-wFZ"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aYO-De-n4k">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aYO-De-n4k" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="127.5" y="0.0" width="120" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="2">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
                                     <connections>
                                         <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="M3w-Cc-KVn"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PkX-kC-KSG">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PkX-kC-KSG" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="255.5" y="0.0" width="119.5" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="3">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
                                     <connections>
                                         <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="zRI-6C-SH5"/>
@@ -81,31 +90,40 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="0mb-Ql-dnE">
                             <rect key="frame" x="0.0" y="75" width="375" height="75"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ctr-Ct-wVn">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ctr-Ct-wVn" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="119.5" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="4">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
                                     <connections>
                                         <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="Z24-09-4KO"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ICd-bU-rTb">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ICd-bU-rTb" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="127.5" y="0.0" width="120" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="5">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
                                     <connections>
                                         <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="7ca-mZ-t5Y"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5mu-Rh-ATf">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5mu-Rh-ATf" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="255.5" y="0.0" width="119.5" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="6">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
                                     <connections>
                                         <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="vD7-QF-lvB"/>
@@ -121,31 +139,40 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="5tD-GM-aT7">
                             <rect key="frame" x="0.0" y="150" width="375" height="75"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yuq-1L-HoU">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yuq-1L-HoU" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="119.5" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="7">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
                                     <connections>
                                         <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="Yia-Mz-aCo"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SDk-qh-2Hi">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SDk-qh-2Hi" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="127.5" y="0.0" width="120" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="8">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
                                     <connections>
                                         <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="Idj-6v-RJp"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vOX-WC-Mc9">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vOX-WC-Mc9" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="255.5" y="0.0" width="119.5" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="9">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
                                     <connections>
                                         <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="lab-z7-Qni"/>
@@ -161,7 +188,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="JG9-Ux-Uyy">
                             <rect key="frame" x="0.0" y="225" width="375" height="75"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sr2-Ia-gcZ" userLabel="Decimal">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sr2-Ia-gcZ" userLabel="Decimal" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="119.5" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title=".">
@@ -171,17 +198,20 @@
                                         <action selector="delimiterButtonTapped:" destination="-1" eventType="touchUpInside" id="5td-FV-uZB"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kma-Kx-hJu">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kma-Kx-hJu" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="127.5" y="0.0" width="120" height="75"/>
                                     <fontDescription key="fontDescription" name="Montserrat-Medium" family="Montserrat" pointSize="19"/>
                                     <state key="normal" title="0">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.16862745100000001" green="0.29411764709999999" blue="0.47450980390000003" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
                                     <connections>
                                         <action selector="numberButtonTapped:" destination="-1" eventType="touchUpInside" id="2yB-KY-1gg"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="center" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sq4-OM-1dd" userLabel="Backspace">
+                                <button opaque="NO" contentMode="center" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sq4-OM-1dd" userLabel="Backspace" customClass="BounceButton" customModule="Blockchain" customModuleProvider="target">
                                     <rect key="frame" x="255.5" y="0.0" width="119.5" height="75"/>
                                     <state key="normal" image="backspace">
                                         <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>


### PR DESCRIPTION
## Objective

Shows a small transform animation when the user taps on a button in the number pad.

## Description

The buttons in `NumberKeypadView` are now `BounceButtons` which scale up or down depending on their selection state. 

## How to Test

1. Build and run
2. Go to the exchange screen
3. Interact with the number pad.
4. The buttons should animate. 

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [x] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
