### PR TITLE
fix(ExchangeListViewController): IOS-1385 show error message when fetching trades fails

### DIFF
--- a/Blockchain/Homebrew/Exchange/API/ExchangeListContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeListContracts.swift
@@ -16,6 +16,7 @@ protocol ExchangeListInterface: class {
     func enablePullToRefresh()
     func showNewExchange(animated: Bool)
     func showTradeDetails(trade: ExchangeTradeModel)
+    func showError(message: String)
 }
 
 protocol ExchangeListInput: class {

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeListViewController.swift
@@ -115,6 +115,10 @@ extension ExchangeListViewController: ExchangeListInterface {
     func showNewExchange(animated: Bool) {
         coordinator.handle(event: .createHomebrewExchange(animated: animated, viewController: nil))
     }
+
+    func showError(message: String) {
+        AlertViewPresenter.shared.standardError(message: message)
+    }
 }
 
 extension ExchangeListViewController: ExchangeListDataProviderDelegate {

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
@@ -77,7 +77,8 @@ extension ExchangeListPresenter: ExchangeListOutput {
     }
     
     func tradeFetchFailed(error: Error?) {
+        Logger.shared.error(error?.localizedDescription ?? "Unknown error")
         interface?.refreshControlVisibility(.hidden)
-        interface?.showError(message: error?.localizedDescription ?? LocalizationConstants.Exchange.exchangeListError)
+        interface?.showError(message:  LocalizationConstants.Exchange.exchangeListError)
     }
 }

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
@@ -77,6 +77,6 @@ extension ExchangeListPresenter: ExchangeListOutput {
     }
     
     func tradeFetchFailed(error: Error?) {
-        // TODO:
+        interface?.showError(message: error?.localizedDescription ?? LocalizationConstants.Exchange.exchangeListError)
     }
 }

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
@@ -77,6 +77,7 @@ extension ExchangeListPresenter: ExchangeListOutput {
     }
     
     func tradeFetchFailed(error: Error?) {
+        interface?.refreshControlVisibility(.hidden)
         interface?.showError(message: error?.localizedDescription ?? LocalizationConstants.Exchange.exchangeListError)
     }
 }

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeListPresenter.swift
@@ -79,6 +79,6 @@ extension ExchangeListPresenter: ExchangeListOutput {
     func tradeFetchFailed(error: Error?) {
         Logger.shared.error(error?.localizedDescription ?? "Unknown error")
         interface?.refreshControlVisibility(.hidden)
-        interface?.showError(message:  LocalizationConstants.Exchange.exchangeListError)
+        interface?.showError(message: LocalizationConstants.Exchange.exchangeListError)
     }
 }

--- a/Blockchain/Homebrew/Exchange/Services/ExchangeService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/ExchangeService.swift
@@ -87,9 +87,11 @@ extension ExchangeService: ExchangeHistoryAPI {
         partnerOperation = AsyncBlockOperation(executionBlock: { [weak self] complete in
             guard let this = self else { return }
             this.partnerAPI.fetchTransactions(with: { result in
-                
-                if case let .success(payload) = result {
+                switch result {
+                case .success(let payload):
                     this.tradeModels.append(contentsOf: payload)
+                case .error(let error):
+                    completion(.error(error))
                 }
                 complete()
             })
@@ -102,8 +104,9 @@ extension ExchangeService: ExchangeHistoryAPI {
                 case .success(let value):
                     this.canPage = value.count >= 50
                     this.tradeModels.append(contentsOf: value)
-                case .error:
+                case .error(let error):
                     this.canPage = false
+                    completion(.error(error))
                 }
                 complete()
             })

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -457,6 +457,10 @@ struct LocalizationConstants {
             "Sorry, an order cannot be placed at this time.",
             comment: "Error message shown to a user if something went wrong during the exchange process and the user cannot continue"
         )
+        static let exchangeListError = NSLocalizedString(
+            "Sorry, your orders cannot be fetched at this time.",
+            comment: "Error message shown to a user if something went wrong while fetching the user's exchange orders"
+        )
     }
 
     struct AddressAndKeyImport {


### PR DESCRIPTION
## Objective

Show user friendly error when fetching trades fails.

## Description

- Implemented `ExchangeListOutput` method `tradeFetchFailed(error: Error?)`
- Implemented `ExchangeListInterface` method `showError(message: String)`

## How to Test

Cherry pick d9fba74e300c91b4dfc5f7cfadaa33a459c5ece8
Go to Exchange, pull to refresh - you should see an error.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
