### PR TITLE
fix(KYC): Don't display state picker if selected country is not in the US (IOS-1330)

### DIFF
--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -209,7 +209,9 @@ extension KYCCountrySelectionController: KYCCountrySelectionView {
     }
 
     func startPartnerExchangeFlow(country: KYCCountry) {
-        ExchangeCoordinator.shared.handle(event: .createPartnerExchange(animated: true, viewController: self))
+        ExchangeCoordinator.shared.handle(
+            event: .createPartnerExchange(country: country, animated: true, viewController: self)
+        )
     }
 
     func showExchangeNotAvailable(country: KYCCountry) {

--- a/Blockchain/Models/TabControllerManager.h
+++ b/Blockchain/Models/TabControllerManager.h
@@ -16,7 +16,6 @@
 #import "SendEtherViewController.h"
 #import "TransactionsEtherViewController.h"
 #import "ReceiveEtherViewController.h"
-#import "PartnerExchangeListViewController.h"
 #import "TransactionsBitcoinCashViewController.h"
 
 @protocol TabControllerDelegate

--- a/Blockchain/View Controllers/PartnerExchangeListViewController.h
+++ b/Blockchain/View Controllers/PartnerExchangeListViewController.h
@@ -9,5 +9,6 @@
 #import <UIKit/UIKit.h>
 
 @interface PartnerExchangeListViewController : UIViewController
++ (PartnerExchangeListViewController * _Nonnull)createWithCountryCode:(NSString *_Nonnull)countryCode;
 - (void)reloadSymbols;
 @end

--- a/Blockchain/View Controllers/PartnerExchangeListViewController.m
+++ b/Blockchain/View Controllers/PartnerExchangeListViewController.m
@@ -29,9 +29,17 @@
 @property (nonatomic) PartnerExchangeCreateViewController *createViewController;
 @property (nonatomic) BOOL didFinishShift;
 @property (nonatomic) UIRefreshControl *refreshControl;
+@property (nonatomic) NSString *countryCode;
 @end
 
 @implementation PartnerExchangeListViewController
+
++ (PartnerExchangeListViewController * _Nonnull)createWithCountryCode:(NSString *_Nonnull)countryCode
+{
+    PartnerExchangeListViewController *controller = [[PartnerExchangeListViewController alloc] init];
+    controller.countryCode = countryCode;
+    return controller;
+}
 
 - (void)viewDidLoad
 {
@@ -40,11 +48,10 @@
     [WalletManager sharedInstance].exchangeDelegate = self;
     
     self.view.backgroundColor = UIColor.lightGray;
-    
-    NSArray *availableStates = [WalletManager.sharedInstance.wallet availableUSStates];
-    
-    if (availableStates.count > 0) {
+
+    if ([self.countryCode  isEqual: @"US"]) {
         [[LoadingViewPresenter sharedInstance] hideBusyView];
+        NSArray *availableStates = [WalletManager.sharedInstance.wallet availableUSStates];
         [self showStates:availableStates];
     } else {
         [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[LocalizationConstantsObjcBridge loadingExchange]];
@@ -274,25 +281,25 @@
 {
     UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableView.frame.size.width, 45)];
     view.backgroundColor = UIColor.lightGray;
-    
+
     UILabel *leftLabel = [[UILabel alloc] initWithFrame:CGRectMake(15, 12, tableView.frame.size.width/2, 30)];
     leftLabel.textColor = UIColor.gray5;
     leftLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_LIGHT size:FONT_SIZE_EXTRA_EXTRA_SMALL];
-    
+
     [view addSubview:leftLabel];
-    
+
     leftLabel.text = [BC_STRING_ORDER_HISTORY uppercaseString];
-    
+
     CGFloat rightLabelOriginX = leftLabel.frame.origin.x + leftLabel.frame.size.width + 8;
     UILabel *rightLabel = [[UILabel alloc] initWithFrame:CGRectMake(rightLabelOriginX, 12, self.view.frame.size.width - rightLabelOriginX - 15, 30)];
     rightLabel.textColor = UIColor.gray5;
     rightLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_LIGHT size:FONT_SIZE_EXTRA_EXTRA_SMALL];
     rightLabel.textAlignment = NSTextAlignmentRight;
-    
+
     [view addSubview:rightLabel];
-    
+
     rightLabel.text = [BC_STRING_INCOMING uppercaseString];
-    
+
     return view;
 }
 
@@ -309,20 +316,20 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     ExchangeTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CELL_IDENTIFIER_EXCHANGE_CELL];
-    
+
     if (cell == nil) {
         cell = [[[NSBundle mainBundle] loadNibNamed:@"ExchangeTableViewCell" owner:nil options:nil] objectAtIndex:0];
         ExchangeTrade *trade = [self.trades objectAtIndex:indexPath.row];
         [cell configureWithTrade:trade];
     }
-    
+
     return cell;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
-    
+
     ExchangeProgressViewController *exchangeProgressVC = [[ExchangeProgressViewController alloc] init];
     exchangeProgressVC.trade = [self.trades objectAtIndex:indexPath.row];
     BCNavigationController *navigationController = [[BCNavigationController alloc] initWithRootViewController:exchangeProgressVC title:BC_STRING_EXCHANGE];


### PR DESCRIPTION
## Objective

When selecting a country that is supported by SS (e.g. Andorra), do not display the state picker screen.

## Description

Fixes an issue where we would display the state picker screen regardless of the user's country selection when launching the partner exchange flow. The reason this was happening was because we were using the country guess which is based on the IP address of the user. This PR fixes that since we no longer need to make guesses.

Note that we are still using country/state guess to optionally show the Exchange side menu item. So, if the country/region the user is in is blacklisted and should not be able to use shapeshift, they won't be able to see the Exchange option.

## How to Test

Pull in changes, tap on a country that is supported by Shapeshift (e.g. Andorra), verify that you don't need to select a state.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
