### PR TITLE
fix(KYC): dismiss KYC navigation stack when starting partner exchange flow (IOS-1337).

### DIFF
--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -237,7 +237,7 @@ struct ExchangeServices: ExchangeDependencies {
     // MARK: - Event handling
     enum ExchangeCoordinatorEvent {
         case createHomebrewExchange(animated: Bool, viewController: UIViewController?)
-        case createPartnerExchange(country: KYCCountry, animated: Bool, viewController: UIViewController?)
+        case createPartnerExchange(country: KYCCountry, animated: Bool)
         case confirmExchange(orderTransaction: OrderTransaction, conversion: Conversion)
         case sentTransaction(orderTransaction: OrderTransaction, conversion: Conversion)
         case showTradeDetails(trade: ExchangeTradeModel)
@@ -250,7 +250,7 @@ struct ExchangeServices: ExchangeDependencies {
                 rootViewController = viewController
             }
             showCreateExchange(animated: animated, type: .homebrew)
-        case .createPartnerExchange(let country, let animated, _):
+        case .createPartnerExchange(let country, let animated):
             showCreateExchange(animated: animated, type: .shapeshift, country: country)
         case .confirmExchange(let orderTransaction, let conversion):
             showConfirmExchange(orderTransaction: orderTransaction, conversion: conversion)

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -250,10 +250,7 @@ struct ExchangeServices: ExchangeDependencies {
                 rootViewController = viewController
             }
             showCreateExchange(animated: animated, type: .homebrew)
-        case .createPartnerExchange(let country, let animated, let viewController):
-            if viewController != nil {
-                rootViewController = viewController
-            }
+        case .createPartnerExchange(let country, let animated, _):
             showCreateExchange(animated: animated, type: .shapeshift, country: country)
         case .confirmExchange(let orderTransaction, let conversion):
             showConfirmExchange(orderTransaction: orderTransaction, conversion: conversion)

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -211,13 +211,13 @@ extension KYCCountrySelectionController: KYCCountrySelectionView {
     func startPartnerExchangeFlow(country: KYCCountry) {
         guard let navController = self.navigationController else {
             ExchangeCoordinator.shared.handle(
-                event: .createPartnerExchange(country: country, animated: true, viewController: self)
+                event: .createPartnerExchange(country: country, animated: true)
             )
             return
         }
-        navController.dismiss(animated: true, completion: { [unowned self] in
+        navController.dismiss(animated: true, completion: {
             ExchangeCoordinator.shared.handle(
-                event: .createPartnerExchange(country: country, animated: true, viewController: self)
+                event: .createPartnerExchange(country: country, animated: true)
             )
         })
     }

--- a/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
+++ b/Blockchain/KYC/CountrySelector/KYCCountrySelectionController.swift
@@ -209,9 +209,17 @@ extension KYCCountrySelectionController: KYCCountrySelectionView {
     }
 
     func startPartnerExchangeFlow(country: KYCCountry) {
-        ExchangeCoordinator.shared.handle(
-            event: .createPartnerExchange(country: country, animated: true, viewController: self)
-        )
+        guard let navController = self.navigationController else {
+            ExchangeCoordinator.shared.handle(
+                event: .createPartnerExchange(country: country, animated: true, viewController: self)
+            )
+            return
+        }
+        navController.dismiss(animated: true, completion: { [unowned self] in
+            ExchangeCoordinator.shared.handle(
+                event: .createPartnerExchange(country: country, animated: true, viewController: self)
+            )
+        })
     }
 
     func showExchangeNotAvailable(country: KYCCountry) {


### PR DESCRIPTION
## Objective

Dismiss KYC navigation stack when starting partner exchange flow

## How to Test

Launch KYC, pick an SS-supported country (e.g. Andorra), notice that KYC nav stack is dismissed first.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
