### PR TITLE
fix(HB): 1338 - Checking user account balance before creating a payment

### DIFF
--- a/Blockchain/Extensions/UIView.swift
+++ b/Blockchain/Extensions/UIView.swift
@@ -13,26 +13,14 @@ extension UIView {
         return Bundle.main.loadNibNamed(String(describing: T.self), owner: nil, options: nil)![0] as! T
     }
     
-    func wiggle(withFeedback: Bool = true) {
+    func wiggle(duration: CFTimeInterval = 0.8) {
         guard layer.animationKeys() == nil else { return }
-        let wiggle = CABasicAnimation(keyPath: "position")
-        wiggle.duration = 0.05
-        wiggle.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseIn)
-        wiggle.repeatCount = 1
-        wiggle.autoreverses = true
-        wiggle.fromValue = CGPoint(
-            x: center.x - 2.0,
-            y: center.y
-        )
-        wiggle.toValue = CGPoint(
-            x: center.x + 2.0,
-            y: center.y
-        )
-        layer.add(wiggle, forKey: wiggle.keyPath)
         
-        guard withFeedback else { return }
-        let feedback = UINotificationFeedbackGenerator()
-        feedback.prepare()
-        feedback.notificationOccurred(.error)
+        let translation = CAKeyframeAnimation(keyPath: "transform.translation.x");
+        translation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseOut)
+        translation.values = [-10, 10, -10, 10, -5, 5, -5, 5, -3, 3, -2, 2, 0]
+        translation.duration = duration
+        
+        self.layer.add(translation, forKey: translation.keyPath)
     }
 }

--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -56,6 +56,7 @@ protocol ExchangeCreateOutput: class {
     func updatedRates(first: String, second: String, third: String)
     func updateTradingPairValues(left: String, right: String)
     func updateTradingPair(pair: TradingPair, fix: Fix)
+    func insufficientFunds(balance: String)
     func entryBelowMinimumValue(minimum: String)
     func entryAboveMaximumValue(maximum: String)
     func loadingVisibility(_ visibility: Visibility)

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -147,7 +147,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$200.42" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okC-2w-xB9">
-                                <rect key="frame" x="154.5" y="208" width="65.5" height="53.5"/>
+                                <rect key="frame" x="155" y="208" width="65.5" height="53.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -158,8 +158,8 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your min is $4.56" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fAr-Eh-XkB">
-                                <rect key="frame" x="107.5" y="189.5" width="159.5" height="44"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your min is $4.56" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fAr-Eh-XkB">
+                                <rect key="frame" x="16" y="223" width="343" height="23.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="19"/>
                                 <color key="textColor" red="0.95999999999999996" green="0.26000000000000001" blue="0.26000000000000001" alpha="1" colorSpace="calibratedRGB"/>
@@ -175,9 +175,9 @@
                             <constraint firstItem="cbA-yh-J0A" firstAttribute="top" secondItem="V30-pI-8jo" secondAttribute="bottom" constant="8" id="7kf-Ns-aJR"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="AHN-eg-W66"/>
                             <constraint firstItem="okC-2w-xB9" firstAttribute="height" secondItem="cbA-yh-J0A" secondAttribute="height" multiplier="0.5" id="AsX-Mv-rk9"/>
-                            <constraint firstItem="fAr-Eh-XkB" firstAttribute="height" secondItem="okC-2w-xB9" secondAttribute="height" id="BvY-ki-J1y"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="top" secondItem="dfm-a1-ad2" secondAttribute="bottom" constant="16" id="EPf-w5-lBJ"/>
                             <constraint firstItem="j0b-5p-LkW" firstAttribute="leading" secondItem="5uc-t6-nYA" secondAttribute="trailing" constant="16" id="Es9-o0-zzi"/>
+                            <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="fAr-Eh-XkB" secondAttribute="trailing" constant="16" id="FMh-T4-biV"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="V30-pI-8jo" secondAttribute="trailing" constant="16" id="GHI-5B-7xh"/>
                             <constraint firstItem="V30-pI-8jo" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="HgH-sR-rJB"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="width" secondItem="dfm-a1-ad2" secondAttribute="width" id="NgP-UU-rcW"/>
@@ -203,6 +203,7 @@
                             <constraint firstItem="cbA-yh-J0A" firstAttribute="leading" secondItem="V30-pI-8jo" secondAttribute="leading" id="p9e-tX-pLR"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="dfm-a1-ad2" secondAttribute="trailing" constant="16" id="pXZ-qz-MkO"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="top" secondItem="eA3-pM-NKs" secondAttribute="bottom" constant="16" id="sAe-mI-cf2"/>
+                            <constraint firstItem="fAr-Eh-XkB" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="sYk-ft-v7v"/>
                             <constraint firstItem="coY-Dg-Mc5" firstAttribute="centerX" secondItem="DUe-4D-nhJ" secondAttribute="centerX" id="wL1-Jj-oLT"/>
                             <constraint firstItem="okC-2w-xB9" firstAttribute="top" secondItem="cbA-yh-J0A" secondAttribute="bottom" constant="4" id="wMz-b9-sNk"/>
                         </constraints>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -125,6 +125,8 @@ class ExchangeCreateViewController: UIViewController {
         [primaryAmountLabel, secondaryAmountLabel].forEach {
             $0?.textColor = UIColor.brandPrimary
         }
+        
+        secondaryAmountLabel.font = styleTemplate().secondaryFont
 
         useMinimumButton.setTitle(LocalizationConstants.Exchange.useMin, for: .normal)
         useMaximumButton.setTitle(LocalizationConstants.Exchange.useMax, for: .normal)

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -254,7 +254,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
             let minValue = payload.0
             let maxValue = payload.1
             
-            guard let volume = Decimal(string: conversion.quote.volume) else { return }
+            guard let volume = Decimal(string: conversion.quote.currencyRatio.base.crypto.value) else { return }
             guard let candidate = Decimal(string: conversion.baseFiatValue) else { return }
             
             if account.balance < volume {

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -245,19 +245,32 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         
         let min = minTradingLimit().asObservable()
         let max = maxTradingLimit().asObservable()
+        let account = model.marketPair.fromAccount
+        
         let disposable = Observable.zip(min, max) {
             return ($0, $1)
         }.subscribe(onNext: { [weak self] payload in
             guard let this = self else { return }
             let minValue = payload.0
             let maxValue = payload.1
-                
+            
+            guard let volume = Decimal(string: conversion.quote.volume) else { return }
             guard let candidate = Decimal(string: conversion.baseFiatValue) else { return }
+            
+            if account.balance < volume {
+                let symbol = conversion.baseCryptoSymbol
+                let notEnough = LocalizationConstants.Exchange.notEnough + " " + symbol + "."
+                let yourBalance = LocalizationConstants.Exchange.yourBalance + " " + "\(account.balance)" + " " + symbol
+                let value = notEnough + " " + yourBalance + "."
+                output.insufficientFunds(balance: value)
+                return
+            }
+            
             switch candidate {
             case ..<minValue:
                 let value = NumberFormatter.localCurrencyFormatter.string(for: minValue) ?? ""
                 let minimum = model.fiatCurrencySymbol + value
-                    
+                
                 output.entryBelowMinimumValue(minimum: minimum)
             case maxValue..<Decimal.greatestFiniteMagnitude:
                 guard let value = NumberFormatter.localCurrencyFormatter.string(for: maxValue) else { return }

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -245,6 +245,13 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
 }
 
 extension ExchangeCreatePresenter: ExchangeCreateOutput {
+    
+    func insufficientFunds(balance: String) {
+        interface?.apply(presentationUpdates: [.updateErrorLabel(balance)])
+        displayError()
+        triggerErrorFeedback()
+    }
+    
     func entryBelowMinimumValue(minimum: String) {
         let display = LocalizationConstants.Exchange.yourMin + " " + minimum
         interface?.apply(presentationUpdates: [.updateErrorLabel(display)])

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -475,8 +475,14 @@ struct LocalizationConstants {
             "Your Max is",
             comment: "Error that displays what the maximum amount of fiat allowed for a trade"
         )
-        static let notEnough = NSLocalizedString("Not enough", comment: "Not enough")
-        static let yourBalance = NSLocalizedString("Your balance is", comment: "Your balance is")
+        static let notEnough = NSLocalizedString(
+            "Not enough",
+            comment: "Part of error message shown when the user doesn't have enough funds to make an exchange"
+        )
+        static let yourBalance = NSLocalizedString(
+            "Your balance is",
+            comment: "Part of error message shown when the user doesn't have enough funds to make an exchange"
+        )
         static let tradeExecutionError = NSLocalizedString(
             "Sorry, an order cannot be placed at this time.",
             comment: "Error message shown to a user if something went wrong during the exchange process and the user cannot continue"

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -475,6 +475,8 @@ struct LocalizationConstants {
             "Your Max is",
             comment: "Error that displays what the maximum amount of fiat allowed for a trade"
         )
+        static let notEnough = NSLocalizedString("Not enough", comment: "Not enough")
+        static let yourBalance = NSLocalizedString("Your balance is", comment: "Your balance is")
         static let tradeExecutionError = NSLocalizedString(
             "Sorry, an order cannot be placed at this time.",
             comment: "Error message shown to a user if something went wrong during the exchange process and the user cannot continue"

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -186,10 +186,6 @@ extension Conversion {
     var baseCryptoValue: String {
         return quote.currencyRatio.base.crypto.value
     }
-    
-    var counterCryptoSymbol: String {
-        return quote.currencyRatio.counter.crypto.symbol
-    }
 }
 
 /// `SocketError` is for any type of error that

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -186,6 +186,10 @@ extension Conversion {
     var baseCryptoValue: String {
         return quote.currencyRatio.base.crypto.value
     }
+    
+    var counterCryptoSymbol: String {
+        return quote.currencyRatio.counter.crypto.symbol
+    }
 }
 
 /// `SocketError` is for any type of error that


### PR DESCRIPTION
## Objective

We now check the user's balance of the `from` account prior to creating a payment.

## Description

When creating an exchange, if the user enters in a fiat or crypto amount that is greater than what they have in their account, an error will be displayed. We check the `volume` of the `Conversion` and compare it to `account.balance`. 

## How to Test

1. Build and run
2. Go to the exchange 
3. Enter in an amount that is greater than what's in your account
4. You should see an error showing your account's balance in crypto. 

## Screenshot/Design assessment

![simulator screen shot - iphone 8 plus - 2018-10-04 at 14 47 18](https://user-images.githubusercontent.com/41585563/46499051-af297200-c7e4-11e8-9872-0d4c80250411.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] You have added sufficient documentation (descriptive comments).
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
