### PR TITLE
fix(HB): Fix issue where receiving zero trades from SS showed an error.

### DIFF
--- a/Blockchain/Homebrew/Exchange/Services/PartnerExchangeService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/PartnerExchangeService.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 protocol PartnerExchangeServiceDelegate {
-    func partnerExchangeDidFailToGetTrades(_ service: PartnerExchangeService, errorDescription: String)
     func partnerExchange(_ service: PartnerExchangeService, didGet exchangeRate: ExchangeRate)
     func partnerExchange(_ service: PartnerExchangeService, didGetBTC availableBalance: NSDictionary)
     func partnerExchange(_ service: PartnerExchangeService, didGetETH availableBalance: NSDictionary)
@@ -47,13 +46,14 @@ extension PartnerExchangeService: WalletPartnerExchangeDelegate {
     func didFailToGetExchangeTrades(errorDescription: String) {
         // Add this alert whenever the delegate is wired up.
         // TODO: AlertViewPresenter.shared.standardError(message: errorDescription)
-        delegate?.partnerExchangeDidFailToGetTrades(self, errorDescription: errorDescription)
+        if let block = completionBlock {
+            block(.error(nil))
+        }
     }
     
     func didGetExchangeTrades(trades: NSArray) {
         if let block = completionBlock, trades.count == 0 {
-            block(.error(nil))
-            return
+            block(.success([]))
         }
         guard let input = trades as? [ExchangeTrade] else { return }
         let models: [ExchangeTradeModel] = input.map({

--- a/Blockchain/Homebrew/Exchange/Services/PartnerExchangeService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/PartnerExchangeService.swift
@@ -44,8 +44,6 @@ class PartnerExchangeService: PartnerExchangeAPI {
 
 extension PartnerExchangeService: WalletPartnerExchangeDelegate {
     func didFailToGetExchangeTrades(errorDescription: String) {
-        // Add this alert whenever the delegate is wired up.
-        // TODO: AlertViewPresenter.shared.standardError(message: errorDescription)
         if let block = completionBlock {
             block(.error(nil))
         }

--- a/Blockchain/Homebrew/Exchange/Services/PartnerExchangeService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/PartnerExchangeService.swift
@@ -52,6 +52,7 @@ extension PartnerExchangeService: WalletPartnerExchangeDelegate {
     func didGetExchangeTrades(trades: NSArray) {
         if let block = completionBlock, trades.count == 0 {
             block(.success([]))
+            return
         }
         guard let input = trades as? [ExchangeTrade] else { return }
         let models: [ExchangeTradeModel] = input.map({


### PR DESCRIPTION
## Objective

Fixes a bug where `.error(nil)` was returned in a completionBlock when really it should be `.success([])` as the call to fetch partner trades completed successfully but there were no trades. 

## How to Test

N/A (Unless you've never done an SS trade, which in that case go to the exchange history screen and refresh your trades. You shouldn't see an alert.)

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] You have added sufficient documentation (descriptive comments).
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
