### PR TITLE
fix(WalletManager): pass partner exchange fetch error from JS to dele…

### DIFF
--- a/Blockchain/Homebrew/Exchange/Services/PartnerExchangeService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/PartnerExchangeService.swift
@@ -44,6 +44,7 @@ class PartnerExchangeService: PartnerExchangeAPI {
 
 extension PartnerExchangeService: WalletPartnerExchangeDelegate {
     func didFailToGetExchangeTrades(errorDescription: String) {
+        Logger.shared.error(errorDescription)
         if let block = completionBlock {
             block(.error(nil))
         }

--- a/Blockchain/Wallet/WalletManager.swift
+++ b/Blockchain/Wallet/WalletManager.swift
@@ -452,6 +452,12 @@ extension WalletManager: WalletDelegate {
         }
     }
 
+    func didFail(toGetExchangeTrades errorDescription: String!) {
+        DispatchQueue.main.async { [unowned self] in
+            self.partnerExchangeDelegate?.didFailToGetExchangeTrades(errorDescription: errorDescription)
+        }
+    }
+
     func didGet(_ rate: ExchangeRate!) {
         DispatchQueue.main.async { [unowned self] in
             self.partnerExchangeDelegate?.didGetExchangeRate(rate: rate)

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -2556,8 +2556,7 @@ MyWalletPhone.getExchangeTrades = function() {
 
     var error = function(e) {
         console.log('Error getting trades');
-        console.log(e);
-        on_get_exchange_trades_error(e)
+        objc_on_get_exchange_trades_error(JSON.stringify(e))
     }
 
     return MyWallet.wallet.shapeshift.fetchFullTrades().then(success).catch(error);


### PR DESCRIPTION
…gate

## Objective

Ensure that homebrew trades are fetched even if fetching partner trades fails.

## Description

Passed error from JS to `partnerExchangeDelegate`.

## How to Test

- Log into a wallet that has both homebrew trades and partner trades in a region that is not supported by Shapeshift.
- Go to Exchange, see error in trade list, but still see homebrew trades being populated.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
