### PR TITLE
fix(Homebrew-Exchange): IOS-1358 make ExchangeCoordinator inject ExchangeServices into view controllers

### DIFF
--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -63,7 +63,6 @@ struct ExchangeServices: ExchangeDependencies {
     private let walletManager: WalletManager
 
     private let walletService: WalletService
-    private let dependencies: ExchangeDependencies = ExchangeServices()
 
     private var disposable: Disposable?
     
@@ -148,7 +147,7 @@ struct ExchangeServices: ExchangeDependencies {
                 Logger.shared.error("View controller to present on is nil")
                 return
             }
-            let listViewController = ExchangeListViewController.make(with: dependencies, coordinator: self)
+            let listViewController = ExchangeListViewController.make(with: ExchangeServices(), coordinator: self)
             navigationController = BCNavigationController(
                 rootViewController: listViewController,
                 title: LocalizationConstants.Exchange.navigationTitle
@@ -171,7 +170,7 @@ struct ExchangeServices: ExchangeDependencies {
     private func showCreateExchange(animated: Bool, type: ExchangeType) {
         switch type {
         case .homebrew:
-            let exchangeCreateViewController = ExchangeCreateViewController.make(with: dependencies)
+            let exchangeCreateViewController = ExchangeCreateViewController.make(with: ExchangeServices())
             if navigationController == nil {
                 guard let viewController = rootViewController else {
                     Logger.shared.error("View controller to present on is nil")
@@ -195,8 +194,8 @@ struct ExchangeServices: ExchangeDependencies {
             Logger.shared.error("No navigation controller found")
             return
         }
-        let model = ExchangeDetailViewController.PageModel.confirm(orderTransaction, conversion, dependencies.tradeExecution)
-        let confirmController = ExchangeDetailViewController.make(with: model, dependencies: dependencies)
+        let model = ExchangeDetailViewController.PageModel.confirm(orderTransaction, conversion)
+        let confirmController = ExchangeDetailViewController.make(with: model, dependencies: ExchangeServices())
         navigationController.pushViewController(confirmController, animated: true)
     }
     
@@ -206,12 +205,12 @@ struct ExchangeServices: ExchangeDependencies {
             return
         }
         let model = ExchangeDetailViewController.PageModel.locked(orderTransaction, conversion)
-        let controller = ExchangeDetailViewController.make(with: model, dependencies: dependencies)
+        let controller = ExchangeDetailViewController.make(with: model, dependencies: ExchangeServices())
         navigationController.present(controller, animated: true, completion: nil)
     }
 
     private func showTradeDetails(trade: ExchangeTradeModel) {
-        let detailViewController = ExchangeDetailViewController.make(with: .overview(trade), dependencies: dependencies)
+        let detailViewController = ExchangeDetailViewController.make(with: .overview(trade), dependencies: ExchangeServices())
         navigationController?.pushViewController(detailViewController, animated: true)
     }
 

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -19,7 +19,7 @@ protocol ExchangeDetailDelegate: class {
 class ExchangeDetailViewController: UIViewController {
 
     enum PageModel {
-        case confirm(OrderTransaction, Conversion, TradeExecutionAPI)
+        case confirm(OrderTransaction, Conversion)
         case locked(OrderTransaction, Conversion)
         case overview(ExchangeTradeModel)
     }

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -51,7 +51,7 @@ class ExchangeDetailCoordinator: NSObject {
         switch event {
         case .updateConfirmDetails(let orderTransaction, let conversion):
             interface?.mostRecentConversion = conversion
-            handle(event: .pageLoaded(.confirm(orderTransaction, conversion, tradeExecution)))
+            handle(event: .pageLoaded(.confirm(orderTransaction, conversion)))
         case .pageLoaded(let model):
             
             // TODO: These are placeholder `ViewModels`
@@ -62,7 +62,7 @@ class ExchangeDetailCoordinator: NSObject {
             var cellModels: [ExchangeCellModel] = []
             
             switch model {
-            case .confirm(let orderTransaction, let conversion, _):
+            case .confirm(let orderTransaction, let conversion):
                 interface?.updateBackgroundColor(#colorLiteral(red: 0.89, green: 0.95, blue: 0.97, alpha: 1))
                 interface?.updateTitle(LocalizationConstants.Exchange.confirmExchange)
                 

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -81,7 +81,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         guard let output = output else { return }
         guard let model = model else { return }
         inputs.setup(with: output.styleTemplate(), usingFiat: model.isUsingFiat)
-        
+        conversions.clear()
         updatedInput()
         
         markets.setup()

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -81,7 +81,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         guard let output = output else { return }
         guard let model = model else { return }
         inputs.setup(with: output.styleTemplate(), usingFiat: model.isUsingFiat)
-        conversions.clear()
+        
         updatedInput()
         
         markets.setup()

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeDetailInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeDetailInteractor.swift
@@ -12,14 +12,12 @@ import RxSwift
 class ExchangeDetailInteractor {
     var disposable: Disposable?
     fileprivate let markets: ExchangeMarketsAPI
-    fileprivate let conversions: ExchangeConversionAPI
     fileprivate let tradeExecution: TradeExecutionAPI
 
     weak var output: ExchangeDetailOutput?
 
     init(dependencies: ExchangeDependencies) {
         self.markets = dependencies.markets
-        self.conversions = dependencies.conversions
         self.tradeExecution = dependencies.tradeExecution
     }
 


### PR DESCRIPTION
## Objective

Make sure all amount label are cleared when returning to the New Exchange screen from the list controller.

## Description

~Cleared the secondary amount label on `viewDidLoad`. Looking for feedback on whether this is the best place for it inside this method.~

Found out that the state of the secondary output is retained in the `ExchangeConversionService`. Discussion with @bchrisarriola concluded that it would be best to inject `ExchangeServices` to ensure new instances for each.

Also did a little cleaning up:
- The `ExchangeDetailInteractor` doesn't need the `ExchangeConversionService` so I removed that.
- The `ExchangeDetailViewController.PageModel` doesn't need to be instantiated with dependencies now that the `ExchangeDetailCoordinator` has it, so I removed the dependencies parameter from the `.confirm(...)` case.

## How to Test

Go to Exchange, type in a value, go back one screen, go back to Exchange - input labels should be zeroed out and reset.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
