### PR TITLE
fix(Exchange): compute min/max (IOS-1361)

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -513,6 +513,7 @@
 		A2599BA71B0B726900C2EA81 /* BackupVerifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2599BA61B0B726900C2EA81 /* BackupVerifyViewController.swift */; };
 		A269E92E1B32D51F0052F953 /* SecondPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A269E92D1B32D51F0052F953 /* SecondPasswordViewController.swift */; };
 		A2913FA21B31830000DC6C15 /* BackupNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2913FA11B31830000DC6C15 /* BackupNavigationViewController.swift */; };
+		AA08439A215C0E210007BFD1 /* SocketMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA084399215C0E210007BFD1 /* SocketMessageTests.swift */; };
 		AA0A412C214AD75300807163 /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A412B214AD75300807163 /* DebugSettings.swift */; };
 		AA0A412D214ADD5B00807163 /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A412B214AD75300807163 /* DebugSettings.swift */; };
 		AA0A4147214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A4146214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift */; };
@@ -3005,6 +3006,7 @@
 		A269E92D1B32D51F0052F953 /* SecondPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecondPasswordViewController.swift; sourceTree = "<group>"; };
 		A2913FA11B31830000DC6C15 /* BackupNavigationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackupNavigationViewController.swift; sourceTree = "<group>"; };
 		A5185A3368C92DCF1134710A /* Pods_BlockchainTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlockchainTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA084399215C0E210007BFD1 /* SocketMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketMessageTests.swift; sourceTree = "<group>"; };
 		AA0A412B214AD75300807163 /* DebugSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettings.swift; sourceTree = "<group>"; };
 		AA0A4146214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeAssetAccountListPresenter.swift; sourceTree = "<group>"; };
 		AA0A414A214B152100807163 /* AssetAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAccount.swift; sourceTree = "<group>"; };
@@ -3842,10 +3844,11 @@
 		511356DF209CA48F00056D65 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				AAE94DC820C25111005A3595 /* API */,
 				511356E0209CA4BA00056D65 /* BlockchainAPI+PayloadTests.swift */,
 				51A862DE20921FCA00B338E0 /* BlockchainAPI+URLSuffixTests.swift */,
 				519435AB208E6279001EF882 /* CertificatePinnerTests.swift */,
+				AAE94DC820C25111005A3595 /* API */,
+				AA08438F215C0E010007BFD1 /* Models */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -6345,6 +6348,14 @@
 			path = "View Controllers";
 			sourceTree = "<group>";
 		};
+		AA08438F215C0E010007BFD1 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				AA084399215C0E210007BFD1 /* SocketMessageTests.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		AA0A4121214AD71100807163 /* Debug */ = {
 			isa = PBXGroup;
 			children = (
@@ -7824,6 +7835,7 @@
 				602B9D192118E25F00BD3D60 /* LocationDataProvider.swift in Sources */,
 				3AB4D8EE212F2017004F0160 /* DateFormatterTests.swift in Sources */,
 				AABB74C920D44B0600C0F7C5 /* AboutUsViewController.swift in Sources */,
+				AA08439A215C0E210007BFD1 /* SocketMessageTests.swift in Sources */,
 				511356BF209B7F6E00056D65 /* BlockchainAPI+Payload.swift in Sources */,
 				602B9D272118E28E00BD3D60 /* ValidationTextField.swift in Sources */,
 				3A26D527214055E600D79BDD /* TradingPairCell.swift in Sources */,

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -187,6 +187,18 @@ extension Conversion {
 struct CurrencyPairRate: Codable {
     let pair: String
     let price: Decimal
+
+    enum CodingKeys: String, CodingKey {
+        case pair
+        case price
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        pair = try container.decode(String.self, forKey: .pair)
+        let priceString = try container.decode(String.self, forKey: .price)
+        price = Decimal(string: priceString)!
+    }
 }
 
 struct Quote: Codable {

--- a/BlockchainTests/Network/Models/SocketMessageTests.swift
+++ b/BlockchainTests/Network/Models/SocketMessageTests.swift
@@ -1,0 +1,35 @@
+//
+//  SocketMessageTests.swift
+//  BlockchainTests
+//
+//  Created by Chris Arriola on 9/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import XCTest
+@testable import Blockchain
+
+class SocketMessageTests: XCTestCase {
+
+    func testDecodingExchangeRates() {
+        let json = """
+        {
+         "sequenceNumber":12,
+         "channel":"exchange_rate",
+         "type":"exchangeRate",
+         "rates": [
+            {"pair":"USD-BTC","price":"0.00015351"},
+            {"pair":"USD-ETH","price":"0.00455498"},
+            {"pair":"USD-BCH","price":"0.00193979"}
+         ]
+        }
+        """.data(using: .utf8)!
+
+        let exchangeRates = try? JSONDecoder().decode(ExchangeRates.self, from: json)
+        XCTAssertNotNil(exchangeRates, "ExchangeRates could not be decoded")
+
+        let usdBtcPair = exchangeRates!.rates.first(where: { $0.pair == "USD-BTC" })
+        XCTAssertNotNil(usdBtcPair, "USD-BTC pair not found")
+        XCTAssertEqual(Decimal(string: "0.00015351")!, usdBtcPair!.price)
+    }
+}


### PR DESCRIPTION
## Objective

Fix min/max not working on exchange create view.

## Description

The reason this was breaking was because the server now returns best rates as a string rather than a number.

## How to Test

Go to exchange, tap min/max, verify that you see it working.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [X] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
