### PR TITLE
fix(Homebrew-Exchange): IOS-1383 prevent duplicate trades and pass in correct AssetAccount

### DIFF
--- a/Blockchain/Homebrew/Exchange/API/TradeExecutionAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/TradeExecutionAPI.swift
@@ -11,14 +11,23 @@ import Foundation
 protocol TradeExecutionAPI {
 
     // Build a transaction
-    func submitOrder(with conversion: Conversion, success: @escaping ((OrderTransaction, Conversion) -> Void), error: @escaping ((String) -> Void))
-
-    // Send the transaction that was last built
-    func sendTransaction(assetType: AssetType, success: @escaping (() -> Void), error: @escaping ((String) -> Void))
+    func buildOrder(
+        with conversion: Conversion,
+        from: AssetAccount,
+        to: AssetAccount,
+        success: @escaping ((OrderTransaction, Conversion) -> Void),
+        error: @escaping ((String) -> Void)
+    )
 
     // Build a transaction and send it
-    func submitAndSend(with conversion: Conversion, success: @escaping (() -> Void), error: @escaping ((String) -> Void))
-    
+    func buildAndSend(
+        with conversion: Conversion,
+        from: AssetAccount,
+        to: AssetAccount,
+        success: @escaping (() -> Void),
+        error: @escaping ((String) -> Void)
+    )
+
     /// Check if the service is currently executing a request prior to
     /// submitting an additional request.
     var isExecuting: Bool { get set }

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -88,7 +88,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let sendTo = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.sendTo,
-                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.destination)
+                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.destination.address.address)
                 )
                 
                 let paragraphStyle = NSMutableParagraphStyle()
@@ -148,7 +148,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let sendTo = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.sendTo,
-                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.destination)
+                    value: accountRepository.nameOfAccountContaining(address: orderTransaction.destination.address.address)
                 )
                 
                 let paragraphStyle = NSMutableParagraphStyle()
@@ -259,8 +259,10 @@ class ExchangeDetailCoordinator: NSObject {
             guard tradeExecution.isExecuting == false else { return }
             interface?.loadingVisibility(.visible, action: .confirmExchange)
             
-            tradeExecution.submitAndSend(
+            tradeExecution.buildAndSend(
                 with: lastConversion,
+                from: transaction.from,
+                to: transaction.destination,
                 success: { [weak self] in
                     guard let this = self else { return }
                     

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -292,15 +292,25 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         output?.loadingVisibility(.visible, action: ExchangeCreateViewController.Action.createPayment)
 
         // Submit order to get payment information
-        tradeExecution.submitOrder(with: conversion, success: { [weak self] orderTransaction, conversion in
-            guard let this = self else { return }
-            this.output?.loadingVisibility(.hidden, action: ExchangeCreateViewController.Action.createPayment)
-            this.output?.showSummary(orderTransaction: orderTransaction, conversion: conversion)
-        }, error: { [weak self] errorMessage in
-            guard let this = self else { return }
-            AlertViewPresenter.shared.standardError(message: errorMessage)
-            this.output?.loadingVisibility(.hidden, action: ExchangeCreateViewController.Action.createPayment)
-        })
+        guard let from = model?.marketPair.fromAccount,
+            let to = model?.marketPair.toAccount else {
+            AlertViewPresenter.shared.standardError(message: "Missing from or to asset account")
+            return
+        }
+        tradeExecution.buildOrder(
+            with: conversion,
+            from: from,
+            to: to,
+            success: { [weak self] orderTransaction, conversion in
+                guard let this = self else { return }
+                this.output?.loadingVisibility(.hidden, action: ExchangeCreateViewController.Action.createPayment)
+                this.output?.showSummary(orderTransaction: orderTransaction, conversion: conversion)
+            }, error: { [weak self] errorMessage in
+                guard let this = self else { return }
+                AlertViewPresenter.shared.standardError(message: errorMessage)
+                this.output?.loadingVisibility(.hidden, action: ExchangeCreateViewController.Action.createPayment)
+            }
+        )
     }
 
     // MARK: - Private

--- a/Blockchain/Homebrew/Exchange/Models/Order.swift
+++ b/Blockchain/Homebrew/Exchange/Models/Order.swift
@@ -74,7 +74,7 @@ struct OrderResult: Codable {
 struct OrderTransaction {
     // The destination is where the user will ultimately receive
     // funds from the exchange.
-    let destination: String
+    let destination: AssetAccount
 
     // Details of payment constructed in Wallet JS
     let from: AssetAccount

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -156,8 +156,7 @@ class TradeExecutionService: TradeExecutionAPI {
                 guard let this = self else { return }
                 // Here we should have an OrderResult object, with a deposit address.
                 // Fees must be fetched from wallet payment APIs
-                let createOrderCompletion: ((OrderTransactionLegacy) -> Void) = { [weak self] orderTransactionLegacy in
-                    guard let this = self else { return }
+                let createOrderCompletion: ((OrderTransactionLegacy) -> Void) = { orderTransactionLegacy in
                     let assetType = AssetType.from(legacyAssetType: orderTransactionLegacy.legacyAssetType)
                     let to = AssetAddressFactory.create(fromAddressString: orderTransactionLegacy.to, assetType: assetType)
                     let orderTransaction = OrderTransaction(

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -158,7 +158,6 @@ class TradeExecutionService: TradeExecutionAPI {
                 // Fees must be fetched from wallet payment APIs
                 let createOrderCompletion: ((OrderTransactionLegacy) -> Void) = { [weak self] orderTransactionLegacy in
                     guard let this = self else { return }
-                    let addressString = this.wallet.getReceiveAddress(forAccount: 0, assetType: orderTransactionLegacy.legacyAssetType)
                     let assetType = AssetType.from(legacyAssetType: orderTransactionLegacy.legacyAssetType)
                     let to = AssetAddressFactory.create(fromAddressString: orderTransactionLegacy.to, assetType: assetType)
                     let orderTransaction = OrderTransaction(


### PR DESCRIPTION
## Objective

- Prevent duplicate trades by calling trades endpoint only once (after tapping "Send Now")
- Allow sending from different account index

## Description

The issue is that the trades endpoint is called twice - once when tapping "Exchange X for Y" to get the `amount` information to build a transaction so that the transaction's fees can be displayed on the confirm screen, and again when tapping "Send Order."

The difficulty and complexity of this issue lies within the `Estimated Fees` being displayed on the confirm screen, which also happens to be receiving websocket messages that are constantly changing the amount to be sent or received (depending on the `Fix`).

It's clear that the transaction must be built and the post to the trades endpoint must happen when tapping "Send Order," but that leaves the question of whether to build the transaction when tapping "Exchange X for Y." I've decided to build the transaction here instead of not building it in order to get the most accurate estimate of fees using the `conversion.quote.currencyRatio.base.crypto` amount.

## How to Test

- Put a breakpoint at `process(order: Order)` and send an Exchange order - it should be called only once.
- Send an Exchange order from an account index that isn't your default account - the transactions tab should show that you sent it from that account.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
