### PR TITLE
fix(Websocket): close exchange WS when no longer needed.

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -516,6 +516,8 @@
 		AA08439A215C0E210007BFD1 /* SocketMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA084399215C0E210007BFD1 /* SocketMessageTests.swift */; };
 		AA08439F215C47290007BFD1 /* NabuNetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08439E215C47290007BFD1 /* NabuNetworkError.swift */; };
 		AA0843A0215C47290007BFD1 /* NabuNetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08439E215C47290007BFD1 /* NabuNetworkError.swift */; };
+		AA0843C5215D72340007BFD1 /* MockSocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0843C4215D72340007BFD1 /* MockSocketManager.swift */; };
+		AA0843C9215D73F50007BFD1 /* MarketsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0843C8215D73F50007BFD1 /* MarketsServiceTests.swift */; };
 		AA0A412C214AD75300807163 /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A412B214AD75300807163 /* DebugSettings.swift */; };
 		AA0A412D214ADD5B00807163 /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A412B214AD75300807163 /* DebugSettings.swift */; };
 		AA0A4147214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0A4146214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift */; };
@@ -3010,6 +3012,8 @@
 		A5185A3368C92DCF1134710A /* Pods_BlockchainTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlockchainTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA084399215C0E210007BFD1 /* SocketMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketMessageTests.swift; sourceTree = "<group>"; };
 		AA08439E215C47290007BFD1 /* NabuNetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NabuNetworkError.swift; sourceTree = "<group>"; };
+		AA0843C4215D72340007BFD1 /* MockSocketManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSocketManager.swift; sourceTree = "<group>"; };
+		AA0843C8215D73F50007BFD1 /* MarketsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsServiceTests.swift; sourceTree = "<group>"; };
 		AA0A412B214AD75300807163 /* DebugSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettings.swift; sourceTree = "<group>"; };
 		AA0A4146214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeAssetAccountListPresenter.swift; sourceTree = "<group>"; };
 		AA0A414A214B152100807163 /* AssetAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAccount.swift; sourceTree = "<group>"; };
@@ -6359,6 +6363,22 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		AA0843C6215D73780007BFD1 /* Exchange */ = {
+			isa = PBXGroup;
+			children = (
+				AA0843C7215D737D0007BFD1 /* Services */,
+			);
+			path = Exchange;
+			sourceTree = "<group>";
+		};
+		AA0843C7215D737D0007BFD1 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				AA0843C8215D73F50007BFD1 /* MarketsServiceTests.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		AA0A4121214AD71100807163 /* Debug */ = {
 			isa = PBXGroup;
 			children = (
@@ -6707,6 +6727,7 @@
 				AAE94DCE20C25F37005A3595 /* MockNetworkManager.swift */,
 				AAE94F6B20C75C67005A3595 /* MockPinInteractor.swift */,
 				AAE94F6920C75C4E005A3595 /* MockPinView.swift */,
+				AA0843C4215D72340007BFD1 /* MockSocketManager.swift */,
 				AACE320A20978EB100B7B806 /* MockWallet.swift */,
 				AA6911A020D18B6E00DDB541 /* MockWalletService.swift */,
 			);
@@ -6767,6 +6788,7 @@
 		C75684C6212F04F600B5059C /* Homebrew */ = {
 			isa = PBXGroup;
 			children = (
+				AA0843C6215D73780007BFD1 /* Exchange */,
 				C75684C9212F053200B5059C /* TradingPairTests.swift */,
 			);
 			path = Homebrew;
@@ -7735,6 +7757,7 @@
 				AA0A4148214B0B2100807163 /* ExchangeAssetAccountListPresenter.swift in Sources */,
 				AA126CD9212C94CB005886A3 /* NabuCreateUserResponse.swift in Sources */,
 				AADB027F20C0BACA000FFFEC /* WalletCryptoService.swift in Sources */,
+				AA0843C5215D72340007BFD1 /* MockSocketManager.swift in Sources */,
 				3A91F7C2213845F700CDC3FD /* TradingPairView.swift in Sources */,
 				AACE31822092858600B7B806 /* Pin.swift in Sources */,
 				C7C0DC23212F677C000EFE71 /* MarketsService.swift in Sources */,
@@ -7754,6 +7777,7 @@
 				3A1552E8213600B400683CEB /* TradingPairConfiguration.swift in Sources */,
 				3AE92BDE2110DF33008D7BDC /* NotificationCenter+Conveniences.swift in Sources */,
 				3AB4D91821309BAD004F0160 /* ExchangeListContracts.swift in Sources */,
+				AA0843C9215D73F50007BFD1 /* MarketsServiceTests.swift in Sources */,
 				3A1552EE2136EAF000683CEB /* TradeLimits.swift in Sources */,
 				AA25F1812146F87C0028C82E /* NabuAuthenticationError.swift in Sources */,
 				51979169210BA7AC0096E50B /* HTTPRequestError.swift in Sources */,

--- a/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
@@ -43,6 +43,7 @@ class MarketsService {
 
     private let restMessageSubject = PublishSubject<Conversion>()
     private let authentication: NabuAuthenticationService
+    private let socketManager: SocketManager
     private let cachedExchangeRates = BehaviorRelay<ExchangeRates?>(value: nil)
     private let disposables = CompositeDisposable()
 
@@ -54,19 +55,24 @@ class MarketsService {
 
     var hasAuthenticated: Bool = false
 
-    init(authenticationService: NabuAuthenticationService = NabuAuthenticationService.shared) {
+    init(
+        authenticationService: NabuAuthenticationService = NabuAuthenticationService.shared,
+        socketManager: SocketManager = SocketManager.shared
+    ) {
         self.authentication = authenticationService
+        self.socketManager = socketManager
     }
 
     deinit {
         disposables.dispose()
+        socketManager.disconnect(socketType: .exchange)
     }
 }
 
 // MARK: - Setup
 extension MarketsService {
     func setup() {
-        SocketManager.shared.setupSocket(socketType: .exchange, url: URL(string: BlockchainAPI.shared.retailCoreSocketUrl)!)
+        socketManager.setupSocket(socketType: .exchange, url: URL(string: BlockchainAPI.shared.retailCoreSocketUrl)!)
     }
 }
 

--- a/Blockchain/Network/SocketManager.swift
+++ b/Blockchain/Network/SocketManager.swift
@@ -101,6 +101,7 @@ class SocketManager {
 
 extension SocketManager: WebSocketAdvancedDelegate {
     func websocketDidConnect(socket: WebSocket) {
+        Logger.shared.debug("Websocket connected to: \(socket.currentURL.absoluteString)")
         if socket == self.exchangeSocket {
             pendingSocketMessages.forEach { [unowned self] in
                 self.send(message: $0)
@@ -160,6 +161,7 @@ extension SocketManager: WebSocketAdvancedDelegate {
 
     func websocketDidDisconnect(socket: WebSocket, error: Error?) {
         // Required by protocol
+        Logger.shared.debug("Websocket disconnected to: \(socket.currentURL.absoluteString)")
     }
 
     func websocketDidReceiveData(socket: WebSocket, data: Data, response: WebSocket.WSResponse) {

--- a/Blockchain/Network/SocketManager.swift
+++ b/Blockchain/Network/SocketManager.swift
@@ -161,7 +161,7 @@ extension SocketManager: WebSocketAdvancedDelegate {
 
     func websocketDidDisconnect(socket: WebSocket, error: Error?) {
         // Required by protocol
-        Logger.shared.debug("Websocket disconnected to: \(socket.currentURL.absoluteString)")
+        Logger.shared.debug("Websocket disconnected from: \(socket.currentURL.absoluteString)")
     }
 
     func websocketDidReceiveData(socket: WebSocket, data: Data, response: WebSocket.WSResponse) {

--- a/BlockchainTests/Homebrew/Exchange/Services/MarketsServiceTests.swift
+++ b/BlockchainTests/Homebrew/Exchange/Services/MarketsServiceTests.swift
@@ -1,0 +1,34 @@
+//
+//  MarketsServiceTests.swift
+//  BlockchainTests
+//
+//  Created by Chris Arriola on 9/27/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import XCTest
+@testable import Blockchain
+
+class MarketsServiceTests: XCTestCase {
+
+    private var socketManager: MockSocketManager!
+
+    override func setUp() {
+        super.setUp()
+        socketManager = MockSocketManager()
+    }
+
+    /// Tests that the websocket is disconnected when MarketsService is dealloc'd
+    func testWebsocketDisconnectOnDeinit() {
+        var marketsService: MarketsService? = MarketsService(socketManager: socketManager)
+
+        socketManager.didCallSetup = expectation(description: "Set up called.")
+        marketsService?.setup()
+
+        socketManager.didCallDisconnect = expectation(description: "WS disconnected.")
+        marketsService = nil
+
+        waitForExpectations(timeout: 0.1)
+    }
+
+}

--- a/BlockchainTests/Mock/MockSocketManager.swift
+++ b/BlockchainTests/Mock/MockSocketManager.swift
@@ -1,0 +1,24 @@
+//
+//  MockSocketManager.swift
+//  BlockchainTests
+//
+//  Created by Chris Arriola on 9/27/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import XCTest
+
+class MockSocketManager: SocketManager {
+
+    var didCallSetup: XCTestExpectation?
+    var didCallDisconnect: XCTestExpectation?
+
+    override func setupSocket(socketType: SocketType, url: URL) {
+        didCallSetup?.fulfill()
+    }
+
+    override func disconnect(socketType: SocketType) {
+        didCallDisconnect?.fulfill()
+    }
+
+}


### PR DESCRIPTION
## Objective

Close exchange WS when no longer needed.

## Description

Fixes issue where quote related WS messages were still received even when the user is no longer on the exchange create screen.

Note about unit tests and directory structures... The location of the test file should mimic the location and directory structure of the file being tested (e.g. https://cloudup.com/cD9DjzafCct).

## How to Test

1. Go to exchange create
2. Verify that you see "Websocket connected..."
3. Exit out of exchange
4. Verify that you see "Websocket disconnected..."

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [X] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
