### PR TITLE
fix(KYC): IOS-1300 allow tapping of "Done" button by dismissing Onfido view controller modally

### DIFF
--- a/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
+++ b/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
@@ -170,15 +170,18 @@ extension KYCVerifyIdentityController: OnfidoControllerDelegate {
     }
 
     func onOnfidoControllerSuccess(_ onfidoController: OnfidoController) {
-        onfidoController.dismiss(animated: true)
         LoadingViewPresenter.shared.showBusyView(withLoadingText: LocalizationConstants.KYC.submittingInformation)
         _ = onfidoService.submitVerification(onfidoController.user)
             .subscribe(onCompleted: { [unowned self] in
                 LoadingViewPresenter.shared.hideBusyView()
-                self.coordinator.handle(event: .nextPageFromPageType(self.pageType, nil))
+                self.dismiss(animated: true, completion: {
+                    self.coordinator.handle(event: .nextPageFromPageType(self.pageType, nil))
+                })
             }, onError: { error in
                 LoadingViewPresenter.shared.hideBusyView()
-                AlertViewPresenter.shared.standardError(message: LocalizationConstants.Errors.genericError)
+                self.dismiss(animated: true, completion: {
+                    AlertViewPresenter.shared.standardError(message: LocalizationConstants.Errors.genericError)
+                })
                 Logger.shared.error("Failed to submit verification \(error.localizedDescription)")
             })
     }


### PR DESCRIPTION
## Objective

Allow "Done" button to be tapped on the Application Complete screen.

## Description

Dismissed Onfido view controller.

## How to Test

Go through KYC, should be able to tap on the "Done" button.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
