### PR TITLE
fix(HB): IOS-1368 - trade date formatter fix

### DIFF
--- a/Blockchain/Extensions/DateFormatter+Conveniences.swift
+++ b/Blockchain/Extensions/DateFormatter+Conveniences.swift
@@ -23,6 +23,11 @@ extension DateFormatter {
         return formatter
     }()
     
+    static let iso8601Format: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        return formatter
+    }()
+    
     static let HTTPRequestDateFormat: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:SS'Z'"

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -281,14 +281,20 @@ struct ExchangeTradeCellModel: Decodable {
         let updated = try values.decode(String.self, forKey: .updatedAt)
         let inserted = try values.decode(String.self, forKey: .createdAt)
         let formatter = DateFormatter.sessionDateFormat
+        let legacyFormatter = DateFormatter.iso8601Format
         
-        guard let transactionResult = formatter.date(from: inserted) else {
+        if let transactionResult = formatter.date(from: inserted) {
+            createdAt = transactionResult
+        } else if let transactionResult = legacyFormatter.date(from: inserted) {
+            createdAt = transactionResult
+        } else {
             throw DecodingError.dataCorruptedError(
                 forKey: .createdAt,
                 in: values,
                 debugDescription: "Date string does not match format expected by formatter."
             )
         }
+        
         guard let updatedResult = formatter.date(from: updated) else {
             throw DecodingError.dataCorruptedError(
                 forKey: .updatedAt,
@@ -297,7 +303,6 @@ struct ExchangeTradeCellModel: Decodable {
             )
         }
         
-        createdAt = transactionResult
         updatedAt = updatedResult
         
         identifier = try values.decode(String.self, forKey: .identifier)

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -283,6 +283,9 @@ struct ExchangeTradeCellModel: Decodable {
         let formatter = DateFormatter.sessionDateFormat
         let legacyFormatter = DateFormatter.iso8601Format
         
+        /// Some trades don't have a consistant date format. Some
+        /// use the same format as what we use for establishing a
+        /// secure session, some use ISO8601.
         if let transactionResult = formatter.date(from: inserted) {
             createdAt = transactionResult
         } else if let transactionResult = legacyFormatter.date(from: inserted) {


### PR DESCRIPTION
## Objective

Fixes an issue where some trades have a `createdAt` date format that doesn't produce a string value when using the `sessionDateFormatter`

## Description

Using an account provided by QA, I saw that some trades use this format: 
`"2018-10-03T16:02:45.435Z"`

Other trades use this format:
`"2018-10-02T22:07:38Z"`

Our session date formatters uses this format: `yyyy-MM-dd'T'HH:mm:ss.SSSZ`

I added an `ISO8601DateFormatter` and it produces a string value for the second format. 

## How to Test

1. Build and run in staging
2. Use the account cited by QA in the ticket
3. Go to the exchange history screen
4. See that trades are now showing

## Screenshot/Design assessment

![simulator screen shot - iphone 8 plus - 2018-10-04 at 09 57 59](https://user-images.githubusercontent.com/41585563/46483191-b046a900-c7bc-11e8-8e93-e0aa0ba04d3e.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [x] You have added sufficient documentation (descriptive comments).
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
