### PR TITLE
fix(Homebrew-Exchange): IOS-1346 adjust keyboard height to 37.5% of superview

### DIFF
--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -31,7 +31,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf" userLabel="Fiat Button">
-                                <rect key="frame" x="311.5" y="100" width="70" height="70"/>
+                                <rect key="frame" x="311.5" y="105.5" width="70" height="70"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="70" id="4dm-4V-5VL"/>
                                     <constraint firstAttribute="height" constant="70" id="fWa-MZ-Ert"/>
@@ -42,7 +42,7 @@
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="5uc-t6-nYA">
-                                <rect key="frame" x="16" y="224" width="343" height="44"/>
+                                <rect key="frame" x="16" y="241" width="343" height="44"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gyg-rh-rE6">
                                         <rect key="frame" x="0.0" y="0.0" width="163.5" height="44"/>
@@ -70,15 +70,15 @@
                                 </constraints>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hcw-SG-3XL" customClass="ConversionRatesView" customModule="Blockchain" customModuleProvider="target">
-                                <rect key="frame" x="15.5" y="344" width="343" height="227"/>
+                                <rect key="frame" x="15.5" y="359.5" width="343" height="213"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dfm-a1-ad2" customClass="NumberKeypadView" customModule="Blockchain" customModuleProvider="target">
-                                <rect key="frame" x="16" y="324" width="343" height="267"/>
+                                <rect key="frame" x="16" y="341" width="343" height="250"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eA3-pM-NKs">
-                                <rect key="frame" x="16" y="276" width="343" height="32"/>
+                                <rect key="frame" x="16" y="293" width="343" height="32"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 BTC = 22.19 ETH" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9l-S4-AAj">
                                         <rect key="frame" x="122" y="8.5" width="99" height="15"/>
@@ -137,13 +137,13 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$200.42" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okC-2w-xB9">
-                                <rect key="frame" x="154.5" y="177.5" width="65.5" height="38.5"/>
+                                <rect key="frame" x="154.5" y="189" width="65.5" height="44"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0.01 BTC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
-                                <rect key="frame" x="16" y="96" width="342.5" height="77.5"/>
+                                <rect key="frame" x="16" y="96" width="342.5" height="89"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="34"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -174,7 +174,7 @@
                             <constraint firstItem="eA3-pM-NKs" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="enm-Og-Fbn"/>
                             <constraint firstItem="cbA-yh-J0A" firstAttribute="trailing" secondItem="V30-pI-8jo" secondAttribute="trailing" id="fCT-6x-0Y5"/>
                             <constraint firstItem="V30-pI-8jo" firstAttribute="top" secondItem="FIv-WY-bvA" secondAttribute="top" constant="8" id="fNG-KC-mpx"/>
-                            <constraint firstItem="dfm-a1-ad2" firstAttribute="height" relation="lessThanOrEqual" secondItem="jre-mq-FDr" secondAttribute="height" multiplier="0.4" id="jtO-7D-eg1"/>
+                            <constraint firstItem="dfm-a1-ad2" firstAttribute="height" secondItem="jre-mq-FDr" secondAttribute="height" multiplier="0.375" id="jtO-7D-eg1"/>
                             <constraint firstItem="okC-2w-xB9" firstAttribute="centerX" secondItem="cbA-yh-J0A" secondAttribute="centerX" id="kRJ-eC-1n8"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="bottom" secondItem="DUe-4D-nhJ" secondAttribute="bottom" constant="16" id="oTE-Cd-lXS"/>
                             <constraint firstItem="cbA-yh-J0A" firstAttribute="leading" secondItem="V30-pI-8jo" secondAttribute="leading" id="p9e-tX-pLR"/>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -157,7 +157,7 @@
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="6Rb-58-f8o"/>
                             <constraint firstItem="cbA-yh-J0A" firstAttribute="top" secondItem="V30-pI-8jo" secondAttribute="bottom" constant="8" id="7kf-Ns-aJR"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="AHN-eg-W66"/>
-                            <constraint firstItem="okC-2w-xB9" firstAttribute="height" relation="lessThanOrEqual" secondItem="cbA-yh-J0A" secondAttribute="height" multiplier="0.5" id="AsX-Mv-rk9"/>
+                            <constraint firstItem="okC-2w-xB9" firstAttribute="height" secondItem="cbA-yh-J0A" secondAttribute="height" multiplier="0.5" id="AsX-Mv-rk9"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="top" secondItem="dfm-a1-ad2" secondAttribute="bottom" constant="16" id="EPf-w5-lBJ"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="5uc-t6-nYA" secondAttribute="trailing" constant="16" id="FZ3-8d-31D"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="V30-pI-8jo" secondAttribute="trailing" constant="16" id="GHI-5B-7xh"/>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -30,8 +30,19 @@
                                     <constraint firstAttribute="height" constant="60" id="eAr-RZ-O8R"/>
                                 </constraints>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf" userLabel="Fiat Button">
+                                <rect key="frame" x="311.5" y="100" width="70" height="70"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="70" id="4dm-4V-5VL"/>
+                                    <constraint firstAttribute="height" constant="70" id="fWa-MZ-Ert"/>
+                                </constraints>
+                                <state key="normal" image="Icon-Switch"/>
+                                <connections>
+                                    <action selector="displayInputTypeTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="f6g-9r-iu8"/>
+                                </connections>
+                            </button>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="5uc-t6-nYA">
-                                <rect key="frame" x="16" y="169.5" width="343" height="44"/>
+                                <rect key="frame" x="16" y="224" width="343" height="44"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gyg-rh-rE6">
                                         <rect key="frame" x="0.0" y="0.0" width="163.5" height="44"/>
@@ -59,15 +70,15 @@
                                 </constraints>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hcw-SG-3XL" customClass="ConversionRatesView" customModule="Blockchain" customModuleProvider="target">
-                                <rect key="frame" x="15.5" y="293.5" width="343" height="273.5"/>
+                                <rect key="frame" x="15.5" y="344" width="343" height="227"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dfm-a1-ad2" customClass="NumberKeypadView" customModule="Blockchain" customModuleProvider="target">
-                                <rect key="frame" x="16" y="269.5" width="343" height="321.5"/>
+                                <rect key="frame" x="16" y="324" width="343" height="267"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eA3-pM-NKs">
-                                <rect key="frame" x="16" y="221.5" width="343" height="32"/>
+                                <rect key="frame" x="16" y="276" width="343" height="32"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 BTC = 22.19 ETH" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9l-S4-AAj">
                                         <rect key="frame" x="122" y="8.5" width="99" height="15"/>
@@ -125,26 +136,14 @@
                                     <action selector="exchangeButtonTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="yeg-hs-kSJ"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf" userLabel="Fiat Button">
-                                <rect key="frame" x="321" y="118" width="54" height="51"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="54" id="0cT-0k-uqW"/>
-                                    <constraint firstAttribute="height" constant="51" id="waH-3r-Rww"/>
-                                </constraints>
-                                <inset key="imageEdgeInsets" minX="19" minY="23" maxX="19" maxY="8"/>
-                                <state key="normal" image="Icon-Switch"/>
-                                <connections>
-                                    <action selector="displayInputTypeTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="f6g-9r-iu8"/>
-                                </connections>
-                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$200.42" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okC-2w-xB9">
-                                <rect key="frame" x="154.5" y="141" width="65.5" height="20.5"/>
+                                <rect key="frame" x="154.5" y="177.5" width="65.5" height="38.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.01 BTC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
-                                <rect key="frame" x="16" y="96" width="342.5" height="41"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0.01 BTC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
+                                <rect key="frame" x="16" y="96" width="342.5" height="77.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="34"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -154,14 +153,15 @@
                         <constraints>
                             <constraint firstItem="5uc-t6-nYA" firstAttribute="top" secondItem="okC-2w-xB9" secondAttribute="bottom" constant="8" id="5a3-e0-C6T"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="DUe-4D-nhJ" secondAttribute="trailing" constant="16" id="5hU-Xa-xif"/>
+                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerY" secondItem="cbA-yh-J0A" secondAttribute="centerY" id="6OF-I7-jLH"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="6Rb-58-f8o"/>
                             <constraint firstItem="cbA-yh-J0A" firstAttribute="top" secondItem="V30-pI-8jo" secondAttribute="bottom" constant="8" id="7kf-Ns-aJR"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="AHN-eg-W66"/>
+                            <constraint firstItem="okC-2w-xB9" firstAttribute="height" relation="lessThanOrEqual" secondItem="cbA-yh-J0A" secondAttribute="height" multiplier="0.5" id="AsX-Mv-rk9"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="top" secondItem="dfm-a1-ad2" secondAttribute="bottom" constant="16" id="EPf-w5-lBJ"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="5uc-t6-nYA" secondAttribute="trailing" constant="16" id="FZ3-8d-31D"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="V30-pI-8jo" secondAttribute="trailing" constant="16" id="GHI-5B-7xh"/>
                             <constraint firstItem="V30-pI-8jo" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="HgH-sR-rJB"/>
-                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerY" secondItem="okC-2w-xB9" secondAttribute="centerY" constant="-8" id="XKu-Vm-Ove"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="width" secondItem="dfm-a1-ad2" secondAttribute="width" id="NgP-UU-rcW"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="height" secondItem="dfm-a1-ad2" secondAttribute="height" multiplier="0.85" id="PLc-ir-uPC"/>
                             <constraint firstItem="coY-Dg-Mc5" firstAttribute="centerY" secondItem="DUe-4D-nhJ" secondAttribute="centerY" id="Pxh-nT-mtp"/>
@@ -174,12 +174,13 @@
                             <constraint firstItem="eA3-pM-NKs" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="enm-Og-Fbn"/>
                             <constraint firstItem="cbA-yh-J0A" firstAttribute="trailing" secondItem="V30-pI-8jo" secondAttribute="trailing" id="fCT-6x-0Y5"/>
                             <constraint firstItem="V30-pI-8jo" firstAttribute="top" secondItem="FIv-WY-bvA" secondAttribute="top" constant="8" id="fNG-KC-mpx"/>
-                            <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="DPE-Uz-yYf" secondAttribute="trailing" id="i1C-yN-uMT"/>
+                            <constraint firstItem="dfm-a1-ad2" firstAttribute="height" relation="lessThanOrEqual" secondItem="jre-mq-FDr" secondAttribute="height" multiplier="0.4" id="jtO-7D-eg1"/>
                             <constraint firstItem="okC-2w-xB9" firstAttribute="centerX" secondItem="cbA-yh-J0A" secondAttribute="centerX" id="kRJ-eC-1n8"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="bottom" secondItem="DUe-4D-nhJ" secondAttribute="bottom" constant="16" id="oTE-Cd-lXS"/>
                             <constraint firstItem="cbA-yh-J0A" firstAttribute="leading" secondItem="V30-pI-8jo" secondAttribute="leading" id="p9e-tX-pLR"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="dfm-a1-ad2" secondAttribute="trailing" constant="16" id="pXZ-qz-MkO"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="top" secondItem="eA3-pM-NKs" secondAttribute="bottom" constant="16" id="sAe-mI-cf2"/>
+                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerX" secondItem="kyX-88-NsD" secondAttribute="centerX" multiplier="1.25" id="wAe-I8-aP3"/>
                             <constraint firstItem="coY-Dg-Mc5" firstAttribute="centerX" secondItem="DUe-4D-nhJ" secondAttribute="centerX" id="wL1-Jj-oLT"/>
                             <constraint firstItem="okC-2w-xB9" firstAttribute="top" secondItem="cbA-yh-J0A" secondAttribute="bottom" constant="4" id="wMz-b9-sNk"/>
                         </constraints>


### PR DESCRIPTION
## Objective

Keyboard is too tall - goal is to adjust to a proportionally smaller size.
With the keyboard height changing I made some changes to the fiat button and the input labels as well.

## Description

- Added constraint - Keypad view to be 37.5% of superview's height (turns out that 40% makes the 5S input labels overlap a tiny bit)
- Removed fiat button image insets (turned out to be way too unmaintainable) and instead gave it constant width/height and had it run over the edge of the screen.
- To give the impression of the image view being aligned with the right-hand side safe area margin similarly to the other subviews, added a constraint for its center to be 1.25x the horizontal center of the Use Max button.
- Vertically centered fiat button with primary amount label instead of secondary amount label to match design spec in the ticket.
- Added constraint for secondary amount label to be half the height of the primary label - Due to how `ExchangeStyleTemplate` is currently used, I expect that this may change.

## How to Test

Go to exchange, notice keyboard height and fiat button position/tappable area.

## Screenshot/Design assessment

Given that designs are not finished, it may not be suitable to assess design accuracy at this time.
Left to right: 5S, 6, 6 plus.
<img width="1073" alt="screen shot 2018-09-25 at 2 42 58 pm" src="https://user-images.githubusercontent.com/10579422/46035618-75b08280-c0d1-11e8-81c8-867a30532d3f.png">

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
