### PR TITLE
fix(Exchange): change default fix to baseInFiat (IOS-1359)

### DIFF
--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -124,7 +124,7 @@ class ExchangeCreateViewController: UIViewController {
                 marketPair: MarketPair(fromAccount: fromAccount, toAccount: toAccount),
                 fiatCurrencyCode: BlockchainSettings.sharedAppInstance().fiatCurrencyCode ?? "USD",
                 fiatCurrencySymbol: BlockchainSettings.sharedAppInstance().fiatCurrencySymbol ?? "$",
-                fix: .base,
+                fix: .baseInFiat,
                 volume: "0"
             )
         )


### PR DESCRIPTION
## Objective

Change default fix to `.baseInFiat`

## How to Test

Launch exchange and notice that fiat is the new default.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
