### PR TITLE
fix(Send): IOS-1314 - Fixing unrecognized selector crash

### DIFF
--- a/Blockchain/View Controllers/SendEtherViewController.m
+++ b/Blockchain/View Controllers/SendEtherViewController.m
@@ -145,7 +145,7 @@
     continueButton.layer.cornerRadius = CORNER_RADIUS_BUTTON;
     continueButton.titleLabel.font = [UIFont fontWithName:FONT_MONTSERRAT_REGULAR size:17.0];
     [continueButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-    [continueButton addTarget:self action:@selector(continueButtonClicked) forControlEvents:UIControlEventTouchUpInside];
+    [continueButton addTarget:self action:@selector(continueButtonTapped) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:continueButton];
     self.continuePaymentButton = continueButton;
 }


### PR DESCRIPTION
## Objective

Fixes a crash when sending ETH

## Description

`continueButton` was calling `continueButtonClicked` rather than `continueButtonTapped`.

## How to Test

1. Build and run
2. Tap `Send`
3. Select `ETH`
4. Tap `Continue`
5. It should not crash. 

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
