### PR TITLE
fix(Exchange): update trading pair view look/behavior (IOS-1345)

### DIFF
--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -24,14 +24,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="V30-pI-8jo" customClass="TradingPairView" customModule="Blockchain" customModuleProvider="target">
-                                <rect key="frame" x="16" y="28" width="343" height="60"/>
+                                <rect key="frame" x="16" y="28" width="343" height="42"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="eAr-RZ-O8R"/>
+                                    <constraint firstAttribute="height" constant="42" id="eAr-RZ-O8R"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="5uc-t6-nYA">
-                                <rect key="frame" x="16" y="169.5" width="343" height="44"/>
+                                <rect key="frame" x="16" y="151.5" width="343" height="44"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gyg-rh-rE6">
                                         <rect key="frame" x="0.0" y="0.0" width="163.5" height="44"/>
@@ -59,15 +59,15 @@
                                 </constraints>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hcw-SG-3XL" customClass="ConversionRatesView" customModule="Blockchain" customModuleProvider="target">
-                                <rect key="frame" x="15.5" y="293.5" width="343" height="273.5"/>
+                                <rect key="frame" x="15.5" y="277" width="343" height="288.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dfm-a1-ad2" customClass="NumberKeypadView" customModule="Blockchain" customModuleProvider="target">
-                                <rect key="frame" x="16" y="269.5" width="343" height="321.5"/>
+                                <rect key="frame" x="16" y="251.5" width="343" height="339.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eA3-pM-NKs">
-                                <rect key="frame" x="16" y="221.5" width="343" height="32"/>
+                                <rect key="frame" x="16" y="203.5" width="343" height="32"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 BTC = 22.19 ETH" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9l-S4-AAj">
                                         <rect key="frame" x="122" y="8.5" width="99" height="15"/>
@@ -126,7 +126,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf" userLabel="Fiat Button">
-                                <rect key="frame" x="321" y="118" width="54" height="51"/>
+                                <rect key="frame" x="321" y="100" width="54" height="51"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="54" id="0cT-0k-uqW"/>
                                     <constraint firstAttribute="height" constant="51" id="waH-3r-Rww"/>
@@ -138,13 +138,13 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$200.42" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okC-2w-xB9">
-                                <rect key="frame" x="154.5" y="141" width="65.5" height="20.5"/>
+                                <rect key="frame" x="154.5" y="123" width="65.5" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.01 BTC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
-                                <rect key="frame" x="16" y="96" width="342.5" height="41"/>
+                                <rect key="frame" x="16" y="78" width="342.5" height="41"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="34"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -161,13 +161,13 @@
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="5uc-t6-nYA" secondAttribute="trailing" constant="16" id="FZ3-8d-31D"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="V30-pI-8jo" secondAttribute="trailing" constant="16" id="GHI-5B-7xh"/>
                             <constraint firstItem="V30-pI-8jo" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="HgH-sR-rJB"/>
-                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerY" secondItem="okC-2w-xB9" secondAttribute="centerY" constant="-8" id="XKu-Vm-Ove"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="width" secondItem="dfm-a1-ad2" secondAttribute="width" id="NgP-UU-rcW"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="height" secondItem="dfm-a1-ad2" secondAttribute="height" multiplier="0.85" id="PLc-ir-uPC"/>
                             <constraint firstItem="coY-Dg-Mc5" firstAttribute="centerY" secondItem="DUe-4D-nhJ" secondAttribute="centerY" id="Pxh-nT-mtp"/>
                             <constraint firstItem="cbA-yh-J0A" firstAttribute="centerX" secondItem="V30-pI-8jo" secondAttribute="centerX" id="Qr8-L9-lCF"/>
                             <constraint firstItem="eA3-pM-NKs" firstAttribute="top" secondItem="5uc-t6-nYA" secondAttribute="bottom" constant="8" id="TBU-fM-o9r"/>
                             <constraint firstItem="5uc-t6-nYA" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="Txz-FX-khz"/>
+                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerY" secondItem="okC-2w-xB9" secondAttribute="centerY" constant="-8" id="XKu-Vm-Ove"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="centerX" secondItem="dfm-a1-ad2" secondAttribute="centerX" id="bJ3-Vq-GwG"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="eA3-pM-NKs" secondAttribute="trailing" constant="16" id="bhv-Sp-60b"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="centerY" secondItem="dfm-a1-ad2" secondAttribute="centerY" id="dnB-8I-crf"/>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -288,10 +288,6 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
         let fromAsset = pair.from
         let toAsset = pair.to
 
-        let isUsingBase = fix == .base || fix == .baseInFiat
-        let leftVisibility: TradingPairView.ViewUpdate = .leftStatusVisibility(isUsingBase ? .visible : .hidden)
-        let rightVisibility: TradingPairView.ViewUpdate = .rightStatusVisibility(isUsingBase ? .hidden : .visible)
-
         let transitionUpdate = TradingPairView.TradingTransitionUpdate(
             transitions: [
                 .images(left: fromAsset.brandImage, right: toAsset.brandImage),
@@ -303,11 +299,8 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
         let presentationUpdate = TradingPairView.TradingPresentationUpdate(
             animations: [
                 .backgroundColors(left: fromAsset.brandColor, right: toAsset.brandColor),
-                leftVisibility,
-                rightVisibility,
-                .statusTintColor(#colorLiteral(red: 0.01176470588, green: 0.662745098, blue: 0.4470588235, alpha: 1)),
                 .swapTintColor(#colorLiteral(red: 0, green: 0.2901960784, blue: 0.4862745098, alpha: 1)),
-                .titleColor(#colorLiteral(red: 0, green: 0.2901960784, blue: 0.4862745098, alpha: 1))
+                .titleVisibility(.hidden)
             ],
             animation: .none
         )
@@ -375,7 +368,7 @@ extension ExchangeCreateViewController: TradingPairViewDelegate {
     }
 
     func onSwapButtonTapped(_ view: TradingPairView) {
-        presenter.onToggleFixTapped()
+        presenter.onSwapPairsTapped()
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -200,9 +200,9 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         applyTradingLimit(limit: .max, assetAccount: assetAccount)
     }
 
-    func toggleFix() {
+    func swapPairs() {
         guard let model = model else { return }
-        model.toggleFix()
+        model.swapPairs()
         model.lastConversion = nil
         clearInputs()
         updatedInput()

--- a/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/MarketsModel.swift
@@ -19,9 +19,13 @@ struct MarketPair {
 
 extension MarketPair {
     var pair: TradingPair {
-        let from = fromAccount.address.assetType
-        let to = toAccount.address.assetType
-        return TradingPair(from: from, to: to)!
+        let fromType = fromAccount.address.assetType
+        let toType = toAccount.address.assetType
+        return TradingPair(from: fromType, to: toType)!
+    }
+
+    func swapped() -> MarketPair {
+        return MarketPair(fromAccount: self.toAccount, toAccount: self.fromAccount)
     }
 }
 
@@ -75,8 +79,8 @@ extension MarketsModel {
         }
     }
 
-    func toggleFix() {
-        fix = fix.toggledFix()
+    func swapPairs() {
+        marketPair = marketPair.swapped()
     }
 }
 

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -67,8 +67,8 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
         interactor.changeMarketPair(marketPair: marketPair)
     }
 
-    func onToggleFixTapped() {
-        interactor.toggleFix()
+    func onSwapPairsTapped() {
+        interactor.swapPairs()
     }
 
     func onUseMinimumTapped(assetAccount: AssetAccount) {

--- a/Blockchain/Homebrew/Exchange/Views/TradingPairView.swift
+++ b/Blockchain/Homebrew/Exchange/Views/TradingPairView.swift
@@ -25,12 +25,10 @@ class TradingPairView: NibBasedView {
     }
     
     enum ViewUpdate: Update {
-        case statusTintColor(UIColor)
         case titleColor(UIColor)
-        case leftStatusVisibility(Visibility)
-        case rightStatusVisibility(Visibility)
         case backgroundColors(left: UIColor, right: UIColor)
         case swapTintColor(UIColor)
+        case titleVisibility(Visibility)
     }
     
     enum ViewTransition: Transition {
@@ -44,11 +42,14 @@ class TradingPairView: NibBasedView {
     @IBOutlet fileprivate var leftButton: UIButton!
     @IBOutlet fileprivate var rightButton: UIButton!
     @IBOutlet fileprivate var swapButton: UIButton!
-    @IBOutlet fileprivate var leftIconStatusImageView: UIImageView!
-    @IBOutlet fileprivate var rightIconStatusImageView: UIImageView!
     @IBOutlet fileprivate var exchangeLabel: UILabel!
     @IBOutlet fileprivate var receiveLabel: UILabel!
-    
+
+    @IBOutlet fileprivate var leftButtonConstraintToTop: NSLayoutConstraint!
+    @IBOutlet fileprivate var leftButtonConstraintToLabel: NSLayoutConstraint!
+    @IBOutlet fileprivate var rightButtonConstraintToTop: NSLayoutConstraint!
+    @IBOutlet fileprivate var rightButtonConstraintToLabel: NSLayoutConstraint!
+
     // MARK: Public
     
     weak var delegate: TradingPairViewDelegate?
@@ -85,10 +86,7 @@ class TradingPairView: NibBasedView {
         let presentationUpdate = TradingPresentationUpdate(
             animations: [
                 .backgroundColors(left: pair.from.brandColor, right: pair.to.brandColor),
-                .statusTintColor(.green),
-                .swapTintColor(.grayBlue),
-                .rightStatusVisibility(.visible),
-                .leftStatusVisibility(.hidden)
+                .swapTintColor(.grayBlue)
             ],
             animation: animation
         )
@@ -128,22 +126,22 @@ class TradingPairView: NibBasedView {
             exchangeLabel.textColor = color
             receiveLabel.textColor = color
             
-        case .statusTintColor(let color):
-            rightIconStatusImageView.tintColor = color
-            leftIconStatusImageView.tintColor = color
-            
-        case .rightStatusVisibility(let visibility):
-            rightIconStatusImageView.alpha = visibility.defaultAlpha
-            
-        case .leftStatusVisibility(let visibility):
-            leftIconStatusImageView.alpha = visibility.defaultAlpha
-            
         case .backgroundColors(left: let leftColor, right: let rightColor):
             leftButton.backgroundColor = leftColor
             rightButton.backgroundColor = rightColor
             
         case .swapTintColor(let color):
             swapButton.tintColor = color
+
+        case .titleVisibility(let visibility):
+            exchangeLabel.alpha = visibility.defaultAlpha
+            receiveLabel.alpha = visibility.defaultAlpha
+            leftButtonConstraintToTop.isActive = (visibility == .hidden)
+            rightButtonConstraintToTop.isActive = (visibility == .hidden)
+            leftButtonConstraintToLabel.isActive = (visibility == .visible)
+            rightButtonConstraintToLabel.isActive = (visibility == .visible)
+            setNeedsUpdateConstraints()
+            updateConstraintsIfNeeded()
         }
     }
     
@@ -200,8 +198,6 @@ extension TradingPairView {
         let presentationUpdate = TradingPresentationUpdate(
             animations: [
                 .backgroundColors(left: fromAsset.brandColor, right: toAsset.brandColor),
-                .leftStatusVisibility(.hidden),
-                .rightStatusVisibility(.hidden),
                 .swapTintColor(#colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)),
                 .titleColor(#colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0))
             ],
@@ -256,8 +252,6 @@ extension TradingPairView {
         let presentationUpdate = TradingPresentationUpdate(
             animations: [
                 .backgroundColors(left: fromAsset.brandColor, right: toAsset.brandColor),
-                .leftStatusVisibility(.hidden),
-                .rightStatusVisibility(.hidden),
                 .swapTintColor(.brandPrimary),
                 .titleColor(.brandPrimary)
             ],

--- a/Blockchain/Homebrew/Exchange/Views/TradingPairView.xib
+++ b/Blockchain/Homebrew/Exchange/Views/TradingPairView.xib
@@ -18,10 +18,12 @@
             <connections>
                 <outlet property="exchangeLabel" destination="mEa-sJ-jfN" id="7fg-j4-fbC"/>
                 <outlet property="leftButton" destination="GNR-OY-3hz" id="Uua-Ij-Ugm"/>
-                <outlet property="leftIconStatusImageView" destination="Bqm-I7-yVy" id="ZL0-F8-Hvp"/>
+                <outlet property="leftButtonConstraintToLabel" destination="D5I-rJ-glB" id="e2C-Wj-cfX"/>
+                <outlet property="leftButtonConstraintToTop" destination="oXF-vx-u0I" id="423-us-9ic"/>
                 <outlet property="receiveLabel" destination="HMc-y4-c3x" id="lPG-qE-A0l"/>
                 <outlet property="rightButton" destination="KVO-Wl-0DT" id="MIr-ct-XPn"/>
-                <outlet property="rightIconStatusImageView" destination="0ad-gs-pwk" id="Z0d-5h-9qS"/>
+                <outlet property="rightButtonConstraintToLabel" destination="OjX-fo-PlQ" id="dMM-du-ivZ"/>
+                <outlet property="rightButtonConstraintToTop" destination="OUS-Yq-n83" id="mZK-8s-RNo"/>
                 <outlet property="swapButton" destination="mjP-2F-nXO" id="QCP-pO-L4C"/>
             </connections>
         </placeholder>
@@ -31,7 +33,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mjP-2F-nXO">
-                    <rect key="frame" x="165" y="65" width="44" height="44"/>
+                    <rect key="frame" x="165" y="56" width="44" height="44"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="44" id="O8B-tX-SWr"/>
                         <constraint firstAttribute="height" constant="44" id="kuj-TF-NM7"/>
@@ -42,25 +44,11 @@
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Exchange" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mEa-sJ-jfN">
-                    <rect key="frame" x="0.0" y="0.0" width="59" height="15"/>
+                    <rect key="frame" x="0.0" y="0.0" width="58.5" height="15"/>
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="12"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Icon-StatusDot" translatesAutoresizingMaskIntoConstraints="NO" id="Bqm-I7-yVy">
-                    <rect key="frame" x="61" y="3.5" width="8" height="8"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="8" id="XXy-bd-3df"/>
-                        <constraint firstAttribute="height" constant="8" id="hL5-k6-7f6"/>
-                    </constraints>
-                </imageView>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Icon-StatusDot" translatesAutoresizingMaskIntoConstraints="NO" id="0ad-gs-pwk">
-                    <rect key="frame" x="257" y="3.5" width="8" height="8"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="8" id="P8s-44-qb3"/>
-                        <constraint firstAttribute="width" constant="8" id="bmz-ZN-RoV"/>
-                    </constraints>
-                </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Receive" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HMc-y4-c3x">
                     <rect key="frame" x="209" y="0.0" width="46" height="15"/>
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="12"/>
@@ -68,7 +56,8 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KVO-Wl-0DT">
-                    <rect key="frame" x="209" y="18" width="166" height="138"/>
+                    <rect key="frame" x="209" y="0.0" width="166" height="156"/>
+                    <color key="backgroundColor" red="0.58861437179999998" green="0.1192065683" blue="0.087561899159999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="16"/>
                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="-5" maxY="0.0"/>
                     <state key="normal" title="Ether" image="Icon-ETH"/>
@@ -77,7 +66,8 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GNR-OY-3hz">
-                    <rect key="frame" x="0.0" y="18" width="165" height="138"/>
+                    <rect key="frame" x="0.0" y="0.0" width="165" height="156"/>
+                    <color key="backgroundColor" red="0.016804177310000001" green="0.19835099580000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="16"/>
                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="-5" maxY="0.0"/>
                     <state key="normal" title="Bitcoin" image="Icon-BTC"/>
@@ -91,15 +81,12 @@
                 <constraint firstItem="mEa-sJ-jfN" firstAttribute="top" secondItem="QVq-IM-xha" secondAttribute="top" id="05V-f3-DJJ"/>
                 <constraint firstItem="mjP-2F-nXO" firstAttribute="leading" secondItem="GNR-OY-3hz" secondAttribute="trailing" id="1Sy-2Q-kTd"/>
                 <constraint firstItem="GNR-OY-3hz" firstAttribute="leading" secondItem="QVq-IM-xha" secondAttribute="leading" id="26e-iJ-ctS"/>
-                <constraint firstItem="0ad-gs-pwk" firstAttribute="centerY" secondItem="HMc-y4-c3x" secondAttribute="centerY" id="668-4M-jiQ"/>
                 <constraint firstItem="mjP-2F-nXO" firstAttribute="centerX" secondItem="QVq-IM-xha" secondAttribute="centerX" id="9gV-6O-eDg"/>
                 <constraint firstItem="GNR-OY-3hz" firstAttribute="top" secondItem="mEa-sJ-jfN" secondAttribute="bottom" constant="3" id="D5I-rJ-glB"/>
-                <constraint firstItem="0ad-gs-pwk" firstAttribute="leading" secondItem="HMc-y4-c3x" secondAttribute="trailing" constant="2" id="KRf-UT-5P5"/>
                 <constraint firstItem="KVO-Wl-0DT" firstAttribute="top" secondItem="QVq-IM-xha" secondAttribute="top" id="OUS-Yq-n83"/>
                 <constraint firstItem="KVO-Wl-0DT" firstAttribute="top" secondItem="HMc-y4-c3x" secondAttribute="bottom" constant="3" id="OjX-fo-PlQ"/>
                 <constraint firstItem="QVq-IM-xha" firstAttribute="trailing" secondItem="KVO-Wl-0DT" secondAttribute="trailing" id="Pps-t7-TES"/>
                 <constraint firstItem="mEa-sJ-jfN" firstAttribute="leading" secondItem="QVq-IM-xha" secondAttribute="leading" id="R2K-jp-pIL"/>
-                <constraint firstItem="Bqm-I7-yVy" firstAttribute="centerY" secondItem="mEa-sJ-jfN" secondAttribute="centerY" id="YBl-lr-JxV"/>
                 <constraint firstItem="KVO-Wl-0DT" firstAttribute="leading" secondItem="mjP-2F-nXO" secondAttribute="trailing" id="fkT-3J-ZC4"/>
                 <constraint firstItem="QVq-IM-xha" firstAttribute="bottom" secondItem="KVO-Wl-0DT" secondAttribute="bottom" id="mx8-iz-V9Q"/>
                 <constraint firstItem="HMc-y4-c3x" firstAttribute="leading" secondItem="KVO-Wl-0DT" secondAttribute="leading" id="n3G-md-mNs"/>
@@ -107,14 +94,13 @@
                 <constraint firstItem="HMc-y4-c3x" firstAttribute="top" secondItem="QVq-IM-xha" secondAttribute="top" id="qXo-7g-b9D"/>
                 <constraint firstItem="QVq-IM-xha" firstAttribute="bottom" secondItem="GNR-OY-3hz" secondAttribute="bottom" id="uU0-BO-dIN"/>
                 <constraint firstItem="mjP-2F-nXO" firstAttribute="centerY" secondItem="GNR-OY-3hz" secondAttribute="centerY" id="xW6-Pm-rP4"/>
-                <constraint firstItem="Bqm-I7-yVy" firstAttribute="leading" secondItem="mEa-sJ-jfN" secondAttribute="trailing" constant="2" id="yhR-C9-M2F"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="QVq-IM-xha"/>
             <variation key="default">
                 <mask key="constraints">
-                    <exclude reference="oXF-vx-u0I"/>
-                    <exclude reference="OUS-Yq-n83"/>
+                    <exclude reference="D5I-rJ-glB"/>
+                    <exclude reference="OjX-fo-PlQ"/>
                 </mask>
             </variation>
             <point key="canvasLocation" x="22.5" y="253"/>
@@ -123,7 +109,6 @@
     <resources>
         <image name="Icon-BTC" width="24" height="24"/>
         <image name="Icon-ETH" width="24" height="24"/>
-        <image name="Icon-Exchange" width="24" height="24"/>
-        <image name="Icon-StatusDot" width="8" height="8"/>
+        <image name="Icon-Exchange" width="20" height="18"/>
     </resources>
 </document>


### PR DESCRIPTION
## Objective

Update look/ behavior of `TradingPairView`.

## Description
* Optionally hide Exchange/Receive title
* Tapping the swap button will swap the trading pairs and not the fix
* Hide green dot

## Screenshot/Design assessment

![simulator screen shot - iphone 8 - 2018-09-25 at 17 44 16](https://user-images.githubusercontent.com/38220701/46050748-aea92100-c0ea-11e8-8081-1d2fc9732ec9.png)

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
