### PR TITLE
fix(Session Token): subtract 30 seconds from expiration time when trying to reuse cached token

### DIFF
--- a/Blockchain/Homebrew/Authentication/NabuAuthenticationService.swift
+++ b/Blockchain/Homebrew/Authentication/NabuAuthenticationService.swift
@@ -14,7 +14,7 @@ final class NabuAuthenticationService {
 
     static let shared = NabuAuthenticationService()
 
-    private var cachedSessionToken = BehaviorRelay<NabuSessionTokenResponse?>(value: nil)
+    private let cachedSessionToken = BehaviorRelay<NabuSessionTokenResponse?>(value: nil)
     private let wallet: Wallet
 
     // MARK: - Initialization
@@ -47,7 +47,6 @@ final class NabuAuthenticationService {
     // MARK: - Private Methods
 
     private func getSessionTokenIfNeeded(from userResponse: NabuCreateUserResponse) -> Single<NabuSessionTokenResponse> {
-
         guard let sessionToken = cachedSessionToken.value else {
             return requestNewSessionToken(from: userResponse)
         }
@@ -57,8 +56,9 @@ final class NabuAuthenticationService {
             return requestNewSessionToken(from: userResponse)
         }
 
-        // Make sure cached session token is not expired
-        guard let expiresAt = sessionToken.expiresAt, Date() < expiresAt else {
+        // Make sure cached session token is not within 30 seconds of the expiration time.
+        // 30 seconds was added to account for server-phone time differences
+        guard let expiresAt = sessionToken.expiresAt, Date() < expiresAt.addingTimeInterval(-30) else {
             return requestNewSessionToken(from: userResponse)
         }
 


### PR DESCRIPTION
## Objective

Attempt to fix the issue wherein nabu returns the following error:

```
["description": Can not process auth request, token can not be found, "channel": auth, "type": error, "sequenceNumber": 0]
```

## Description

One of the scenarios wherein the server can return that error is if the client sends an expired token to the server. Since the server's clock and the phone's clock can be slightly off (i.e. the server might read time at "4:00.00 pm" but the client's clock might be at "3.59.30 pm"), the client might be sending expired tokens which result in failed WS auth calls. To prevent this, this PR subtracts 30 seconds off the expiration time comparison on the client so that the client will just request a new session token if it's within < 30 seconds of the expiration time in the phone's frame of reference.

## How to Test

This one is a bit tricky to test apart from just verifying that you can still get to the exchange create view and receive websocket calls (and not get the error message above).

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
