### PR TITLE
fix(Exchange): fix issue where partner exchange can't be launched.

### DIFF
--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -159,11 +159,7 @@ struct ExchangeServices: ExchangeDependencies {
                 Logger.shared.error("View controller to present on is nil")
                 return
             }
-            guard let country = country else {
-                Logger.shared.warning("Country is nil. Cannot present partner exchange.")
-                return
-            }
-            exchangeViewController = PartnerExchangeListViewController.create(withCountryCode: country.code)
+            exchangeViewController = PartnerExchangeListViewController.create(withCountryCode: country?.code)
             let partnerNavigationController = BCNavigationController(
                 rootViewController: exchangeViewController,
                 title: LocalizationConstants.Exchange.navigationTitle

--- a/Blockchain/View Controllers/PartnerExchangeListViewController.h
+++ b/Blockchain/View Controllers/PartnerExchangeListViewController.h
@@ -9,6 +9,6 @@
 #import <UIKit/UIKit.h>
 
 @interface PartnerExchangeListViewController : UIViewController
-+ (PartnerExchangeListViewController * _Nonnull)createWithCountryCode:(NSString *_Nonnull)countryCode;
++ (PartnerExchangeListViewController * _Nonnull)createWithCountryCode:(NSString *_Nullable)countryCode;
 - (void)reloadSymbols;
 @end

--- a/Blockchain/View Controllers/PartnerExchangeListViewController.m
+++ b/Blockchain/View Controllers/PartnerExchangeListViewController.m
@@ -34,7 +34,7 @@
 
 @implementation PartnerExchangeListViewController
 
-+ (PartnerExchangeListViewController * _Nonnull)createWithCountryCode:(NSString *_Nonnull)countryCode
++ (PartnerExchangeListViewController * _Nonnull)createWithCountryCode:(NSString *_Nullable)countryCode
 {
     PartnerExchangeListViewController *controller = [[PartnerExchangeListViewController alloc] init];
     controller.countryCode = countryCode;
@@ -49,13 +49,15 @@
     
     self.view.backgroundColor = UIColor.lightGray;
 
-    if ([self.countryCode  isEqual: @"US"]) {
+    Wallet *wallet = WalletManager.sharedInstance.wallet;
+    NSString *countryCode = (self.countryCode != nil) ? self.countryCode : wallet.countryCodeGuess;
+    NSArray *availableStates = wallet.availableUSStates;
+    if ([countryCode  isEqual: @"US"] && availableStates.count > 0) {
         [[LoadingViewPresenter sharedInstance] hideBusyView];
-        NSArray *availableStates = [WalletManager.sharedInstance.wallet availableUSStates];
         [self showStates:availableStates];
     } else {
         [[LoadingViewPresenter sharedInstance] showBusyViewWithLoadingText:[LocalizationConstantsObjcBridge loadingExchange]];
-        [WalletManager.sharedInstance.wallet performSelector:@selector(getExchangeTrades) withObject:nil afterDelay:ANIMATION_DURATION];
+        [wallet performSelector:@selector(getExchangeTrades) withObject:nil afterDelay:ANIMATION_DURATION];
     }
 }
 


### PR DESCRIPTION
## Objective

Fixes issue where partner exchange cannot be launched when tapping on the exchange side menu. This was a regression introduced in 91891143.

## How to Test

Launch the app with an approved nabu user (but have "enable homebrew" in the debug options turned off), tap on "Exchange", verify that the partner exchange is launched.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
