### PR TITLE
fix(HB): Fixing issue where multiple trades could be submitted.

### DIFF
--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -32,6 +32,7 @@ protocol ExchangeCreateInput: NumberKeypadViewDelegate {
     func ratesViewTapped()
     func useMinimumAmount(assetAccount: AssetAccount)
     func useMaximumAmount(assetAccount: AssetAccount)
+    func confirmationIsExecuting() -> Bool
     func confirmConversion()
     func changeMarketPair(marketPair: MarketPair)
 }

--- a/Blockchain/Homebrew/Exchange/API/TradeExecutionAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/TradeExecutionAPI.swift
@@ -18,4 +18,8 @@ protocol TradeExecutionAPI {
 
     // Build a transaction and send it
     func submitAndSend(with conversion: Conversion, success: @escaping (() -> Void), error: @escaping ((String) -> Void))
+    
+    /// Check if the service is currently executing a request prior to
+    /// submitting an additional request.
+    var isExecuting: Bool { get set }
 }

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -255,11 +255,25 @@ class ExchangeDetailCoordinator: NSObject {
                 Logger.shared.error("No conversion to use")
                 return
             }
-            tradeExecution.submitAndSend(with: lastConversion, success: { [weak self] in
+            guard tradeExecution.isExecuting == false else { return }
+            interface?.loadingVisibility(.visible, action: .confirmExchange)
+            
+            tradeExecution.submitAndSend(
+                with: lastConversion,
+                success: { [weak self] in
+                    guard let this = self else { return }
+                    this.interface?.loadingVisibility(.hidden, action: .confirmExchange)
+                    ExchangeCoordinator.shared.handle(
+                        event: .sentTransaction(
+                            orderTransaction: transaction,
+                            conversion: lastConversion
+                        )
+                    )
+            }) { [weak self] errorDescription in
                 guard let this = self else { return }
-                ExchangeCoordinator.shared.handle(event: .sentTransaction(orderTransaction: transaction, conversion: lastConversion))
-                this.delegate?.coordinator(this, completedTransaction: transaction)
-            }) { AlertViewPresenter.shared.standardError(message: $0) }
+                this.interface?.loadingVisibility(.hidden, action: .confirmExchange)
+                AlertViewPresenter.shared.standardError(message: errorDescription)
+            }
         }
     }
 }

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -272,6 +272,10 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         updatedInput()
         output?.updateTradingPair(pair: model.pair, fix: model.fix)
     }
+    
+    func confirmationIsExecuting() -> Bool {
+        return tradeExecution.isExecuting
+    }
 
     func confirmConversion() {
         guard let conversion = self.model?.lastConversion else {

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -84,10 +84,12 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
     }
 
     func onExchangeButtonTapped() {
+        guard interactor.confirmationIsExecuting() == false else { return }
         interactor.confirmConversion()
     }
 
     func confirmConversion() {
+        guard interactor.confirmationIsExecuting() == false else { return }
         interactor.confirmConversion()
     }
 }

--- a/Blockchain/Models/Wallet.h
+++ b/Blockchain/Models/Wallet.h
@@ -462,8 +462,8 @@
 - (void)updateKYCUserCredentialsWithUserId:(NSString *)userId lifetimeToken:(NSString *)lifetimeToken success:(void (^ _Nonnull)(NSString *_Nonnull))success error: (void (^ _Nonnull)(NSString *_Nullable))error;
 - (NSString *_Nullable)KYCUserId;
 - (NSString *_Nullable)KYCLifetimeToken;
-- (void)createOrderPaymentWithOrderTransaction:(OrderTransactionLegacy *_Nonnull)orderTransaction success:(void (^)(NSString *_Nonnull))success error:(void (^ _Nonnull)(NSString *_Nonnull))error;
-- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error;
+- (void)createOrderPaymentWithOrderTransaction:(OrderTransactionLegacy *_Nonnull)orderTransaction completion:(void (^ _Nonnull)(void))completion success:(void (^)(NSString *_Nonnull))success error:(void (^ _Nonnull)(NSString *_Nonnull))error;
+- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error;
 // Top Bar Display
 - (NSDecimalNumber *)btcDecimalBalance;
 - (NSDecimalNumber *)ethDecimalBalance;


### PR DESCRIPTION
## Objective

Fixes an issue where multiple trades could be submitted on the `Exchange - Send Now` screen.

## Description

This PR adds an `isExecuting` property to the `TradeExecutionAPI`. It also adds some completion handlers to the `Wallet` class to allow `TradeExecutionService` to update its `isExecuting` property when the `Wallet` completes exchange submissions. 

## How to Test

1. Build and run
2. Go to the exchange
3. Create an exchange
4. Tap `Send Now` quickly, twice. 
5. See that a loading indicator is shown preventing the user from multiple taps
6. See that the `isExecuting` property is `true` when a request is in flight, and thus returns early. 

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
