### PR TITLE
fix(Homebrew-Exchange): IOS-1348 add dismiss handler to password confirm view

### DIFF
--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -629,14 +629,14 @@ extension AuthenticationCoordinator: SetupDelegate {
 }
 
 extension AuthenticationCoordinator: WalletSecondPasswordDelegate {
-    func getSecondPassword(success: WalletSuccessCallback, dismiss: WalletDismissCallback) {
+    func getSecondPassword(success: WalletSuccessCallback, dismiss: WalletDismissCallback?) {
         showPasswordConfirm(withDisplayText: LocalizationConstants.Authentication.secondPasswordDefaultDescription,
                             headerText: LocalizationConstants.Authentication.secondPasswordRequired,
                             validateSecondPassword: true,
                             confirmHandler: { (secondPassword) in
                                 success.success(string: secondPassword)
                             },
-                            dismissHandler: { dismiss.dismiss() }
+                            dismissHandler: { dismiss?.dismiss() }
         )
     }
 

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -427,7 +427,8 @@ import RxSwift
         withDisplayText displayText: String,
         headerText: String,
         validateSecondPassword: Bool,
-        confirmHandler: @escaping PasswordConfirmView.OnPasswordConfirmHandler
+        confirmHandler: @escaping PasswordConfirmView.OnPasswordConfirmHandler,
+        dismissHandler: @escaping PasswordConfirmView.OnPasswordDismissHandler
     ) {
         let loadingViewPresenter = LoadingViewPresenter.shared
         let isLoadingShown = loadingViewPresenter.isLoadingShown
@@ -455,6 +456,7 @@ import RxSwift
 
             confirmHandler(password)
         }
+        passwordConfirmView.dismissHandler = dismissHandler
         ModalPresenter.shared.showModal(
             withContent: passwordConfirmView,
             closeType: ModalCloseTypeClose,
@@ -627,19 +629,25 @@ extension AuthenticationCoordinator: SetupDelegate {
 }
 
 extension AuthenticationCoordinator: WalletSecondPasswordDelegate {
-    func getSecondPassword(success: WalletSuccessCallback) {
+    func getSecondPassword(success: WalletSuccessCallback, dismiss: WalletDismissCallback) {
         showPasswordConfirm(withDisplayText: LocalizationConstants.Authentication.secondPasswordDefaultDescription,
                             headerText: LocalizationConstants.Authentication.secondPasswordRequired,
-                            validateSecondPassword: true) { (secondPassword) in
+                            validateSecondPassword: true,
+                            confirmHandler: { (secondPassword) in
                                 success.success(string: secondPassword)
-        }
+                            },
+                            dismissHandler: { dismiss.dismiss() }
+        )
     }
 
     func getPrivateKeyPassword(success: WalletSuccessCallback) {
         showPasswordConfirm(withDisplayText: LocalizationConstants.Authentication.privateKeyPasswordDefaultDescription,
                             headerText: LocalizationConstants.Authentication.privateKeyNeeded,
-                            validateSecondPassword: false) { (privateKeyPassword) in
+                            validateSecondPassword: false,
+                            confirmHandler: { (privateKeyPassword) in
                                 success.success(string: privateKeyPassword)
-        }
+                            },
+                            dismissHandler: {}
+        )
     }
 }

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -428,7 +428,7 @@ import RxSwift
         headerText: String,
         validateSecondPassword: Bool,
         confirmHandler: @escaping PasswordConfirmView.OnPasswordConfirmHandler,
-        dismissHandler: PasswordConfirmView.OnPasswordDismissHandler?
+        dismissHandler: PasswordConfirmView.OnPasswordDismissHandler? = nil
     ) {
         let loadingViewPresenter = LoadingViewPresenter.shared
         let isLoadingShown = loadingViewPresenter.isLoadingShown
@@ -646,8 +646,7 @@ extension AuthenticationCoordinator: WalletSecondPasswordDelegate {
                             validateSecondPassword: false,
                             confirmHandler: { (privateKeyPassword) in
                                 success.success(string: privateKeyPassword)
-                            },
-                            dismissHandler: nil
+                            }
         )
     }
 }

--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -428,7 +428,7 @@ import RxSwift
         headerText: String,
         validateSecondPassword: Bool,
         confirmHandler: @escaping PasswordConfirmView.OnPasswordConfirmHandler,
-        dismissHandler: @escaping PasswordConfirmView.OnPasswordDismissHandler
+        dismissHandler: PasswordConfirmView.OnPasswordDismissHandler?
     ) {
         let loadingViewPresenter = LoadingViewPresenter.shared
         let isLoadingShown = loadingViewPresenter.isLoadingShown
@@ -647,7 +647,7 @@ extension AuthenticationCoordinator: WalletSecondPasswordDelegate {
                             confirmHandler: { (privateKeyPassword) in
                                 success.success(string: privateKeyPassword)
                             },
-                            dismissHandler: {}
+                            dismissHandler: nil
         )
     }
 }

--- a/Blockchain/Authentication/Views/PasswordConfirmView.swift
+++ b/Blockchain/Authentication/Views/PasswordConfirmView.swift
@@ -12,6 +12,7 @@ import Foundation
 class PasswordConfirmView: BCModalContentView {
 
     typealias OnPasswordConfirmHandler = ((_ password: String) -> Void)
+    typealias OnPasswordDismissHandler = (() -> Void)
 
     @IBOutlet private weak var labelDescription: UILabel!
     @IBOutlet private weak var textFieldPassword: BCTextField!
@@ -20,6 +21,7 @@ class PasswordConfirmView: BCModalContentView {
     var validateSecondPassword = false
 
     var confirmHandler: OnPasswordConfirmHandler?
+    var dismissHandler: OnPasswordDismissHandler?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -56,6 +58,7 @@ class PasswordConfirmView: BCModalContentView {
 
     override func modalWasDismissed() {
         ModalPresenter.shared.closeAllModals()
+        self.dismissHandler?()
     }
 }
 

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -110,10 +110,12 @@ struct ExchangeServices: ExchangeDependencies {
                 AuthenticationCoordinator.shared.showPasswordConfirm(
                     withDisplayText: LocalizationConstants.Authentication.etherSecondPasswordPrompt,
                     headerText: LocalizationConstants.Authentication.secondPasswordRequired,
-                    validateSecondPassword: true
-                ) { (secondPassword) in
-                    WalletManager.shared.wallet.createEthAccount(forExchange: secondPassword)
-                }
+                    validateSecondPassword: true,
+                    confirmHandler: { (secondPassword) in
+                        WalletManager.shared.wallet.createEthAccount(forExchange: secondPassword)
+                    },
+                    dismissHandler: {}
+                )
             } else {
                 WalletManager.shared.wallet.createEthAccount(forExchange: nil)
             }

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -92,7 +92,7 @@ struct ExchangeServices: ExchangeDependencies {
     }
 
     private func showAppropriateExchange() {
-        if WalletManager.shared.wallet.hasEthAccount() {
+        if walletManager.wallet.hasEthAccount() {
             let success = { [weak self] (isHomebrewAvailable: Bool) in
                 if isHomebrewAvailable {
                     self?.showExchange(type: .homebrew)
@@ -106,24 +106,24 @@ struct ExchangeServices: ExchangeDependencies {
             }
             checkForHomebrewAvailability(success: success, error: error)
         } else {
-            if WalletManager.shared.wallet.needsSecondPassword() {
+            if walletManager.wallet.needsSecondPassword() {
                 AuthenticationCoordinator.shared.showPasswordConfirm(
                     withDisplayText: LocalizationConstants.Authentication.etherSecondPasswordPrompt,
                     headerText: LocalizationConstants.Authentication.secondPasswordRequired,
                     validateSecondPassword: true,
                     confirmHandler: { (secondPassword) in
-                        WalletManager.shared.wallet.createEthAccount(forExchange: secondPassword)
+                        self.walletManager.wallet.createEthAccount(forExchange: secondPassword)
                     },
                     dismissHandler: {}
                 )
             } else {
-                WalletManager.shared.wallet.createEthAccount(forExchange: nil)
+                walletManager.wallet.createEthAccount(forExchange: nil)
             }
         }
     }
 
     private func checkForHomebrewAvailability(success: @escaping (Bool) -> Void, error: @escaping (Error) -> Void) {
-        guard let countryCode = WalletManager.sharedInstance().wallet.countryCodeGuess() else {
+        guard let countryCode = walletManager.wallet.countryCodeGuess() else {
             error(NetworkError.generic(message: "No country code found"))
             return
         }

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -113,8 +113,7 @@ struct ExchangeServices: ExchangeDependencies {
                     validateSecondPassword: true,
                     confirmHandler: { (secondPassword) in
                         self.walletManager.wallet.createEthAccount(forExchange: secondPassword)
-                    },
-                    dismissHandler: {}
+                    }
                 )
             } else {
                 walletManager.wallet.createEthAccount(forExchange: nil)

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -124,14 +124,16 @@ class TradeExecutionService: TradeExecutionAPI {
 
     func sendTransaction(assetType: AssetType, success: @escaping (() -> Void), error: @escaping ((String) -> Void)) {
         isExecuting = true
+        let executionDone = { [weak self] in
+            guard let this = self else { return }
+            this.isExecuting = false
+        }
         wallet.sendOrderTransaction(
             assetType.legacy,
-            completion: { [weak self] in
-                guard let this = self else { return }
-                this.isExecuting = false
-        },
+            completion: executionDone,
             success: success,
-            error: error
+            error: error,
+            dismiss: executionDone
         )
     }
 

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -133,7 +133,7 @@ class TradeExecutionService: TradeExecutionAPI {
             completion: executionDone,
             success: success,
             error: error,
-            dismiss: executionDone
+            cancel: executionDone
         )
     }
 

--- a/Blockchain/Models/TransferAllFundsBuilder.m
+++ b/Blockchain/Models/TransferAllFundsBuilder.m
@@ -136,7 +136,7 @@
             [AuthenticationCoordinator.shared showPasswordConfirmWithDisplayText:[LocalizationConstantsObjcBridge secondPasswordDefaultDescription] headerText:[LocalizationConstantsObjcBridge secondPasswordRequired] validateSecondPassword:YES confirmHandler:^(NSString * _Nonnull secondPasswordInput) {
                 if (self.on_before_send) self.on_before_send();
                 [wallet transferFundsBackupWithListener:listener secondPassword:secondPasswordInput];
-            } dismissHandler: ^(){}];
+            } dismissHandler: nil];
         } else {
             if (self.on_before_send) self.on_before_send();
             [wallet transferFundsBackupWithListener:listener secondPassword:_secondPassword];

--- a/Blockchain/Models/TransferAllFundsBuilder.m
+++ b/Blockchain/Models/TransferAllFundsBuilder.m
@@ -136,7 +136,7 @@
             [AuthenticationCoordinator.shared showPasswordConfirmWithDisplayText:[LocalizationConstantsObjcBridge secondPasswordDefaultDescription] headerText:[LocalizationConstantsObjcBridge secondPasswordRequired] validateSecondPassword:YES confirmHandler:^(NSString * _Nonnull secondPasswordInput) {
                 if (self.on_before_send) self.on_before_send();
                 [wallet transferFundsBackupWithListener:listener secondPassword:secondPasswordInput];
-            }];
+            } dismissHandler: ^(){}];
         } else {
             if (self.on_before_send) self.on_before_send();
             [wallet transferFundsBackupWithListener:listener secondPassword:_secondPassword];

--- a/Blockchain/Models/Wallet.h
+++ b/Blockchain/Models/Wallet.h
@@ -462,8 +462,26 @@
 - (void)updateKYCUserCredentialsWithUserId:(NSString *)userId lifetimeToken:(NSString *)lifetimeToken success:(void (^ _Nonnull)(NSString *_Nonnull))success error: (void (^ _Nonnull)(NSString *_Nullable))error;
 - (NSString *_Nullable)KYCUserId;
 - (NSString *_Nullable)KYCLifetimeToken;
+
+/// Call this method to build an Exchange order.
+/// It constructs and stores a payment object with a given AssetType, to, from, and amount (properties of OrderTransactionLegacy).
+/// To send the order, call sendOrderTransaction:completion:success:error:cancel.
+///
+/// - Parameters:
+///   - orderTransaction: the object containing the payment information (AssetType, to, from, and amount)
+///   - completion: handler called when the payment is successfully built
+///   - error: handler called when an error occurs while building the payment
 - (void)createOrderPaymentWithOrderTransaction:(OrderTransactionLegacy *_Nonnull)orderTransaction completion:(void (^ _Nonnull)(void))completion success:(void (^)(NSString *_Nonnull))success error:(void (^ _Nonnull)(NSString *_Nonnull))error;
-- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error dismiss:(void (^ _Nonnull)(void))dismiss;
+
+/// Sign and publish a transaction that was built by createOrderPaymentWithOrderTransaction:completion:success:error.
+/// This is the last step in sending an exchange order via Homebrew.
+///
+/// - Parameters:
+///   - legacyAssetType: used to determine the type of payment to use
+///   - completion: handler called when the payment is successfully sent
+///   - error: handler called when an error occurs while sending the payment
+///   - cancel: handler called when the payment is cancelled (e.g., when an intermediate screen such as second password is dismissed)
+- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error cancel:(void (^ _Nonnull)(void))cancel;
 // Top Bar Display
 - (NSDecimalNumber *)btcDecimalBalance;
 - (NSDecimalNumber *)ethDecimalBalance;

--- a/Blockchain/Models/Wallet.h
+++ b/Blockchain/Models/Wallet.h
@@ -43,7 +43,7 @@
 
 @class Wallet, Transaction, JSValue, JSContext, ExchangeRate, OrderTransactionLegacy;
 
-@protocol WalletSuccessCallback;
+@protocol WalletSuccessCallback, WalletDismissCallback;
 
 @protocol ExchangeAccountDelegate
 - (void)watchPendingTrades:(BOOL)shouldSync;
@@ -140,7 +140,7 @@
 - (void)walletDidGetAccountInfo:(Wallet *)wallet;
 - (void)walletDidGetBtcExchangeRates:(Wallet *)wallet;
 - (void)walletDidGetAccountInfoAndExchangeRates:(Wallet *)wallet;
-- (void)getSecondPasswordWithSuccess:(id<WalletSuccessCallback>)success;
+- (void)getSecondPasswordWithSuccess:(id<WalletSuccessCallback>)success dismiss:(id<WalletDismissCallback>)dismiss;
 - (void)getPrivateKeyPasswordWithSuccess:(id<WalletSuccessCallback>)success;
 - (void)walletUpgraded:(Wallet *)wallet;
 @end
@@ -463,7 +463,7 @@
 - (NSString *_Nullable)KYCUserId;
 - (NSString *_Nullable)KYCLifetimeToken;
 - (void)createOrderPaymentWithOrderTransaction:(OrderTransactionLegacy *_Nonnull)orderTransaction completion:(void (^ _Nonnull)(void))completion success:(void (^)(NSString *_Nonnull))success error:(void (^ _Nonnull)(NSString *_Nonnull))error;
-- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error;
+- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error dismiss:(void (^ _Nonnull)(void))dismiss;
 // Top Bar Display
 - (NSDecimalNumber *)btcDecimalBalance;
 - (NSDecimalNumber *)ethDecimalBalance;

--- a/Blockchain/Models/Wallet.m
+++ b/Blockchain/Models/Wallet.m
@@ -465,8 +465,8 @@
         [weakSelf error_restoring_wallet];
     };
 
-    self.context[@"objc_get_second_password"] = ^(JSValue *secondPassword, JSValue *helperText) {
-        [weakSelf getSecondPasswordSuccess:secondPassword error:nil helperText:[helperText isUndefined] ? nil :  [helperText toString]];
+    self.context[@"objc_get_second_password"] = ^(JSValue *secondPassword, JSValue *dismiss, JSValue *helperText) {
+        [weakSelf getSecondPasswordSuccess:secondPassword dismiss:dismiss error:nil helperText:[helperText isUndefined] ? nil :  [helperText toString]];
     };
 
     self.context[@"objc_get_private_key_password"] = ^(JSValue *privateKeyPassword) {
@@ -2665,7 +2665,7 @@
     [self.context evaluateScript:script];
 }
 
-- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error
+- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error dismiss:(void (^ _Nonnull)(void))dismiss
 {
     [self.context invokeOnceWithFunctionBlock:^{
         completion();
@@ -2676,6 +2676,10 @@
         completion();
         error(errorValue);
     } forJsFunctionName:@"objc_on_send_order_transaction_error"];
+
+    [self.context invokeOnceWithFunctionBlock:^{
+        dismiss();
+    } forJsFunctionName:@"objc_on_send_order_transaction_dismiss"];
     
     NSString *tradeExecutionType;
     if (legacyAssetType == LegacyAssetTypeBitcoin) {
@@ -3244,10 +3248,10 @@
     }
 }
 
-- (void)getSecondPasswordSuccess:(JSValue *)success error:(void(^)(id))_error helperText:(NSString *)helperText
+- (void)getSecondPasswordSuccess:(JSValue *)success dismiss:(JSValue *)dismiss error:(void(^)(id))_error helperText:(NSString *)helperText
 {
-    if ([delegate respondsToSelector:@selector(getSecondPasswordWithSuccess:)]) {
-        [delegate getSecondPasswordWithSuccess:success];
+    if ([delegate respondsToSelector:@selector(getSecondPasswordWithSuccess:dismiss:)]) {
+        [delegate getSecondPasswordWithSuccess:success dismiss:dismiss];
     } else {
         DLog(@"Error: delegate of class %@ does not respond to selector getSecondPassword!", [delegate class]);
     }

--- a/Blockchain/Models/Wallet.m
+++ b/Blockchain/Models/Wallet.m
@@ -2665,7 +2665,7 @@
     [self.context evaluateScript:script];
 }
 
-- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error dismiss:(void (^ _Nonnull)(void))dismiss
+- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error cancel:(void (^ _Nonnull)(void))cancel
 {
     [self.context invokeOnceWithFunctionBlock:^{
         completion();
@@ -2678,7 +2678,7 @@
     } forJsFunctionName:@"objc_on_send_order_transaction_error"];
 
     [self.context invokeOnceWithFunctionBlock:^{
-        dismiss();
+        cancel();
     } forJsFunctionName:@"objc_on_send_order_transaction_dismiss"];
     
     NSString *tradeExecutionType;

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -601,8 +601,8 @@ extension WalletManager: WalletDelegate {
     }
 
     // MARK: - Second Password
-    @objc func getSecondPassword(withSuccess success: WalletSuccessCallback) {
-        secondPasswordDelegate?.getSecondPassword(success: success)
+    @objc func getSecondPassword(withSuccess success: WalletSuccessCallback, dismiss: WalletDismissCallback) {
+        secondPasswordDelegate?.getSecondPassword(success: success, dismiss: dismiss)
     }
 
     @objc func getPrivateKeyPassword(withSuccess success: WalletSuccessCallback) {

--- a/Blockchain/Wallet/WalletSecondPasswordDelegate.swift
+++ b/Blockchain/Wallet/WalletSecondPasswordDelegate.swift
@@ -10,7 +10,7 @@ import Foundation
 
 protocol WalletSecondPasswordDelegate: class {
     /// Method invoked when second password is required for JS function to complete.
-    func getSecondPassword(success: WalletSuccessCallback, dismiss: WalletDismissCallback)
+    func getSecondPassword(success: WalletSuccessCallback, dismiss: WalletDismissCallback?)
 
     /// Method invoked when a password is required for bip38 private key decryption
     func getPrivateKeyPassword(success: WalletSuccessCallback)

--- a/Blockchain/Wallet/WalletSecondPasswordDelegate.swift
+++ b/Blockchain/Wallet/WalletSecondPasswordDelegate.swift
@@ -10,7 +10,7 @@ import Foundation
 
 protocol WalletSecondPasswordDelegate: class {
     /// Method invoked when second password is required for JS function to complete.
-    func getSecondPassword(success: WalletSuccessCallback)
+    func getSecondPassword(success: WalletSuccessCallback, dismiss: WalletDismissCallback)
 
     /// Method invoked when a password is required for bip38 private key decryption
     func getPrivateKeyPassword(success: WalletSuccessCallback)
@@ -23,5 +23,16 @@ protocol WalletSecondPasswordDelegate: class {
 extension JSValue: WalletSuccessCallback {
     func success(string: String) {
         self.call(withArguments: [string])
+    }
+}
+
+@objc protocol WalletDismissCallback {
+    func dismiss()
+}
+
+extension JSValue: WalletDismissCallback {
+    func dismiss() {
+        guard !self.isUndefined && !self.isNull else { return }
+        self.call(withArguments: nil)
     }
 }


### PR DESCRIPTION
## Objective

Allow creating and sending exchange order with second password.

## Description
- Added property `dismissHandler` to `PasswordConfirmView` to allow setting `tradeExecution.isExecuting` back to `false` after dismissing `PasswordConfirmView`
- Fixed issue where `bitcoincash:` prefix could be added twice
- Fixed some missing parameter bugs in JS

## How to Test

Submit and send an exchange order with second password enabled.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
