### PR TITLE
fix(Exchange): update conversion rates view as rates and trading pairs change (IOS-1364)

### DIFF
--- a/Blockchain.xcodeproj/project.pbxproj
+++ b/Blockchain.xcodeproj/project.pbxproj
@@ -658,6 +658,8 @@
 		AAA3333F2088131D0019AD55 /* ModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA3333E2088131D0019AD55 /* ModalPresenter.swift */; };
 		AAA6648A21234250009C1C64 /* LocationUpdateAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3D5DB5211B96FA00E6C241 /* LocationUpdateAPI.swift */; };
 		AAA6648B2123426A009C1C64 /* PrimaryButtonContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B9CD42118E15200BD3D60 /* PrimaryButtonContainer.swift */; };
+		AAB43A892162C19C0015C863 /* Rx+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB43A882162C19C0015C863 /* Rx+Helpers.swift */; };
+		AAB43A8A2162C19C0015C863 /* Rx+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB43A882162C19C0015C863 /* Rx+Helpers.swift */; };
 		AABB74C620D44AE300C0F7C5 /* AboutUsView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AABB74C520D44AE300C0F7C5 /* AboutUsView.storyboard */; };
 		AABB74C820D44B0600C0F7C5 /* AboutUsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB74C720D44B0600C0F7C5 /* AboutUsViewController.swift */; };
 		AABB74C920D44B0600C0F7C5 /* AboutUsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB74C720D44B0600C0F7C5 /* AboutUsViewController.swift */; };
@@ -3096,6 +3098,7 @@
 		AAA3333A2088115C0019AD55 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		AAA3333C208813040019AD55 /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
 		AAA3333E2088131D0019AD55 /* ModalPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalPresenter.swift; sourceTree = "<group>"; };
+		AAB43A882162C19C0015C863 /* Rx+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rx+Helpers.swift"; sourceTree = "<group>"; };
 		AABB74C520D44AE300C0F7C5 /* AboutUsView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AboutUsView.storyboard; sourceTree = "<group>"; };
 		AABB74C720D44B0600C0F7C5 /* AboutUsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutUsViewController.swift; sourceTree = "<group>"; };
 		AABDED3F208A6E8D002D8BAC /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
@@ -3844,6 +3847,7 @@
 				AABDED3F208A6E8D002D8BAC /* UIViewController.swift */,
 				AA63F84A20A12AE9002B719B /* URLs.swift */,
 				513913EF2081206C002578FD /* UserDefaults.swift */,
+				AAB43A882162C19C0015C863 /* Rx+Helpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -7660,6 +7664,7 @@
 				AAF2AEC3212379CC00687E30 /* PersonalDetailsCoordinator.swift in Sources */,
 				604598AD2118BA9700AE08C8 /* Settings+Helpers.swift in Sources */,
 				C74E866220B3272B00F7263D /* TransferAllCoordinator.swift in Sources */,
+				AAB43A8A2162C19C0015C863 /* Rx+Helpers.swift in Sources */,
 				AAE94F3D20C70F4B005A3595 /* BIP21URI.swift in Sources */,
 				AA126CFE212CE40E005886A3 /* KYCUpdatePersonalDetailsRequest.swift in Sources */,
 				51A862BE2090DD6400B338E0 /* PairingInstructionsView.swift in Sources */,
@@ -8431,6 +8436,7 @@
 				A269E92E1B32D51F0052F953 /* SecondPasswordViewController.swift in Sources */,
 				C76D732C20B2F5CD00040B57 /* WalletFiatAtTimeDelegate.swift in Sources */,
 				AAD158DE2123740C0058B3C8 /* BlockchainDataRepository.swift in Sources */,
+				AAB43A892162C19C0015C863 /* Rx+Helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Blockchain/Extensions/Rx+Helpers.swift
+++ b/Blockchain/Extensions/Rx+Helpers.swift
@@ -1,0 +1,15 @@
+//
+//  Rx+Helpers.swift
+//  Blockchain
+//
+//  Created by Chris Arriola on 10/1/18.
+//  Copyright © 2018 Blockchain Luxembourg S.A. All rights reserved.
+//
+
+import RxSwift
+
+extension CompositeDisposable {
+    @discardableResult func insertWithDiscardableResult(_ disposable: Disposable) -> CompositeDisposable.DisposeKey? {
+        return self.insert(disposable)
+    }
+}

--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -29,7 +29,6 @@ protocol ExchangeCreateInterface: class {
 protocol ExchangeCreateInput: NumberKeypadViewDelegate {
     func viewLoaded()
     func displayInputTypeTapped()
-    func ratesViewTapped()
     func useMinimumAmount(assetAccount: AssetAccount)
     func useMaximumAmount(assetAccount: AssetAccount)
     func confirmationIsExecuting() -> Bool

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -188,6 +188,7 @@
                     </view>
                     <connections>
                         <outlet property="conversionRatesView" destination="Hcw-SG-3XL" id="2o2-Fx-Jb5"/>
+                        <outlet property="conversionTitleLabel" destination="C9l-S4-AAj" id="Z2S-dI-FzM"/>
                         <outlet property="conversionView" destination="eA3-pM-NKs" id="veU-HE-Ibp"/>
                         <outlet property="exchangeButton" destination="DUe-4D-nhJ" id="8Ye-3x-3jU"/>
                         <outlet property="hideRatesButton" destination="coY-Dg-Mc5" id="bEB-4e-zyz"/>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -44,6 +44,7 @@ class ExchangeCreateViewController: UIViewController {
     @IBOutlet private var useMinimumButton: UIButton!
     @IBOutlet private var useMaximumButton: UIButton!
     @IBOutlet private var conversionView: UIView!
+    @IBOutlet private var conversionTitleLabel: UILabel!
     @IBOutlet private var exchangeButton: UIButton!
 
     @IBAction func useMinimumButtonTapped(_ sender: Any) {
@@ -334,6 +335,7 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
     }
 
     func updateRateLabels(first: String, second: String, third: String) {
+        conversionTitleLabel.text = first
         conversionRatesView.apply(
             baseToCounter: first,
             baseToFiat: second,

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -90,44 +90,8 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         markets.authenticate(completion: { [unowned self] in
             self.subscribeToConversions()
             self.updateMarketsConversion()
+            self.subscribeToBestRates()
         })
-    }
-
-    func subscribeToConversions() {
-        let conversionsDisposable = markets.conversions.subscribe(onNext: { [weak self] conversion in
-            guard let this = self else { return }
-
-            guard let model = this.model else { return }
-
-            guard model.pair.stringRepresentation == conversion.quote.pair else {
-                Logger.shared.warning(
-                    "Pair '\(conversion.quote.pair)' is different from model pair '\(model.pair.stringRepresentation)'."
-                )
-                return
-            }
-
-            // Store conversion
-            model.lastConversion = conversion
-
-            // Use conversions service to determine new input/output
-            this.conversions.update(with: conversion)
-
-            // Update interface to reflect the values returned from the conversion
-            // Update input labels
-            this.updateOutput()
-
-            // Update trading pair view values
-            this.updateTradingValues(left: this.conversions.baseOutput, right: this.conversions.counterOutput)
-        }, onError: { error in
-            Logger.shared.error("Error subscribing to quote with trading pair")
-        })
-        
-        let errorDisposable = markets.errors.subscribe(onNext: { [weak self] socketError in
-            // TODO: Implement error handling from Socket.
-        })
-        
-        _ = disposables.insert(conversionsDisposable)
-        _ = disposables.insert(errorDisposable)
     }
 
     func updateMarketsConversion() {
@@ -172,14 +136,6 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
             let primary = inputs.primaryAssetAttributedString(symbol: symbol)
             output.updatedInput(primary: primary, secondary: secondaryResult)
         }
-        
-        guard let conversion = model.lastConversion else { return }
-        
-        output.updatedRates(
-            first: conversion.baseToCounterDescription,
-            second: conversion.baseToFiatDescription,
-            third: conversion.counterToFiatDescription
-        )
     }
 
     func updateTradingValues(left: String, right: String) {
@@ -192,10 +148,6 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         inputs.isUsingFiat = model.isUsingFiat
         inputs.toggleInput(withOutput: conversions.output)
         updatedInput()
-    }
-    
-    func ratesViewTapped() {
-        
     }
     
     func useMinimumAmount(assetAccount: AssetAccount) {
@@ -305,6 +257,66 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
 
     // MARK: - Private
 
+    private func subscribeToBestRates() {
+        guard let model = model else { return }
+
+        let bestRatesDisposable = markets.bestExchangeRates(
+            fiatCurrencyCode: model.fiatCurrencyCode
+        ).subscribe(onNext: { [weak self] rates in
+            guard let strongSelf = self else { return }
+
+            guard let marketsModel = strongSelf.model else { return }
+
+            let fiatCode = marketsModel.fiatCurrencyCode
+            let baseCode = marketsModel.pair.from.symbol
+            let counterCode = marketsModel.pair.to.symbol
+
+            strongSelf.output?.updatedRates(
+                first: rates.exchangeRateDescription(fromCurrency: baseCode, toCurrency: counterCode),
+                second: rates.exchangeRateDescription(fromCurrency: baseCode, toCurrency: fiatCode),
+                third: rates.exchangeRateDescription(fromCurrency: counterCode, toCurrency: fiatCode)
+            )
+        })
+        disposables.insertWithDiscardableResult(bestRatesDisposable)
+    }
+
+    private func subscribeToConversions() {
+        let conversionsDisposable = markets.conversions.subscribe(onNext: { [weak self] conversion in
+            guard let this = self else { return }
+
+            guard let model = this.model else { return }
+
+            guard model.pair.stringRepresentation == conversion.quote.pair else {
+                Logger.shared.warning(
+                    "Pair '\(conversion.quote.pair)' is different from model pair '\(model.pair.stringRepresentation)'."
+                )
+                return
+            }
+
+            // Store conversion
+            model.lastConversion = conversion
+
+            // Use conversions service to determine new input/output
+            this.conversions.update(with: conversion)
+
+            // Update interface to reflect the values returned from the conversion
+            // Update input labels
+            this.updateOutput()
+
+            // Update trading pair view values
+            this.updateTradingValues(left: this.conversions.baseOutput, right: this.conversions.counterOutput)
+            }, onError: { error in
+                Logger.shared.error("Error subscribing to quote with trading pair")
+        })
+
+        let errorDisposable = markets.errors.subscribe(onNext: { [weak self] socketError in
+            // TODO: Implement error handling from Socket.
+        })
+
+        disposables.insertWithDiscardableResult(conversionsDisposable)
+        disposables.insertWithDiscardableResult(errorDisposable)
+    }
+
     private func applyTradingLimit(limit: TradingLimit, assetAccount: AssetAccount) {
         guard let model = model else { return }
 
@@ -368,5 +380,14 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         case false:
             return inputs.canAddAssetCharacter(value)
         }
+    }
+}
+
+extension ExchangeRates {
+    func exchangeRateDescription(fromCurrency: String, toCurrency: String) -> String {
+        guard let rate = pairRate(fromCurrency: fromCurrency, toCurrency: toCurrency) else {
+            return ""
+        }
+        return "1 \(fromCurrency) = \(rate.price) \(toCurrency)"
     }
 }

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -120,10 +120,14 @@ struct ExchangeRates: SocketMessageCodable {
 
 extension ExchangeRates {
     func convert(balance: Decimal, fromCurrency: String, toCurrency: String) -> Decimal {
-        if let matchingPair = rates.first(where: { $0.pair == "\(fromCurrency)-\(toCurrency)" }) {
+        if let matchingPair = pairRate(fromCurrency: fromCurrency, toCurrency: toCurrency) {
             return matchingPair.price * balance
         }
         return balance
+    }
+
+    func pairRate(fromCurrency: String, toCurrency: String) -> CurrencyPairRate? {
+        return rates.first(where: { $0.pair == "\(fromCurrency)-\(toCurrency)" })
     }
 }
 
@@ -154,30 +158,6 @@ struct Conversion: SocketMessageCodable {
         case channel
         case type
         case quote
-    }
-}
-
-extension Conversion {
-    var baseToFiatDescription: String {
-        let fiatSymbol = quote.currencyRatio.base.fiat.symbol
-        let base = "1" + " " + quote.currencyRatio.base.crypto.symbol
-        let fiat = fiatSymbol + quote.currencyRatio.baseToFiatRate
-        return base + " = " + fiat
-    }
-    
-    var baseToCounterDescription: String {
-        let base = "1" + " " + quote.currencyRatio.base.crypto.symbol
-        let counterSymbol = quote.currencyRatio.counter.crypto.symbol
-        let counter = quote.currencyRatio.baseToCounterRate + " " + counterSymbol
-        return base + " = " + counter
-    }
-    
-    var counterToFiatDescription: String {
-        let counterSymbol = quote.currencyRatio.counter.crypto.symbol
-        let fiatSymbol = quote.currencyRatio.counter.fiat.symbol
-        let counter = "1" + " " + counterSymbol
-        let fiat = fiatSymbol + quote.currencyRatio.counterToFiatRate
-        return counter + " = " + fiat
     }
 }
 


### PR DESCRIPTION
## Objective

Display best crypto-to-crypto and crypto-to-fiat exchange rates

## Description

Summary of changes:
* Display best rates as provided by the "exchange_rates" websocket end-point (previously, these rates were only used to convert balances to fiat). Using these rates, we can display the conversion rate for the selected trading pair.

Other changes:
* Added an extension to `CompositeDisposable` to allow discardable result inserts
* Note that the "exchange_rates" websocket does not return the fiat symbol, the consequence of this is that crypto to fiat rates are displayed as "1 BTC = 123 USD" and not "1 BTC = $123" (confirmed with design that this behavior is fine). 

## How to Test

1. Pull in changes
2. Try selecting different trading pairs
3. Verify that conversions update

## Screenshot/Design assessment

![img_5d7057e29b4f-1](https://user-images.githubusercontent.com/38220701/46318755-6d05f380-c58c-11e8-96c4-81e7d8ede185.jpeg)


## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] You have added sufficient documentation (descriptive comments).
- [X] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
