### PR TITLE
fix(Account): remove 'Invalid email address' alert when creating another account

### DIFF
--- a/Blockchain/Modal Content Views/BCCreateAccountView.m
+++ b/Blockchain/Modal Content Views/BCCreateAccountView.m
@@ -61,10 +61,6 @@
         [AlertViewPresenter.sharedInstance showNoInternetConnectionAlert];
         return;
     }
-    if (!self.labelTextField.text ||!self.labelTextField.text.isEmail) {
-        [[AlertViewPresenter sharedInstance] standardNotifyWithMessage:BC_STRING_INVALID_EMAIL_ADDRESS title:BC_STRING_ERROR  in:nil handler:nil];
-        return;
-    }
     // Remove whitespace
     NSString *label = [self.labelTextField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 


### PR DESCRIPTION
## Objective

Fixes bug where user cannot create another account.

## Description

User was not able to create a new account because the entered account label was being evaluated as an email address. Looks like it may have been added by accident in bf0eb1d. Found this issue while testing #534 

## How to Test

Pull in changes, try to create account (Tap "Addresses" in the side menu -> "+" button in the Wallets header for Bitcoin), and verify that it succeeds.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
