### PR TITLE
fix(Order history): IOS-1339 - Not showing pending trade

### DIFF
--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -84,6 +84,7 @@ struct Constants {
         static let appEnteredBackground = NSNotification.Name("applicationDidEnterBackground")
         static let backupSuccess = NSNotification.Name("backupSuccess")
         static let getFiatAtTime = NSNotification.Name("getFiatAtTime")
+        static let exchangeSubmitted = NSNotification.Name("exchangeSubmitted")
     }
     struct PushNotificationKeys {
         static let userInfoType = "type"

--- a/Blockchain/Extensions/DateFormatter+Conveniences.swift
+++ b/Blockchain/Extensions/DateFormatter+Conveniences.swift
@@ -22,6 +22,12 @@ extension DateFormatter {
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
         return formatter
     }()
+    
+    static let HTTPRequestDateFormat: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:SS'Z'"
+        return formatter
+    }()
 
     /// The API expects the user's DOB to be formatted
     /// this way.

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
@@ -51,6 +51,7 @@ class ExchangeListViewController: UIViewController {
         dependenciesSetup()
         dataProvider?.delegate = self
         delegate?.onLoaded()
+        registerForNotifications()
     }
     
     fileprivate func dependenciesSetup() {
@@ -61,9 +62,20 @@ class ExchangeListViewController: UIViewController {
         delegate = presenter
     }
     
+    fileprivate func registerForNotifications() {
+        NotificationCenter.when(Constants.NotificationKeys.exchangeSubmitted) { [weak self] _ in
+            guard let this = self else { return }
+            this.delegate?.onLoaded()
+        }
+    }
+    
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         delegate?.onDisappear()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -257,6 +257,9 @@ class ExchangeDetailCoordinator: NSObject {
             }
             tradeExecution.submitAndSend(with: lastConversion, success: { [weak self] in
                 guard let this = self else { return }
+                NotificationCenter.default.post(
+                    Notification(name: Constants.NotificationKeys.exchangeSubmitted)
+                )
                 ExchangeCoordinator.shared.handle(event: .sentTransaction(orderTransaction: transaction, conversion: lastConversion))
                 this.delegate?.coordinator(this, completedTransaction: transaction)
             }) { AlertViewPresenter.shared.standardError(message: $0) }

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -187,7 +187,8 @@ class ExchangeDetailCoordinator: NSObject {
                     description: LocalizationConstants.Exchange.status,
                     value: trade.status.displayValue,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1),
-                    statusVisibility: .visible
+                    statusVisibility: .visible,
+                    statusTintColor: trade.status.tintColor
                 )
                 
                 let value = ExchangeCellModel.Plain(

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeListInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeListInteractor.swift
@@ -19,6 +19,7 @@ class ExchangeListInteractor: ExchangeListInput {
     }
     
     func fetchAllTrades() {
+        guard service.isExecuting() == false else { return }
         service.getAllTrades { [weak self] (result) in
             switch result {
             case .success(let models):

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeCellModel.swift
@@ -30,7 +30,14 @@ enum ExchangeCellModel {
 
         var descriptionActionBlock: LabelAction?
 
-        init(description: String, value: String, backgroundColor: UIColor = .white, statusVisibility: Visibility = .hidden, bold: Bool = false, statusTintColor: UIColor = .green) {
+        init(
+            description: String,
+            value: String,
+            backgroundColor: UIColor = .white,
+            statusVisibility: Visibility = .hidden,
+            bold: Bool = false,
+            statusTintColor: UIColor = .green
+            ) {
             self.description = description
             self.value = value
             self.backgroundColor = backgroundColor

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeCellModel.swift
@@ -25,16 +25,18 @@ enum ExchangeCellModel {
         let value: String
         let backgroundColor: UIColor
         let statusVisibility: Visibility
+        let statusTintColor: UIColor
         let bold: Bool
 
         var descriptionActionBlock: LabelAction?
 
-        init(description: String, value: String, backgroundColor: UIColor = .white, statusVisibility: Visibility = .hidden, bold: Bool = false) {
+        init(description: String, value: String, backgroundColor: UIColor = .white, statusVisibility: Visibility = .hidden, bold: Bool = false, statusTintColor: UIColor = .green) {
             self.description = description
             self.value = value
             self.backgroundColor = backgroundColor
             self.statusVisibility = statusVisibility
             self.bold = bold
+            self.statusTintColor = statusTintColor
         }
     }
     

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -248,15 +248,15 @@ struct ExchangeTradeCellModel: Decodable {
     let updatedAt: Date
     let pair: TradingPair
     let refundAddress: String
-    let rate: String
+    let rate: String?
     let depositAddress: String
     let deposit: SymbolValue
     let withdrawalAddress: String
     let withdrawal: SymbolValue
     let withdrawalFee: SymbolValue
     let fiatValue: SymbolValue
-    let depositTxHash: String
-    let withdrawalTxHash: String
+    let depositTxHash: String?
+    let withdrawalTxHash: String?
 
     // MARK: - Decodable
 
@@ -314,15 +314,15 @@ struct ExchangeTradeCellModel: Decodable {
         }
         
         refundAddress = try values.decode(String.self, forKey: .refundAddress)
-        rate = try values.decode(String.self, forKey: .rate)
+        rate = try values.decodeIfPresent(String.self, forKey: .rate)
         depositAddress = try values.decode(String.self, forKey: .depositAddress)
         deposit = try values.decode(SymbolValue.self, forKey: .deposit)
         withdrawalAddress = try values.decode(String.self, forKey: .withdrawalAddress)
         withdrawal = try values.decode(SymbolValue.self, forKey: .withdrawal)
         withdrawalFee = try values.decode(SymbolValue.self, forKey: .withdrawalFee)
         fiatValue = try values.decode(SymbolValue.self, forKey: .fiatValue)
-        depositTxHash = try values.decode(String.self, forKey: .depositTxHash)
-        withdrawalTxHash = try values.decode(String.self, forKey: .withdrawalTxHash)
+        depositTxHash = try values.decodeIfPresent(String.self, forKey: .depositTxHash)
+        withdrawalTxHash = try values.decodeIfPresent(String.self, forKey: .withdrawalTxHash)
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/Models/TradingPair.swift
+++ b/Blockchain/Homebrew/Exchange/Models/TradingPair.swift
@@ -13,14 +13,9 @@ struct TradingPair {
     private var internalTo: AssetType
 
     init?(from: AssetType, to: AssetType) {
-        // TODO: This used to return early with `nil`.
-        // Some have already executed trades though when
-        // there was a server side bug that allowed for the
-        // two asset types to be the same. So, when those of
-        // us who have that in our trade history GET trades
-        // we hit an assertion error. 
-        if from == to {
+        guard from != to else {
             Logger.shared.error("From and to must be different")
+            return nil
         }
         internalFrom = from
         internalTo = to

--- a/Blockchain/Homebrew/Exchange/Models/TradingPair.swift
+++ b/Blockchain/Homebrew/Exchange/Models/TradingPair.swift
@@ -13,9 +13,14 @@ struct TradingPair {
     private var internalTo: AssetType
 
     init?(from: AssetType, to: AssetType) {
-        guard from != to else {
+        // TODO: This used to return early with `nil`.
+        // Some have already executed trades though when
+        // there was a server side bug that allowed for the
+        // two asset types to be the same. So, when those of
+        // us who have that in our trade history GET trades
+        // we hit an assertion error. 
+        if from == to {
             Logger.shared.error("From and to must be different")
-            return nil
         }
         internalFrom = from
         internalTo = to

--- a/Blockchain/Homebrew/Exchange/Services/ExchangeService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/ExchangeService.swift
@@ -120,7 +120,8 @@ extension ExchangeService: ExchangeHistoryAPI {
     }
     
     func isExecuting() -> Bool {
-        return tradeQueue.operations.count > 0 || homebrewOperation.isExecuting
+        guard let homebrew = homebrewOperation else { return false }
+        return tradeQueue.operations.count > 0 || homebrew.isExecuting
     }
     
     func cancel() {

--- a/Blockchain/Homebrew/Exchange/Services/HomebrewExchangeService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/HomebrewExchangeService.swift
@@ -47,9 +47,8 @@ class HomebrewExchangeService: HomebrewExchangeAPI {
         guard let baseURL = URL(string: BlockchainAPI.shared.retailCoreUrl) else {
             return .error(HomebrewExchangeServiceError.generic)
         }
-        
-        let timestamp = DateFormatter.sessionDateFormat.string(from: timestamp)
-        guard let endpoint = URL.endpoint(baseURL, pathComponents: ["trades"], queryParameters: ["before": timestamp]) else {
+        let dateParameter = DateFormatter.HTTPRequestDateFormat.string(from: timestamp)
+        guard let endpoint = URL.endpoint(baseURL, pathComponents: ["trades"], queryParameters: ["before": dateParameter]) else {
             return .error(HomebrewExchangeServiceError.generic)
         }
         

--- a/Blockchain/Homebrew/Exchange/Views/Cells/DetailCollectionViewCells/Plain/PlainCell.swift
+++ b/Blockchain/Homebrew/Exchange/Views/Cells/DetailCollectionViewCells/Plain/PlainCell.swift
@@ -36,7 +36,7 @@ class PlainCell: ExchangeDetailCell {
         backgroundColor = payload.backgroundColor
         subject.textColor = payload.bold ? .darkGray : #colorLiteral(red: 0.64, green: 0.64, blue: 0.64, alpha: 1)
         statusImageView.alpha = payload.statusVisibility.defaultAlpha
-        statusImageView.tintColor = .green
+        statusImageView.tintColor = payload.statusTintColor
 
         if let action = payload.descriptionActionBlock {
             tapActionBlock = action


### PR DESCRIPTION
## Objective

Fixes issue where we were not showing the user's order history.

## Description

This endpoint requires a different date format than our session token endpoint. Additionally, some of the values on our trade model need to be optional. Lastly, there's an issue with the `pair` property. You're not supposed to ever have a pair with two of the same asset types. However, there was a server side bug where this could feasibly happen. This has been fixed on the server however, if you did submit trades while this bug was still around, you would get an assertion as `pair` would be nil. 

I'm waiting to hear from the backend team to see if these trades could be purged. 

## How to Test

1. Build and run
2. Go to the Exchange List screen
3. If you've submitted trades on HB, you should see those trades now.
4. Try pulling to refresh. 
5. If you've submitted over 50 trades, try paginating. 

## Screenshot/Design assessment

![simulator screen shot - iphone x - 2018-09-25 at 12 55 32](https://user-images.githubusercontent.com/41585563/46037001-8dd1d300-c0cc-11e8-893d-1a4bf2538b6c.png)


## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
