### PR TITLE
fix(OrderHistory) - IOS-1343 - Order history fields for partner trades were blank and/or incorrect 

### DIFF
--- a/Blockchain/Accounts/AssetAccountRepository.swift
+++ b/Blockchain/Accounts/AssetAccountRepository.swift
@@ -120,7 +120,9 @@ extension AssetAccountRepository {
         let accounts = allAccounts()
 
         // TICKET: IOS-1326 - Destination Name on Exchange Locked Screen Should Match Withdrawal Address
-        let destination = accounts.filter({ return $0.address.address == address }).first
+        let destination = accounts.filter({
+            return $0.address.address.lowercased() == address.lowercased()
+        }).first
         return destination?.name ?? ""
     }
 }

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -233,7 +233,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 withReuseIdentifier: ExchangeDetailHeaderView.identifier,
                 for: indexPath
                 ) as? ExchangeDetailHeaderView else { return UICollectionReusableView() }
-            header.title = trade.amountReceivedCryptoValue + " " + trade.amountReceivedCryptoSymbol
+            header.title = trade.amountReceivedCrypto
             return header
         }
     }
@@ -253,7 +253,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 height: ExchangeLockedHeaderView.estimatedHeight()
             )
         case .overview(let trade):
-            let title = trade.amountReceivedCryptoValue
+            let title = trade.amountReceivedCrypto
             let height = ExchangeDetailHeaderView.height(for: title)
             return CGSize(
                 width: collectionView.bounds.width,

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -212,7 +212,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let fees = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.fees,
-                    value: trade.amountFeeValue + " " + trade.amountFeeSymbol,
+                    value: trade.feeDisplayValue,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
                 

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -180,7 +180,7 @@ class ExchangeDetailCoordinator: NSObject {
                 delegate?.coordinator(self, updated: cellModels)
             case .overview(let trade):
                 interface?.updateBackgroundColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))
-                interface?.updateTitle(trade.amountReceivedCryptoValue + LocalizationConstants.Exchange.orderID + " " + trade.identifier)
+                interface?.updateTitle(trade.amountReceivedCrypto + LocalizationConstants.Exchange.orderID + " " + trade.identifier)
                 interface?.navigationBarVisibility(.visible)
                 
                 let status = ExchangeCellModel.Plain(
@@ -199,13 +199,13 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let exchange = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.exchange,
-                    value: trade.amountDepositedCryptoValue + " " + trade.amountDepositedCryptoSymbol,
+                    value: trade.amountDepositedCrypto,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
                 
                 let receive = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.receive,
-                    value: trade.amountReceivedCryptoValue + " " + trade.amountReceivedCryptoSymbol,
+                    value: trade.amountReceivedCrypto,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1),
                     bold: true
                 )
@@ -291,7 +291,8 @@ extension ExchangeDetailCoordinator {
     func valueString(for amount: String, currencyCode: String) -> String {
         if let currencySymbol =  BlockchainSettings.sharedAppInstance().fiatSymbolFromCode(currencyCode: currencyCode) {
             // $2.34
-            return currencySymbol + amount
+            // `Partner` models already have the currency symbol appended.
+            return amount.contains(currencySymbol) ? amount : currencySymbol + amount
         } else {
             // 2.34 USD
             return amount + " " + currencyCode

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -424,8 +424,8 @@ fileprivate extension ExchangeTrade {
     fileprivate func toFiat(from assetType: AssetType, amount: NSDecimalNumber) -> String? {
         switch assetType {
         case .bitcoin:
-            let value = NumberFormatter.formatBch(
-                withSymbol: amount.uint64Value,
+            let value = NumberFormatter.formatMoney(
+                amount.uint64Value,
                 localCurrency: true
             )
             return value

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -75,9 +75,8 @@ enum ExchangeTradeModel {
 extension ExchangeTradeModel {
     var withdrawalAddress: String {
         switch self {
-        case .partner:
-            // Not in ExchangeTableViewCell
-            return ""
+        case .partner(let model):
+            return model.destination
         case .homebrew(let model):
             return model.withdrawalAddress
         }
@@ -86,7 +85,6 @@ extension ExchangeTradeModel {
     var amountFeeSymbol: String {
         switch self {
         case .partner:
-            // Not in ExchangeTableViewCell
             return ""
         case .homebrew(let model):
             return model.withdrawalFee.symbol
@@ -96,7 +94,6 @@ extension ExchangeTradeModel {
     var amountFeeValue: String {
         switch self {
         case .partner:
-            // Not in ExchangeTableViewCell
             return ""
         case .homebrew(let model):
             return model.withdrawalFee.value
@@ -105,9 +102,8 @@ extension ExchangeTradeModel {
 
     var amountFiatValue: String {
         switch self {
-        case .partner:
-            // Currently calculated in ExchangeTableViewCell based on latest rates
-            return ""
+        case .partner(let model):
+            return model.amountReceivedFiatValue
         case .homebrew(let model):
             return model.fiatValue.value
         }
@@ -116,46 +112,31 @@ extension ExchangeTradeModel {
     var amountFiatSymbol: String {
         switch self {
         case .partner:
-            // Currently calculated in ExchangeTableViewCell cell based on latest rates
             return ""
         case .homebrew(let model):
             return model.fiatValue.symbol
         }
     }
-
-    var amountDepositedCryptoValue: String {
+    
+    var amountDepositedCrypto: String {
         switch self {
         case .partner(let model):
             return model.amountDepositedCryptoValue
         case .homebrew(let model):
-            return model.deposit.value
+            return model.deposit.value + " " + model.deposit.symbol
         }
     }
     
-    var amountDepositedCryptoSymbol: String {
-        switch self {
-        case .partner(let model):
-            return model.pair.from.symbol
-        case .homebrew(let model):
-            return model.deposit.symbol
-        }
-    }
-
-    var amountReceivedCryptoSymbol: String {
-        switch self {
-        case .partner(let model):
-            return model.pair.to.symbol
-        case .homebrew(let model):
-            return model.withdrawal?.symbol ?? ""
-        }
-    }
-
-    var amountReceivedCryptoValue: String {
+    var amountReceivedCrypto: String {
         switch self {
         case .partner(let model):
             return model.amountReceivedCryptoValue
         case .homebrew(let model):
-            return model.withdrawal?.value ?? ""
+            if let value = model.withdrawal?.value, let symbol = model.withdrawal?.symbol {
+                return value + " " + symbol
+            } else {
+                return ""
+            }
         }
     }
     
@@ -204,30 +185,49 @@ struct PartnerTrade {
     let status: TradeStatus
     let assetType: AssetType
     let pair: TradingPair
+    let destination: String
+    let deposit: String
     let transactionDate: Date
     let amountReceivedCryptoValue: String
+    let amountReceivedFiatValue: String
     let amountDepositedCryptoValue: String
+    let amountDepositedFiatValue: String
     
     init(with trade: ExchangeTrade) {
         identifier = trade.orderID
         status = TradeStatus(shapeshift: trade.status)
         transactionDate = trade.date
+        destination = trade.withdrawal
+        deposit = trade.deposit
+        
         if let pairType = TradingPair(string: trade.pair) {
             pair = pairType
         } else {
             fatalError("Failed to map \(trade.pair)")
         }
         
-        if let value = trade.inboundDisplayAmount() {
+        if let value = trade.inboundCryptoAmount() {
             amountReceivedCryptoValue = value
         } else {
-            fatalError("Failed to map \(trade.inboundDisplayAmount() ?? "")")
+            fatalError("Failed to map \(trade.inboundCryptoAmount() ?? "")")
         }
         
-        if let value = trade.outboundDisplayAmount() {
+        if let value = trade.inboundFiatAmount() {
+            amountReceivedFiatValue = value
+        } else {
+            fatalError("Failed to map \(trade.inboundFiatAmount() ?? "")")
+        }
+        
+        if let value = trade.outboundCryptoAmount() {
             amountDepositedCryptoValue = value
         } else {
-            fatalError("Failed to map \(trade.outboundDisplayAmount() ?? "")")
+            fatalError("Failed to map \(trade.outboundCryptoAmount() ?? "")")
+        }
+        
+        if let value = trade.outboundFiatAmount() {
+            amountDepositedFiatValue = value
+        } else {
+            fatalError("Failed to map \(trade.outboundFiatAmount() ?? "")")
         }
         
         if let asset = AssetType(stringValue: trade.withdrawalCurrency()) {
@@ -394,55 +394,67 @@ extension ExchangeTradeModel.TradeStatus {
 
 fileprivate extension ExchangeTrade {
     
-    fileprivate func inboundDisplayAmount() -> String? {
-        if BlockchainSettings.sharedAppInstance().symbolLocal {
-            guard let currencySymbol = withdrawalCurrency() else { return nil }
-            guard let assetType = AssetType(stringValue: currencySymbol) else { return nil }
-            switch assetType {
-            case .bitcoin:
-                let value = NumberFormatter.parseBtcValue(from: withdrawalAmount.stringValue)
-                return NumberFormatter.formatMoney(value.magnitude)
-            case .ethereum:
-                guard let exchangeRate = WalletManager.shared.wallet.latestEthExchangeRate else { return nil }
-                return NumberFormatter.formatEth(
-                    withLocalSymbol: withdrawalAmount.stringValue,
-                    exchangeRate: exchangeRate
-                )
-            case .bitcoinCash:
-                let value = NumberFormatter.parseBtcValue(from: withdrawalAmount.stringValue)
-                return NumberFormatter.formatBch(withSymbol: value.magnitude)
-            }
-        } else {
-            guard let toAsset = pair.components(separatedBy: "_").last else { return nil }
-            let formatted = toAsset.uppercased()
-            guard let amount = NumberFormatter.localFormattedString(withdrawalAmount.stringValue) else { return nil }
-            return amount + " " + formatted
+    fileprivate func inboundFiatAmount() -> String? {
+        guard let toAsset = pair.components(separatedBy: "_").last else { return nil }
+        guard let assetType = AssetType(stringValue: toAsset) else { return nil }
+        return toFiat(from: assetType, amount: withdrawalAmount)
+    }
+    
+    fileprivate func inboundCryptoAmount() -> String? {
+        guard let currencySymbol = withdrawalCurrency() else { return nil }
+        guard let assetType = AssetType(stringValue: currencySymbol) else { return nil }
+        return toCrypto(from: assetType, amount: withdrawalAmount)
+    }
+    
+    fileprivate func outboundFiatAmount() -> String? {
+        guard let fromAsset = pair.components(separatedBy: "_").first else { return nil }
+        guard let assetType = AssetType(stringValue: fromAsset) else { return nil }
+        return toFiat(from: assetType, amount: depositAmount)
+    }
+    
+    fileprivate func outboundCryptoAmount() -> String? {
+        guard let currencySymbol = depositCurrency() else { return nil }
+        guard let assetType = AssetType(stringValue: currencySymbol) else { return nil }
+        return toCrypto(from: assetType, amount: depositAmount)
+    }
+    
+    fileprivate func toFiat(from assetType: AssetType, amount: NSDecimalNumber) -> String? {
+        switch assetType {
+        case .bitcoin:
+            let value = NumberFormatter.formatBch(
+                withSymbol: amount.uint64Value,
+                localCurrency: true
+            )
+            return value
+        case .ethereum:
+            let value = NumberFormatter.formatEthToFiat(
+                withSymbol: amount.stringValue,
+                exchangeRate: WalletManager.shared.wallet.latestEthExchangeRate
+            )
+            return value
+        case .bitcoinCash:
+            let value = NumberFormatter.formatBch(
+                withSymbol: amount.uint64Value,
+                localCurrency: true
+            )
+            return value
         }
     }
     
-    fileprivate func outboundDisplayAmount() -> String? {
-        if BlockchainSettings.sharedAppInstance().symbolLocal {
-            guard let currencySymbol = depositCurrency() else { return nil }
-            guard let assetType = AssetType(stringValue: currencySymbol) else { return nil }
-            switch assetType {
-            case .bitcoin:
-                let value = NumberFormatter.parseBtcValue(from: depositAmount.stringValue)
-                return NumberFormatter.formatMoney(value.magnitude)
-            case .ethereum:
-                guard let exchangeRate = WalletManager.shared.wallet.latestEthExchangeRate else { return nil }
-                return NumberFormatter.formatEth(
-                    withLocalSymbol: depositAmount.stringValue,
-                    exchangeRate: exchangeRate
-                )
-            case .bitcoinCash:
-                let value = NumberFormatter.parseBtcValue(from: depositAmount.stringValue)
-                return NumberFormatter.formatBch(withSymbol: value.magnitude)
-            }
-        } else {
-            guard let fromAsset = pair.components(separatedBy: "_").first else { return nil }
-            let formatted = fromAsset.uppercased()
-            guard let amount = NumberFormatter.localFormattedString(depositAmount.stringValue) else { return nil }
-            return amount + " " + formatted
+    fileprivate func toCrypto(from assetType: AssetType, amount: NSDecimalNumber) -> String? {
+        switch assetType {
+        case .bitcoin:
+            let value = NumberFormatter.parseBtcValue(from: amount.stringValue)
+            return NumberFormatter.formatMoney(value.magnitude)
+        case .ethereum:
+            guard let exchangeRate = WalletManager.shared.wallet.latestEthExchangeRate else { return nil }
+            return NumberFormatter.formatEth(
+                withLocalSymbol: amount.stringValue,
+                exchangeRate: exchangeRate
+            )
+        case .bitcoinCash:
+            let value = NumberFormatter.parseBtcValue(from: amount.stringValue)
+            return NumberFormatter.formatBch(withSymbol: value.magnitude)
         }
     }
 }

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -195,43 +195,43 @@ struct PartnerTrade {
         if let value = trade.minerFeeCryptoAmount() {
             minerFee = value
         } else {
-            fatalError("Failed to map \(trade.minerFee)")
+            fatalError("Failed to map minerFee")
         }
         
         if let pairType = TradingPair(string: trade.pair) {
             pair = pairType
         } else {
-            fatalError("Failed to map \(trade.pair)")
+            fatalError("Failed to map pair")
         }
         
         if let value = trade.inboundCryptoAmount() {
             amountReceivedCryptoValue = value
         } else {
-            fatalError("Failed to map \(trade.inboundCryptoAmount() ?? "")")
+            fatalError("Failed to map amountReceivedCryptoValue)")
         }
         
         if let value = trade.inboundFiatAmount() {
             amountReceivedFiatValue = value
         } else {
-            fatalError("Failed to map \(trade.inboundFiatAmount() ?? "")")
+            fatalError("Failed to map amountReceivedFiatValue)")
         }
         
         if let value = trade.outboundCryptoAmount() {
             amountDepositedCryptoValue = value
         } else {
-            fatalError("Failed to map \(trade.outboundCryptoAmount() ?? "")")
+            fatalError("Failed to map amountDepositedCryptoValue)")
         }
         
         if let value = trade.outboundFiatAmount() {
             amountDepositedFiatValue = value
         } else {
-            fatalError("Failed to map \(trade.outboundFiatAmount() ?? "")")
+            fatalError("Failed to map amountDepositedFiatValue)")
         }
         
         if let asset = AssetType(stringValue: trade.withdrawalCurrency()) {
             assetType = asset
         } else {
-            fatalError("Failed to map \(trade.withdrawalCurrency())")
+            fatalError("Failed to map assetType")
         }
     }
 }

--- a/Blockchain/Homebrew/Exchange/Views/Cells/ExchangeListViewCell.swift
+++ b/Blockchain/Homebrew/Exchange/Views/Cells/ExchangeListViewCell.swift
@@ -24,8 +24,8 @@ class ExchangeListViewCell: UITableViewCell {
 
     func configure(with cellModel: ExchangeTradeModel) {
         timestamp.text = cellModel.formattedDate
-        depositAmount.text = "-" + cellModel.amountDepositedCryptoValue + " \(cellModel.amountDepositedCryptoSymbol)"
-        receivedAmount.text = cellModel.amountReceivedCryptoValue + " \(cellModel.amountReceivedCryptoSymbol)"
+        depositAmount.text = "-" + cellModel.amountDepositedCrypto
+        receivedAmount.text = cellModel.amountReceivedCrypto
         
         status.text = cellModel.status.displayValue
 
@@ -33,7 +33,7 @@ class ExchangeListViewCell: UITableViewCell {
     }
 
     class func estimatedHeight(for model: ExchangeTradeModel) -> CGFloat {
-        let received = model.amountReceivedCryptoValue
+        let received = model.amountReceivedCrypto
         let status = model.status.displayValue
         
         guard let receivedFont = UIFont(name: Constants.FontNames.montserratRegular, size: 16) else { return 0.0 }

--- a/Blockchain/Models/ExchangeTrade.h
+++ b/Blockchain/Models/ExchangeTrade.h
@@ -21,6 +21,8 @@
 #define DICTIONARY_KEY_QUOTE @"quote"
 #define DICTIONARY_KEY_QUOTED_RATE @"quotedRate"
 #define DICTIONARY_KEY_ORDER_ID @"orderId"
+#define DICTIONARY_KEY_WITHDRAWAL @"withdrawal"
+#define DICTIONARY_KEY_DEPOSIT @"deposit"
 #define DICTIONARY_KEY_WITHDRAWAL_AMOUNT @"withdrawalAmount"
 #define DICTIONARY_KEY_EXPIRATION_DATE @"expirationDate"
 #define DICTIONARY_KEY_DEPOSIT_AMOUNT @"depositAmount"
@@ -32,6 +34,8 @@
 @property (nonatomic) NSDate *expirationDate;
 @property (nonatomic) NSString *status;
 @property (nonatomic) NSString *pair;
+@property (nonatomic) NSString *withdrawal;
+@property (nonatomic) NSString *deposit;
 @property (nonatomic) NSDecimalNumber *depositAmount;
 @property (nonatomic) NSDecimalNumber *withdrawalAmount;
 @property (nonatomic) NSDecimalNumber *transactionFee;

--- a/Blockchain/Models/ExchangeTrade.h
+++ b/Blockchain/Models/ExchangeTrade.h
@@ -49,5 +49,6 @@
 - (NSString *)exchangeRateString;
 - (NSString *)depositCurrency;
 - (NSString *)withdrawalCurrency;
+- (NSString *)minerCurrency;
 
 @end

--- a/Blockchain/Models/ExchangeTrade.m
+++ b/Blockchain/Models/ExchangeTrade.m
@@ -26,6 +26,8 @@
     trade.depositAmount = [ExchangeTrade decimalNumberFromDictValue:[quote objectForKey:DICTIONARY_KEY_DEPOSIT_AMOUNT]];
     trade.withdrawalAmount = [ExchangeTrade decimalNumberFromDictValue:[quote objectForKey:DICTIONARY_KEY_WITHDRAWAL_AMOUNT]];
     trade.minerFee = [ExchangeTrade decimalNumberFromDictValue:[quote objectForKey:DICTIONARY_KEY_MINER_FEE]];
+    trade.withdrawal = [quote objectForKey:DICTIONARY_KEY_WITHDRAWAL];
+    trade.deposit = [quote objectForKey:DICTIONARY_KEY_DEPOSIT];
     
     trade.exchangeRate = [ExchangeTrade decimalNumberFromDictValue:[quote objectForKey:DICTIONARY_KEY_QUOTED_RATE]];
     trade.exchangeRateString = [trade exchangeRateString];

--- a/Blockchain/Models/ExchangeTrade.m
+++ b/Blockchain/Models/ExchangeTrade.m
@@ -83,7 +83,12 @@
 {
     NSArray *components = [self.pair componentsSeparatedByString:@"_"];
     return components.lastObject;
-    
+}
+
+- (NSString *)minerCurrency
+{
+    NSArray *components = [self.pair componentsSeparatedByString:@"_"];
+    return components.firstObject;
 }
 
 @end


### PR DESCRIPTION
## Objective

Multiple fixes for incorrectly formatted trade overview details.

## Description

There were a bunch of minor things here: 
* We were comparing wallet addresses without taking into account casing. 
* The extension on `ExchangeTradeModel` was returning an empty string for a few values when the model type was of `.partner`
* The functions that are on the `ExchangeTrade` extension were using `BlockchainSettings.shared.symbolLocal`. This was correct in the case that we're using `ExchangeTableViewCell`, but we aren't. I broke up those functions to be a bit more descriptive and easier to follow. That settings value was actually `nil` but we were using the function for both fiat and crypto when both fiat *and* crypto should be displayed simultaneously (not toggled like the older design). 
* Now taking into account `minerFee` for partner trades. This isn't taking into account the `transactionFee`. Not sure where that comes from just yet, but it's not in the fetch request currently. 

## How to Test

1. Build and run
2. Go to the `Exchange` 
3. Look at your prior trades. 
4. They should look the same if they're HB trades
5. Partner trades should have filled in fields. 

## Screenshot/Design assessment

![simulator screen shot - iphone x - 2018-09-27 at 17 36 46](https://user-images.githubusercontent.com/41585563/46178559-011a4700-c27d-11e8-85d9-795d46a30c6c.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
