### PR TITLE
fix(KYC): fix bug where user cannot continue with KYC (IOS-1321).

### DIFF
--- a/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
+++ b/Blockchain/KYC/Identity Verification/KYCVerifyIdentityController.swift
@@ -41,7 +41,7 @@ final class KYCVerifyIdentityController: KYCBaseViewController {
                                  DocumentMap.passport: DocumentType.passport,
                                  DocumentMap.residencePermitCard: DocumentType.residencePermit]
 
-    private var country: KYCCountry?
+    private var countryCode: String?
 
     private var disposable: Disposable?
 
@@ -53,8 +53,8 @@ final class KYCVerifyIdentityController: KYCBaseViewController {
     // MARK: - KYCCoordinatorDelegate
 
     override func apply(model: KYCPageModel) {
-        guard case let .verifyIdentity(country) = model else { return }
-        self.country = country
+        guard case let .verifyIdentity(countryCode) = model else { return }
+        self.countryCode = countryCode
     }
 
     // MARK: - Private Methods
@@ -85,15 +85,15 @@ final class KYCVerifyIdentityController: KYCBaseViewController {
         _ onfidoUser: OnfidoUser,
         _ providerCredentials: OnfidoCredentials
     ) -> OnfidoConfig? {
-        guard let country = country else {
-            Logger.shared.warning("Cannot construct OnfidoConfig. Country is nil.")
+        guard let countryCode = countryCode else {
+            Logger.shared.warning("Cannot construct OnfidoConfig. Country code is nil.")
             return nil
         }
 
         let config = try? OnfidoConfig.builder()
             .withToken(providerCredentials.key)
             .withApplicantId(onfidoUser.identifier)
-            .withDocumentStep(ofType: document, andCountryCode: country.code)
+            .withDocumentStep(ofType: document, andCountryCode: countryCode)
             .withFaceStep(ofVariant: .video)
             .build()
         return config

--- a/Blockchain/KYC/KYCCoordinator.swift
+++ b/Blockchain/KYC/KYCCoordinator.swift
@@ -231,8 +231,8 @@ protocol KYCCoordinatorDelegate: class {
             guard let current = user else { return }
             delegate?.apply(model: .phone(current))
         case .verifyIdentity:
-            guard let country = country else { return }
-            delegate?.apply(model: .verifyIdentity(country))
+            guard let countryCode = country?.code ?? user?.address?.countryCode else { return }
+            delegate?.apply(model: .verifyIdentity(countryCode: countryCode))
         }
     }
 

--- a/Blockchain/KYC/Models/KYCPageModel.swift
+++ b/Blockchain/KYC/Models/KYCPageModel.swift
@@ -12,5 +12,5 @@ enum KYCPageModel {
     case personalDetails(NabuUser)
     case address(NabuUser, KYCCountry?)
     case phone(NabuUser)
-    case verifyIdentity(KYCCountry)
+    case verifyIdentity(countryCode: String)
 }


### PR DESCRIPTION
## Objective

Fix bug where use cannot continue through KYC if they drop-off right at the verify identity step.

## Description

This was previously failing because the user's country selection, which is just stored in memory, can be dealloc'd if the user drops off right before the verify identity step. The fix is to instead pass around the country code which can be recovered from the user's address.

## How to Test

1. Create a new wallet
2. Go through KYC and drop-off right before the identity verification step (kill the app)
3. Go back to KYC, and verify that you can continue

## Screenshot/Design assessment

N/A

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
