### PR TITLE
 fix(Settings): fix flickering account status badge (IOS-1286)

### DIFF
--- a/Blockchain/Authentication/AuthenticationCoordinator.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator.swift
@@ -61,6 +61,8 @@ import RxSwift
         tabControllerManager.sendBitcoinViewController?.reload()
         tabControllerManager.sendBitcoinCashViewController?.reload()
 
+        strongSelf.dataRepository.prefetchData()
+
         /// Prompt the user for push notification permission
         PushNotificationManager.shared.requestAuthorization()
 
@@ -108,6 +110,8 @@ import RxSwift
         }
     }
 
+    internal let dataRepository: BlockchainDataRepository
+
     internal let walletManager: WalletManager
 
     private let walletService: WalletService
@@ -136,10 +140,12 @@ import RxSwift
 
     init(
         walletManager: WalletManager = WalletManager.shared,
-        walletService: WalletService = WalletService.shared
+        walletService: WalletService = WalletService.shared,
+        dataRepository: BlockchainDataRepository = BlockchainDataRepository.shared
     ) {
         self.walletManager = walletManager
         self.walletService = walletService
+        self.dataRepository = dataRepository
         super.init()
         self.walletManager.secondPasswordDelegate = self
     }
@@ -214,7 +220,7 @@ import RxSwift
 
         WalletManager.shared.close()
 
-        BlockchainDataRepository.shared.clearCache()
+        dataRepository.clearCache()
 
         BlockchainSettings.App.shared.reset()
 

--- a/Blockchain/Coordinators/ExchangeCoordinator.swift
+++ b/Blockchain/Coordinators/ExchangeCoordinator.swift
@@ -77,6 +77,8 @@ struct ExchangeServices: ExchangeDependencies {
 
     func start() {
         disposable = BlockchainDataRepository.shared.nabuUser
+            .take(1)
+            .asSingle()
             .subscribeOn(MainScheduler.asyncInstance)
             .observeOn(MainScheduler.instance)
             .subscribe(onSuccess: { [unowned self] in

--- a/Blockchain/Data/BlockchainDataRepository.swift
+++ b/Blockchain/Data/BlockchainDataRepository.swift
@@ -24,9 +24,10 @@ import RxSwift
 
     // MARK: - Public Properties
 
-    /// The NabuUser. This will use a cached value if available
-    var nabuUser: Single<NabuUser> {
-        return fetchData(
+    /// An Observable emitting the authenticated NabuUser. This Observable will first emit a value
+    /// from the cache, if available, followed by the value over the network.
+    var nabuUser: Observable<NabuUser> {
+        return fetchDataStartingWithCache(
             cachedValue: cachedUser,
             networkValue: fetchNabuUser()
         )
@@ -66,6 +67,17 @@ import RxSwift
     }
 
     // MARK: - Private Methods
+
+    private func fetchDataStartingWithCache<ResponseType: Decodable>(
+        cachedValue: BehaviorRelay<ResponseType?>,
+        networkValue: Single<ResponseType>
+    ) -> Observable<ResponseType> {
+        let networkObservable = networkValue.asObservable()
+        guard let cachedValue = cachedValue.value else {
+            return networkObservable
+        }
+        return networkObservable.startWith(cachedValue)
+    }
 
     private func fetchData<ResponseType: Decodable>(
         cachedValue: BehaviorRelay<ResponseType?>,

--- a/Blockchain/Data/BlockchainDataRepository.swift
+++ b/Blockchain/Data/BlockchainDataRepository.swift
@@ -48,6 +48,14 @@ import RxSwift
 
     // MARK: - Public Methods
 
+    /// Prefetches data so that it can be cached
+    func prefetchData() {
+        _ = Observable.zip(
+            nabuUser,
+            countries.asObservable()
+        ).subscribe()
+    }
+
     /// Clears cached data in this repository
     func clearCache() {
         cachedUser = BehaviorRelay<NabuUser?>(value: nil)

--- a/Blockchain/Settings/Settings+Table.swift
+++ b/Blockchain/Settings/Settings+Table.swift
@@ -125,18 +125,18 @@ extension SettingsTableViewController {
     }
 
     func getUserVerificationStatus(handler: @escaping (NabuUser?, Bool) -> Void) {
-        disposable = BlockchainDataRepository.shared.fetchNabuUser()
+        disposable = BlockchainDataRepository.shared.nabuUser
             .subscribeOn(MainScheduler.asyncInstance) // network call will be performed off the main thread
             .observeOn(MainScheduler.instance) // closures passed in subscribe will be on the main thread
-            .subscribe(onSuccess: { user in
+            .subscribe(onNext: { user in
                 handler(user, true)
-            }, onError: {  error in
+            }, onError: { error in
+                Logger.shared.error("Failed to get nabu user: \(error.localizedDescription)")
                 handler(nil, false)
             })
     }
 
     func prepareIdentityCell(_ cell: UITableViewCell) {
-        self.createBadge(cell)
         self.getUserVerificationStatus { user, success in
             if success {
                 if let theUser = user {


### PR DESCRIPTION
## Objective

Fix flickering KYC account status badge in settings view.

## Description

The badge was previously flickering because each time that cell was being rendered, it would first set it to "Unverified", make a network call to get the current NabuUser, and finally update the state of the badge to the correct KYC account status.

This PR fixes that issue by (1) not initializing the badge to "Unverified", and (2) using BlockchainDataRepository's cached version of the `NabuUser`. Since it's using the cached value which is in memory, you should no longer see the badge flicker. Notice though that I changed the property in BlockchainDataRepository to now be an `Observable<NabuUser>` so that it will first emit the cached value if available, followed by the network value.

I've also added an initialization step in `AuthenticationCoordinator` so that upon authenticating, the BlockchainDataRepository cache would be initialized. One (positive) side-effect of this, is we also no longer see a delay in the "Exchange" side menu option.

## How to Test

Go to settings.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
