### PR TITLE
feat(NabuNetworkError): unmarshall error payloads returned by Nabu into NabuNetworkError, if possible

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -514,6 +514,8 @@
 		A269E92E1B32D51F0052F953 /* SecondPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A269E92D1B32D51F0052F953 /* SecondPasswordViewController.swift */; };
 		A2913FA21B31830000DC6C15 /* BackupNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2913FA11B31830000DC6C15 /* BackupNavigationViewController.swift */; };
 		AA08439A215C0E210007BFD1 /* SocketMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA084399215C0E210007BFD1 /* SocketMessageTests.swift */; };
+		AA08439F215C47290007BFD1 /* NabuNetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08439E215C47290007BFD1 /* NabuNetworkError.swift */; };
+		AA0843A0215C47290007BFD1 /* NabuNetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08439E215C47290007BFD1 /* NabuNetworkError.swift */; };
 		AA0A412C214AD75300807163 /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A412B214AD75300807163 /* DebugSettings.swift */; };
 		AA0A412D214ADD5B00807163 /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A412B214AD75300807163 /* DebugSettings.swift */; };
 		AA0A4147214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A4146214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift */; };
@@ -3007,6 +3009,7 @@
 		A2913FA11B31830000DC6C15 /* BackupNavigationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackupNavigationViewController.swift; sourceTree = "<group>"; };
 		A5185A3368C92DCF1134710A /* Pods_BlockchainTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlockchainTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA084399215C0E210007BFD1 /* SocketMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketMessageTests.swift; sourceTree = "<group>"; };
+		AA08439E215C47290007BFD1 /* NabuNetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NabuNetworkError.swift; sourceTree = "<group>"; };
 		AA0A412B214AD75300807163 /* DebugSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettings.swift; sourceTree = "<group>"; };
 		AA0A4146214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeAssetAccountListPresenter.swift; sourceTree = "<group>"; };
 		AA0A414A214B152100807163 /* AssetAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAccount.swift; sourceTree = "<group>"; };
@@ -6457,6 +6460,7 @@
 			isa = PBXGroup;
 			children = (
 				3A8B229C211E2A960091E706 /* NabuUser.swift */,
+				AA08439E215C47290007BFD1 /* NabuNetworkError.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -7586,6 +7590,7 @@
 				AACE31DA2092A99B00B7B806 /* Application+Helpers.swift in Sources */,
 				602B9D252118E27100BD3D60 /* KYCVerifyPhoneNumberPresenter.swift in Sources */,
 				3A3D5D8E211B454000E6C241 /* ValidationDateField.swift in Sources */,
+				AA0843A0215C47290007BFD1 /* NabuNetworkError.swift in Sources */,
 				AA447BCB21276DA900EC0FA0 /* SideMenuPresenter.swift in Sources */,
 				C7C0DC24212F6783000EFE71 /* ExchangeService.swift in Sources */,
 				C787180220A22362000CC46E /* WalletAddressesDelegate.swift in Sources */,
@@ -8133,6 +8138,7 @@
 				AA0A4147214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift in Sources */,
 				C75EE7D8201BBA820067BA16 /* UITextView+Animations.m in Sources */,
 				23C95EA61C0779C600E4692A /* SettingsChangePasswordViewController.m in Sources */,
+				AA08439F215C47290007BFD1 /* NabuNetworkError.swift in Sources */,
 				51578AEA20B448BF00B0080A /* WalletKeyImportDelegate.swift in Sources */,
 				23FDEFA91D6E43DE00FC80D6 /* TransactionDetailTableCell.m in Sources */,
 				3AC4F97821234040003AA207 /* Storyboardable.swift in Sources */,

--- a/Blockchain/Homebrew/Models/NabuNetworkError.swift
+++ b/Blockchain/Homebrew/Models/NabuNetworkError.swift
@@ -1,0 +1,107 @@
+//
+//  NabuNetworkError.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 9/26/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import Foundation
+
+/// Describes an error returned by Nabu
+struct NabuNetworkError: Codable, Error {
+    let code: NabuNetworkErrorCode
+    let type: NabuNetworkErrorType
+    let description: String
+}
+
+enum NabuNetworkErrorCode: Int, Codable {
+
+    // Generic HTTP errors
+    case internalServerError = 1
+    case notFound = 2
+    case badMethod = 3
+    case conflict = 4
+
+    // generic user input errors
+    case missingBody = 5
+    case missingParam = 6
+    case badParamValue = 7
+
+    // authentication errors
+    case invalidCredentials = 8
+    case wrongPassword = 9
+    case wrong2fa = 10
+    case bad2fa = 11
+    case unknownUser = 12
+    case invalidRole = 13
+    case alreadyLoggedIn = 14
+    case invalidStatus = 15
+
+    // currency ratio errors
+    case notSupportedCurrencyPair = 16
+    case unknownCurrencyPair = 17
+    case unknownCurrency = 18
+    case currencyIsNotFiat = 19
+    case tooSmallVolume = 26
+    case tooBigVolume = 27
+    case resultCurrencyRatioTooSmall = 28
+
+    // conversion errors
+    case providedVolumeIsNotDouble = 20
+    case unknownConversionType = 21
+
+    // kyc errors
+    case userNotActive = 22
+    case pendingKycReview = 23
+    case kycAlreadyCompleted = 24
+    case maxKycAttempts = 25
+    case invalidCountryCode = 29
+
+    // user-onboarding errors
+    case invalidJwtToken = 30
+    case expiredJwtToken = 31
+    case mobileRegisteredAlready = 32
+    case userRegisteredAlready = 33
+    case missingApiToken = 34
+    case couldNotInsertUser = 35
+    case userRestored = 36
+
+    // user trading error
+    case genericTradingError = 37
+    case albertExecutionError = 38
+    case userHasNoCountry = 39
+    case userNotFound = 40
+    case orderBelowMinLimit = 41
+    case wrongDepositAmount = 42
+    case orderAboveMaxLimit = 43
+    case ratesApiError = 44
+    case dailyLimitExceeded = 45
+    case weeklyLimitExceeded = 46
+    case annualLimitExceeded = 47
+    case notCryptoToCryptoCurrencyPair = 48
+}
+
+enum NabuNetworkErrorType: String, Codable {
+
+    // Generic HTTP errors
+    case internalServerError = "INTERNAL_SERVER_ERROR"
+    case notFound = "NOT_FOUND"
+    case badMethod = "BAD_METHOD"
+    case conflict = "CONFLICT"
+
+    // Generic user input errors
+    case missingBody = "MISSING_BODY"
+    case missinParam = "MISSING_PARAM"
+    case badParamValue = "BAD_PARAM_VALUE"
+
+    // Authentication errors
+    case invalidCredentials = "INVALID_CREDENTIALS"
+    case wrongPassword = "WRONG_PASSWORD"
+    case wrong2FA = "WRONG_2FA"
+    case bad2FA = "BAD_2FA"
+    case unknownUser = "UNKNOWN_USER"
+    case invalidRole = "INVALID_ROLE"
+    case alreadyLoggedIn = "ALREADY_LOGGED_IN"
+    case invalidStatus = "INVALID_STATUS"
+}

--- a/Blockchain/KYC/KYCNetworkRequest.swift
+++ b/Blockchain/KYC/KYCNetworkRequest.swift
@@ -222,7 +222,8 @@ final class KYCNetworkRequest {
                 }
 
                 guard (200...299).contains(httpResponse.statusCode) else {
-                    taskFailure(HTTPRequestServerError.badStatusCode(code: httpResponse.statusCode)); return
+                    let errorPayload = try? JSONDecoder().decode(NabuNetworkError.self, from: responseData)
+                    taskFailure(HTTPRequestServerError.badStatusCode(code: httpResponse.statusCode, error: errorPayload)); return
                 }
                 if let mimeType = httpResponse.mimeType {
                     guard mimeType == HttpHeaderValue.json else {

--- a/Blockchain/Network/HTTPRequestError/HTTPRequestError.swift
+++ b/Blockchain/Network/HTTPRequestError/HTTPRequestError.swift
@@ -23,11 +23,11 @@ enum HTTPRequestClientError: HTTPRequestError {
     }
 }
 enum HTTPRequestServerError: HTTPRequestError {
-    case badResponse, badStatusCode(code: Int)
+    case badResponse, badStatusCode(code: Int, error: Error?)
     var debugDescription: String {
         switch self {
         case .badResponse: return "Bad response."
-        case .badStatusCode(let code): return "The server returned a bad response: \(code)."
+        case .badStatusCode(let code, _): return "The server returned a bad response: \(code)."
         }
     }
 }

--- a/Blockchain/Network/NetworkRequest.swift
+++ b/Blockchain/Network/NetworkRequest.swift
@@ -89,7 +89,8 @@ struct NetworkRequest {
             }
 
             guard (200...299).contains(httpResponse.statusCode) else {
-                withCompletion(.error(HTTPRequestServerError.badStatusCode(code: httpResponse.statusCode)), httpResponse.statusCode)
+                let errorStatusCode = HTTPRequestServerError.badStatusCode(code: httpResponse.statusCode, error: nil)
+                withCompletion(.error(errorStatusCode), httpResponse.statusCode)
                 return
             }
 


### PR DESCRIPTION
## Objective

Created `NabuNetworkError` to allow closer inspection on 4xx type HTTP errors returned by the server.

## Description

Nabu returns us a very specific error code when a network request fails. For example, we get the following error message when trying to go through the exchange flow with an email associated to a wallet:

```
{
    "id":"someId",
    "code":33,
    "type":"CONFLICT",
    "description":"User already exists"
}
```

At the moment, the client simply logs these kind of messages and does not propagate it back up to the caller of the network request.

With `NabuNetworkError`, callers can now have closer inspection on the error message returned by the server which in turn allows us to show a more user-friendly error message to the user. At the moment, it isn't used anywhere but wanted to get this PR in so that we can start using it.

## How to Test

0. Put a breakpoint on line 226 in `KYCNetworkRequest`
1. Create a wallet with an existing user
2. Tap on "Exchange"
3. Notice that the breakpoint is hit, and that `errorPayload` has a value.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
