### PR TITLE
fix(HB): IOS-1312 - All accounts should show in the alert controller

### DIFF
--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -33,7 +33,7 @@ protocol ExchangeCreateInput: NumberKeypadViewDelegate {
     func useMinimumAmount(assetAccount: AssetAccount)
     func useMaximumAmount(assetAccount: AssetAccount)
     func confirmConversion()
-    func changeTradingPair(tradingPair: TradingPair)
+    func changeMarketPair(marketPair: MarketPair)
 }
 
 protocol ExchangeCreateOutput: class {

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -389,6 +389,9 @@ extension ExchangeCreateViewController: ExchangeAssetAccountListView {
         assetAccounts.forEach { account in
             let alertAction = UIAlertAction(title: account.name, style: .default, handler: { [unowned self] _ in
                 Logger.shared.debug("Selected account titled: '\(account.name)' of type: '\(account.address.assetType.symbol)'")
+                
+                /// Note: Users should not be able to exchange between
+                /// accounts with the same assetType.
                 switch action {
                 case .exchanging:
                     if account.address.assetType == self.toAccount.address.assetType {

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -391,10 +391,15 @@ extension ExchangeCreateViewController: ExchangeAssetAccountListView {
                 Logger.shared.debug("Selected account titled: '\(account.name)' of type: '\(account.address.assetType.symbol)'")
                 switch action {
                 case .exchanging:
-                    self.toAccount = account == self.toAccount ? self.fromAccount : self.toAccount
+                    if account.address.assetType == self.toAccount.address.assetType {
+                        self.toAccount = self.fromAccount
+                    }
+                    
                     self.fromAccount = account
                 case .receiving:
-                    self.fromAccount = account == self.fromAccount ? self.toAccount : self.fromAccount
+                    if account.address.assetType == self.fromAccount.address.assetType {
+                        self.fromAccount = self.toAccount
+                    }
                     self.toAccount = account
                 }
                 self.onTradingPairChanged()

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -127,7 +127,7 @@ class ExchangeCreateViewController: UIViewController {
         let interactor = ExchangeCreateInteractor(
             dependencies: dependencies,
             model: MarketsModel(
-                pair: TradingPair(from: fromAccount.address.assetType, to: toAccount.address.assetType)!,
+                marketPair: MarketPair(fromAccount: fromAccount, toAccount: toAccount),
                 fiatCurrencyCode: BlockchainSettings.sharedAppInstance().fiatCurrencyCode ?? "USD",
                 fiatCurrencySymbol: BlockchainSettings.sharedAppInstance().fiatCurrencySymbol ?? "$",
                 fix: .base,
@@ -367,11 +367,11 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
 
 extension ExchangeCreateViewController: TradingPairViewDelegate {
     func onLeftButtonTapped(_ view: TradingPairView, title: String) {
-        assetAccountListPresenter.presentPicker(excludingAssetType: fromAccount.address.assetType, for: .exchanging)
+        assetAccountListPresenter.presentPicker(excludingAccount: fromAccount, for: .exchanging)
     }
 
     func onRightButtonTapped(_ view: TradingPairView, title: String) {
-        assetAccountListPresenter.presentPicker(excludingAssetType: toAccount.address.assetType, for: .receiving)
+        assetAccountListPresenter.presentPicker(excludingAccount: toAccount, for: .receiving)
     }
 
     func onSwapButtonTapped(_ view: TradingPairView) {
@@ -404,18 +404,16 @@ extension ExchangeCreateViewController: ExchangeAssetAccountListView {
         actionSheetController.addAction(
             UIAlertAction(title: LocalizationConstants.cancel, style: .cancel)
         )
-
-        // Present picker
+        
         present(actionSheetController, animated: true)
     }
 
     private func onTradingPairChanged() {
-        guard let tradingPair = TradingPair(
-            from: fromAccount.address.assetType,
-            to: toAccount.address.assetType
-        ) else {
-            return
-        }
-        presenter.changeTradingPair(tradingPair: tradingPair)
+        presenter.changeMarketPair(
+            marketPair: MarketPair(
+                fromAccount: fromAccount,
+                toAccount: toAccount
+            )
+        )
     }
 }

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -260,7 +260,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         updatedInput()
     }
 
-    func changeTradingPair(tradingPair: TradingPair) {
+    func changeMarketPair(marketPair: MarketPair) {
         guard let model = model else { return }
 
         // Unsubscribe from old pair conversions
@@ -268,7 +268,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         markets.unsubscribeToCurrencyPair(pair: model.pair.stringRepresentation)
 
         // Update to new pair
-        model.pair = tradingPair
+        model.marketPair = marketPair
         updatedInput()
         output?.updateTradingPair(pair: model.pair, fix: model.fix)
     }

--- a/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
@@ -8,25 +8,48 @@
 
 import Foundation
 
+/// `MarketPair` is to keep track of what accounts
+/// the user is transferring from and to. We originally
+/// used just a `TradingPair` but some users may have
+/// multiple wallets of the same asset type.
+struct MarketPair {
+    let fromAccount: AssetAccount
+    let toAccount: AssetAccount
+}
+
+extension MarketPair {
+    var pair: TradingPair {
+        let from = fromAccount.address.assetType
+        let to = toAccount.address.assetType
+        return TradingPair(from: from, to: to)!
+    }
+}
+
 // State model for interacting with the MarketsService
 class MarketsModel {
-    var pair: TradingPair
+    var marketPair: MarketPair
     var fiatCurrencyCode: String
     var fiatCurrencySymbol: String
     var fix: Fix
     var volume: String
     var lastConversion: Conversion?
 
-    init(pair: TradingPair,
+    init(marketPair: MarketPair,
          fiatCurrencyCode: String,
          fiatCurrencySymbol: String,
          fix: Fix,
          volume: String) {
-        self.pair = pair
+        self.marketPair = marketPair
         self.fiatCurrencyCode = fiatCurrencyCode
         self.fiatCurrencySymbol = fiatCurrencySymbol
         self.fix = fix
         self.volume = volume
+    }
+}
+
+extension MarketsModel {
+    var pair: TradingPair {
+        return marketPair.pair
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeAssetAccountListPresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeAssetAccountListPresenter.swift
@@ -39,11 +39,10 @@ class ExchangeAssetAccountListPresenter {
         self.assetAccountRepository = assetAccountRepository
     }
 
-    func presentPicker(excludingAssetType assetTypeToExclude: AssetType?, for action: ExchangeAction) {
+    func presentPicker(excludingAccount assetAccount: AssetAccount?, for action: ExchangeAction) {
         let accountsToPick = assetAccountRepository.allAccounts().filter { account -> Bool in
-            guard let assetTypeToExclude = assetTypeToExclude else { return true }
-
-            return account.address.assetType != assetTypeToExclude
+            guard let excluding = assetAccount else { return true }
+            return account != excluding
         }
         view?.showPicker(for: accountsToPick, action: action)
     }

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -63,8 +63,8 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
         interface?.ratesChevronButtonVisibility(ratesViewVisibility, animated: animated)
     }
 
-    func changeTradingPair(tradingPair: TradingPair) {
-        interactor.changeTradingPair(tradingPair: tradingPair)
+    func changeMarketPair(marketPair: MarketPair) {
+        interactor.changeMarketPair(marketPair: marketPair)
     }
 
     func onToggleFixTapped() {


### PR DESCRIPTION
## Objective

This fixes a bug where users who had multiple wallets of the same asset type could not select alternate wallets. e.g. A user trading from BTC to ETH who had a secondary ETH wallet could not select the secondary ETH wallet in the picker. 

## Description

We were filtering based on the `TradingPair` of the `MarketsModel`. I've added `MarketPair` which houses a `fromAsset` and `toAsset`. When the user taps on the `TradingPairView` to select a different wallet, instead of filtering on the `assetType`, we now filter out the `AssetAccount`. 

## How to Test

1. Build and run
2. Sign into an account with multiple wallets of the same type
3. Go to the exchange screen
4. Try to select different wallets of the same type

**Note: You should still not be able to trade between accounts of the same asset type**

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
