### PR TITLE
fix(Wallet): IOS-1387 fetch balances after sync

### DIFF
--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -342,7 +342,7 @@ extension AppCoordinator: WalletAccountInfoAndExchangeRatesDelegate {
 
 extension AppCoordinator: WalletBackupDelegate {
     func didBackupWallet() {
-        reload()
+        walletManager.wallet.getHistoryForAllAssets()
     }
 
     func didFailBackupWallet() {

--- a/Blockchain/Coordinators/AppCoordinator.swift
+++ b/Blockchain/Coordinators/AppCoordinator.swift
@@ -346,7 +346,7 @@ extension AppCoordinator: WalletBackupDelegate {
     }
 
     func didFailBackupWallet() {
-        walletManager.wallet.getAndHistory()
+        walletManager.wallet.getHistoryForAllAssets()
     }
 }
 

--- a/Blockchain/Models/Wallet.h
+++ b/Blockchain/Models/Wallet.h
@@ -263,6 +263,7 @@
 - (void)getHistoryIfNoTransactionMessage;
 - (void)getBitcoinCashHistoryIfNoTransactionMessage;
 - (void)getWalletAndHistory;
+- (void)getHistoryForAllAssets;
 
 - (id)getLegacyAddressBalance:(NSString *)address assetType:(LegacyAssetType)assetType;
 - (uint64_t)parseBitcoinValueFromTextField:(UITextField *)textField;

--- a/Blockchain/Models/Wallet.m
+++ b/Blockchain/Models/Wallet.m
@@ -3494,8 +3494,7 @@
         DLog(@"Error: delegate of class %@ does not respond to selector didBackupWallet!", [delegate class]);
     }
     [[NSNotificationCenter defaultCenter] postNotificationName:[ConstantsObjcBridge notificationKeyBackupSuccess] object:nil];
-    // Hide the busy view if previously syncing
-    [self loading_stop];
+
     self.isSyncing = NO;
 
     if (self.isSettingDefaultAccount) {
@@ -4475,7 +4474,6 @@
         [self loading_start_create_account];
 
         self.isSyncing = YES;
-        self.shouldLoadMetadata = YES;
 
         // Wait a little bit to make sure the loading text is showing - then execute the blocking and kind of long create account
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ANIMATION_DURATION * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -156,11 +156,7 @@ MyWalletPhone.createAccount = function(label) {
     var success = function () {
         console.log('Created new account');
 
-        objc_loading_stop();
-
         objc_on_add_new_account();
-
-        objc_reload();
     };
 
     var error = function (error) {


### PR DESCRIPTION
## Objective

Fix issue where creating an HD account resulted in zero balances displayed in the dashboard and transactions tab.

## Description

After a successful wallet backup, the views were reloading while balances were `null`. Made `getHistoryForAllAssets` public and called it in `didBackupSuccess` and `didBackupError`. Also removed a couple of busy view and reload calls since `getHistoryForAllAssets` will ultimately hide the busy view.

## How to Test

Create an HD account in Addresses, and see that the balances are unchanged.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
