### PR TITLE
fix(KYC): IOS-1269 fix previous Nabu user not being cleared when creating a new wallet.

### DIFF
--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -314,10 +314,6 @@ extension AppCoordinator: SideMenuViewControllerDelegate {
         BuySellCoordinator.shared.showBuyBitcoinView()
     }
     
-    private func handleLaunchKYC() {
-        KYCCoordinator.shared.start()
-    }
-    
     private func handleExchange() {
         ExchangeCoordinator.shared.start(rootViewController: self.tabControllerManager)
     }

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -49,8 +49,6 @@ struct ExchangeServices: ExchangeDependencies {
         case shapeshift
     }
 
-    private(set) var user: NabuUser?
-
     static let shared = ExchangeCoordinator()
 
     // class function declared so that the ExchangeCoordinator singleton can be accessed from obj-C
@@ -79,15 +77,11 @@ struct ExchangeServices: ExchangeDependencies {
     // MARK: - Entry Point
 
     func start() {
-        if let theUser = user, theUser.status == .approved {
-            showAppropriateExchange(); return
-        }
         disposable = BlockchainDataRepository.shared.nabuUser
             .subscribeOn(MainScheduler.asyncInstance)
             .observeOn(MainScheduler.instance)
             .subscribe(onSuccess: { [unowned self] in
-                self.user = $0
-                guard self.user?.status == .approved else {
+                guard $0.status == .approved else {
                     KYCCoordinator.shared.start(); return
                 }
                 self.showAppropriateExchange()


### PR DESCRIPTION
## Objective

Fix bug where previous Nabu user not being cleared when logging out, and creating a new wallet. 

## How to Test

Create a wallet, go through KYC, log out, create new wallet, verify that when tapping on "Exchange" you are forced to go through the KYC process again.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
