### PR TITLE
fix(KYC): IOS-1310 - Autocomplete leaves address field blank

### DIFF
--- a/Blockchain/KYC/Address/KYCAddressController.swift
+++ b/Blockchain/KYC/Address/KYCAddressController.swift
@@ -214,7 +214,9 @@ extension KYCAddressController: LocationSuggestionInterface {
     }
 
     func populateAddressEntryView(_ address: PostalAddress) {
-        addressTextField.text = "\(address.streetNumber ?? "") \(address.street ?? "")"
+        if let number = address.streetNumber, let street = address.street {
+            addressTextField.text = "\(number) \(street)"
+        }
         cityTextField.text = address.city
         stateTextField.text = address.state
         postalCodeTextField.text = address.postalCode


### PR DESCRIPTION
## Objective

Fixes an issue where autocomplete could leave a blank address field.

## Description

If the address didn't contain a street number or street address, we populated the field with two empty strings and a space. This caused the placeholder to no longer be visible. Now we only populate the field if there is a valid street number and street address. 

## How to Test

1. Build and run
2. Go through KYC
3. Use the autocomplete feature in the address screen
4. Select an address
5. It should autopopulate.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
