### PR TITLE
fix(HB): IOS-1368 - `Withdrawal` SymbolValue can sometimes be nil resulting in no trade history

### DIFF
--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
@@ -52,6 +52,10 @@ class ExchangeListViewController: UIViewController {
         dataProvider?.delegate = self
         delegate?.onLoaded()
         registerForNotifications()
+        
+        if let controller = navigationController as? BCNavigationController {
+            controller.applyDarkAppearance()
+        }
     }
     
     fileprivate func dependenciesSetup() {

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
@@ -52,10 +52,19 @@ class ExchangeListViewController: UIViewController {
         dataProvider?.delegate = self
         delegate?.onLoaded()
         registerForNotifications()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         
         if let controller = navigationController as? BCNavigationController {
             controller.applyDarkAppearance()
         }
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        delegate?.onDisappear()
     }
     
     fileprivate func dependenciesSetup() {
@@ -71,11 +80,6 @@ class ExchangeListViewController: UIViewController {
             guard let this = self else { return }
             this.delegate?.onLoaded()
         }
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        delegate?.onDisappear()
     }
     
     deinit {

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -146,7 +146,7 @@ extension ExchangeTradeModel {
         case .partner(let model):
             return model.pair.to.symbol
         case .homebrew(let model):
-            return model.withdrawal.symbol
+            return model.withdrawal?.symbol ?? ""
         }
     }
 
@@ -155,7 +155,7 @@ extension ExchangeTradeModel {
         case .partner(let model):
             return model.amountReceivedCryptoValue
         case .homebrew(let model):
-            return model.withdrawal.value
+            return model.withdrawal?.value ?? ""
         }
     }
     
@@ -252,7 +252,7 @@ struct ExchangeTradeCellModel: Decodable {
     let depositAddress: String
     let deposit: SymbolValue
     let withdrawalAddress: String
-    let withdrawal: SymbolValue
+    let withdrawal: SymbolValue?
     let withdrawalFee: SymbolValue
     let fiatValue: SymbolValue
     let depositTxHash: String?
@@ -318,7 +318,7 @@ struct ExchangeTradeCellModel: Decodable {
         depositAddress = try values.decode(String.self, forKey: .depositAddress)
         deposit = try values.decode(SymbolValue.self, forKey: .deposit)
         withdrawalAddress = try values.decode(String.self, forKey: .withdrawalAddress)
-        withdrawal = try values.decode(SymbolValue.self, forKey: .withdrawal)
+        withdrawal = try values.decodeIfPresent(SymbolValue.self, forKey: .withdrawal)
         withdrawalFee = try values.decode(SymbolValue.self, forKey: .withdrawalFee)
         fiatValue = try values.decode(SymbolValue.self, forKey: .fiatValue)
         depositTxHash = try values.decodeIfPresent(String.self, forKey: .depositTxHash)

--- a/Blockchain/Homebrew/Exchange/Views/Cells/ExchangeListViewCell.swift
+++ b/Blockchain/Homebrew/Exchange/Views/Cells/ExchangeListViewCell.swift
@@ -24,8 +24,8 @@ class ExchangeListViewCell: UITableViewCell {
 
     func configure(with cellModel: ExchangeTradeModel) {
         timestamp.text = cellModel.formattedDate
-        depositAmount.text = "-" + cellModel.amountDepositedCryptoValue
-        receivedAmount.text = cellModel.amountReceivedCryptoValue
+        depositAmount.text = "-" + cellModel.amountDepositedCryptoValue + " \(cellModel.amountDepositedCryptoSymbol)"
+        receivedAmount.text = cellModel.amountReceivedCryptoValue + " \(cellModel.amountReceivedCryptoSymbol)"
         
         status.text = cellModel.status.displayValue
 


### PR DESCRIPTION
## Objective

Fixes an issue where `withdrawal` is `nil` in the event of a failed trade. Also fixes some UI issues including a incorrect color for a back button and missing currency symbols. 

## How to Test

1. Build and run
2. Go to the Exchange List
3. See that you can now see your prior exchanges (even the failed ones)

## Screenshot/Design assessment

![simulator screen shot - iphone se - 2018-09-27 at 12 48 15](https://user-images.githubusercontent.com/41585563/46164473-acaea180-c253-11e8-8479-fd642c12a514.png)

Design is still TBD for handling `Failed` state. Likely remains the same but possible that `zero` is inserted vs `nil` to account for a trade that didn't complete. 

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
