### PR TITLE
fix(Homebrew-Exchange): IOS-1363 UI fixes to display rates

### DIFF
--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -90,8 +90,8 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eA3-pM-NKs">
                                 <rect key="frame" x="16" y="309.5" width="343" height="32"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 BTC = 22.19 ETH" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9l-S4-AAj">
-                                        <rect key="frame" x="114" y="7.5" width="115.5" height="17.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9l-S4-AAj">
+                                        <rect key="frame" x="172" y="16.5" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -159,7 +159,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your min is $4.56" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fAr-Eh-XkB">
-                                <rect key="frame" x="107.5" y="189.5" width="159.5" height="44"/>
+                                <rect key="frame" x="107.5" y="208" width="159.5" height="53.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="19"/>
                                 <color key="textColor" red="0.95999999999999996" green="0.26000000000000001" blue="0.26000000000000001" alpha="1" colorSpace="calibratedRGB"/>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -90,7 +90,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eA3-pM-NKs">
                                 <rect key="frame" x="16" y="309.5" width="343" height="32"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9l-S4-AAj">
+                                    <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9l-S4-AAj">
                                         <rect key="frame" x="172" y="16.5" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -65,6 +65,7 @@ class ExchangeCreateViewController: UIViewController {
     }
     
     enum ViewUpdate: Update {
+        case conversionTitleLabel(Visibility)
         case conversionView(Visibility)
         case exchangeButton(Visibility)
         case ratesChevron(Visibility)
@@ -275,6 +276,8 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
     
     func apply(update: ViewUpdate) {
         switch update {
+        case .conversionTitleLabel(let visibility):
+            conversionTitleLabel.alpha = visibility.defaultAlpha
         case .conversionView(let visibility):
             conversionView.alpha = visibility.defaultAlpha
         case .exchangeButton(let visibility):

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -281,6 +281,12 @@ extension ExchangeCreatePresenter: ExchangeCreateOutput {
     
     func updatedRates(first: String, second: String, third: String) {
         interface?.apply(presentationUpdates: [.updateRateLabels(first: first, second: second, third: third)])
+        interface?.apply(
+            animatedUpdate: ExchangeCreateInterface.AnimatedUpdate(
+                animations: [.conversionTitleLabel(.visible)],
+                animation: .standard(duration: 0.2)
+            )
+        )
     }
     
     func updateTradingPairValues(left: String, right: String) {

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -165,7 +165,7 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
             animatedUpdate: ExchangeCreateInterface.AnimatedUpdate(
                 animations: [.exchangeButton(.hidden),
                              .conversionView(.hidden)],
-                animation: .easeIn(duration: 2.0)
+                animation: .easeIn(duration: 0.2)
             )
         )
     }


### PR DESCRIPTION
## Description

- Remove placeholder text for conversion title label.
- Fade in display rate for conversion title label.
- Speed up toggle to display rates.

## How to Test

Go to Exchange.
- Observe that the display rate is not populated with placeholder text
- Observe that the display rate fades in
- When tapping on the display rate, the animation for showing the rates happens at a reasonably fast speed.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
