### PR TITLE
fix(HB): IOS-1319 - Adding `SocketError` and error subscribing to `ExchangeInteractor`

### DIFF
--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -19,7 +19,7 @@ class ExchangeCreateInteractor {
         }
     }
 
-    private var disposable: Disposable?
+    private let disposables = CompositeDisposable()
     private var tradingLimitDisposable: Disposable?
 
     fileprivate let inputs: ExchangeInputsAPI
@@ -62,11 +62,10 @@ class ExchangeCreateInteractor {
     }
 
     deinit {
-        disposable?.dispose()
-        disposable = nil
-
         tradingLimitDisposable?.dispose()
         tradingLimitDisposable = nil
+        
+        disposables.dispose()
     }
 }
 
@@ -95,7 +94,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
     }
 
     func subscribeToConversions() {
-        disposable = markets.conversions.subscribe(onNext: { [weak self] conversion in
+        let conversionsDisposable = markets.conversions.subscribe(onNext: { [weak self] conversion in
             guard let this = self else { return }
 
             guard let model = this.model else { return }
@@ -122,6 +121,13 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         }, onError: { error in
             Logger.shared.error("Error subscribing to quote with trading pair")
         })
+        
+        let errorDisposable = markets.errors.subscribe(onNext: { [weak self] socketError in
+            // TODO: Implement error handling from Socket.
+        })
+        
+        _ = disposables.insert(conversionsDisposable)
+        _ = disposables.insert(errorDisposable)
     }
 
     func updateMarketsConversion() {

--- a/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
@@ -30,6 +30,7 @@ protocol ExchangeMarketsAPI {
 
     var hasAuthenticated: Bool { get }
     var conversions: Observable<Conversion> { get }
+    var errors: Observable<SocketError> { get }
     func updateConversion(model: MarketsModel)
 }
 
@@ -106,6 +107,17 @@ extension MarketsService: ExchangeMarketsAPI {
             return restMessageSubject.filter({ _ -> Bool in
                 return false
             })
+        }
+    }
+    
+    var errors: Observable<SocketError> {
+        // TODO: handle REST
+        // TICKET: IOS-1320
+        return socketMessageObservable.filter {
+            $0.type == .exchange &&
+                $0.JSONMessage is SocketError
+            }.map { message in
+                return message.JSONMessage as! SocketError
         }
     }
 

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -44,6 +44,9 @@ extension SocketMessageCodable {
         do {
             let decoded = try JSONType.decode(data: data)
             let socketMessage = SocketMessage(type: socketType, JSONMessage: decoded)
+            if JSONType.self != HeartBeat.self {
+                Logger.shared.debug("Decoded socket message of type \(JSONType.self)")
+            }
             onSuccess(socketMessage)
             return
         } catch {

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -44,9 +44,6 @@ extension SocketMessageCodable {
         do {
             let decoded = try JSONType.decode(data: data)
             let socketMessage = SocketMessage(type: socketType, JSONMessage: decoded)
-            if JSONType.self != HeartBeat.self {
-                Logger.shared.debug("Decoded socket message of type \(JSONType.self)")
-            }
             onSuccess(socketMessage)
             return
         } catch {

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -44,7 +44,6 @@ extension SocketMessageCodable {
         do {
             let decoded = try JSONType.decode(data: data)
             let socketMessage = SocketMessage(type: socketType, JSONMessage: decoded)
-            Logger.shared.debug("Decoded socket message of type \(JSONType.self)")
             onSuccess(socketMessage)
             return
         } catch {
@@ -179,6 +178,81 @@ extension Conversion {
         let counter = "1" + " " + counterSymbol
         let fiat = fiatSymbol + quote.currencyRatio.counterToFiatRate
         return counter + " = " + fiat
+    }
+}
+
+/// `SocketError` is for any type of error that
+/// is returned from the WS endpoint. 
+struct SocketError: SocketMessageCodable, Error {
+    typealias JSONType = SocketError
+    
+    enum SocketErrorType {
+        
+        case currencyRatioError
+        case `default`
+        
+        init(rawValue: String) {
+            switch rawValue {
+            case "currencyRatioError":
+                self = .currencyRatioError
+            default:
+                self = .default
+            }
+        }
+    }
+    
+    
+    let errorType: SocketErrorType
+    let channel: String
+    let description: String
+    
+    private enum CodingKeys: CodingKey {
+        case type
+        case channel
+        case error
+    }
+    
+    private enum ErrorKeys: CodingKey {
+        case description
+    }
+    
+    init(channel: String, description: String) {
+        self.errorType = .default
+        self.channel = channel
+        self.description = description
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let typeValue = try container.decode(String.self, forKey: .type)
+        errorType = SocketErrorType(rawValue: typeValue)
+        channel = try container.decode(String.self, forKey: .channel)
+        let errorContainer = try container.nestedContainer(keyedBy: ErrorKeys.self, forKey: .error)
+        description = try errorContainer.decode(String.self, forKey: .description)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(errorType.rawValue, forKey: .type)
+        try container.encode(channel, forKey: .channel)
+        var errorContainer = container.nestedContainer(keyedBy: ErrorKeys.self, forKey: .error)
+        try errorContainer.encode(description, forKey: .description)
+    }
+}
+
+extension SocketError {
+    static let generic: SocketError = SocketError(channel: "unknown", description: "unknown")
+}
+
+extension SocketError.SocketErrorType {
+    
+    var rawValue: String {
+        switch self {
+        case .currencyRatioError:
+            return "currencyRatioError"
+        case .default:
+            return "default"
+        }
     }
 }
 

--- a/Blockchain/Network/SocketManager.swift
+++ b/Blockchain/Network/SocketManager.swift
@@ -23,16 +23,6 @@ class SocketManager {
     init() {
         self.webSocketMessageSubject = PublishSubject<SocketMessage>()
     }
-    
-    /// Data providers should subscribe to this for error handling.
-    /// The reason we use this and not `webSocketMessageObservable` is
-    /// because since it's technically not an `Error` but rather a `SocketMessage`
-    /// the `onError` closure in the `webSocketMessageObservable` won't be called.
-    /// For simplicity sake, you'll want to observe both `webSocketMessageObservable`
-    /// and `webSocketErrorObservable`.
-    var webSocketErrorObservable: Observable<SocketMessage> {
-        return webSocketMessageSubject.asObservable()
-    }
 
     /// Data providers should suscribe to this and filter (e.g., { $0 is ExchangeSocketMessage })
     var webSocketMessageObservable: Observable<SocketMessage> {


### PR DESCRIPTION
## Objective

This is a progress PR for adding in some error handling in `SocketManager`. 

## Description

This PR includes the addition of `SocketError` as well as `ExchangeInteractor` subscribing to the error payloads returned by `SocketManager`. Note that this PR does not include UI updates in response to the returned errors. 

I also dialed back the logging a bit in `SocketManager`. I'm filtering out `Heartbeat` types as it was getting a bit noisy in the console log. 

## How to Test

1. Build and run
2. Go to the new exchange
3. Begin entering in some small values. You should see errors returned in the console log. e.g. `Decoded socket message of type SocketError`
4. Enter in a value that is within the appropriate limits (max/min). You should see the correct conversion. 

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
