### PR TITLE
feat(ExchangeDetailViewController): IOS-1393 add refund button to expired trades.

### DIFF
--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -115,7 +115,8 @@ struct Constants {
         static let cookiePolicy = blockchainHome + "/cookies"
         static let appStoreLinkPrefix = "itms-apps://itunes.apple.com/app/"
         static let blockchainSupport = "https://support.blockchain.com"
-        static let blockchainSupportRequest = "https://support.blockchain.com/hc/en-us/requests/new?"
+        static let blockchainSupportRequest = blockchainSupport + "/hc/en-us/requests/new?"
+        static let supportTicketBuySellExchange = blockchainSupportRequest + "ticket_form_id=360000014686"
         static let forgotPassword = "https://support.blockchain.com/hc/en-us/articles/211205343-I-forgot-my-password-What-can-you-do-to-help-"
     }
     struct Wallet {

--- a/Blockchain/Constants.swift
+++ b/Blockchain/Constants.swift
@@ -115,6 +115,7 @@ struct Constants {
         static let cookiePolicy = blockchainHome + "/cookies"
         static let appStoreLinkPrefix = "itms-apps://itunes.apple.com/app/"
         static let blockchainSupport = "https://support.blockchain.com"
+        static let blockchainSupportRequest = "https://support.blockchain.com/hc/en-us/requests/new?"
         static let forgotPassword = "https://support.blockchain.com/hc/en-us/articles/211205343-I-forgot-my-password-What-can-you-do-to-help-"
     }
     struct Wallet {

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -130,8 +130,7 @@ class ExchangeDetailViewController: UIViewController {
                 forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
                 withReuseIdentifier: ActionableFooterView.identifier
             )
-            
-        case .overview(let trade):
+        case .overview:
             let headerNib = UINib(nibName: ExchangeDetailHeaderView.identifier, bundle: nil)
             collectionView.register(
                 headerNib,
@@ -139,14 +138,12 @@ class ExchangeDetailViewController: UIViewController {
                 withReuseIdentifier: ExchangeDetailHeaderView.identifier
             )
 
-            if trade.status == .expired {
-                let footerNib = UINib(nibName: ActionableFooterView.identifier, bundle: nil)
-                collectionView.register(
-                    footerNib,
-                    forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
-                    withReuseIdentifier: ActionableFooterView.identifier
-                )
-            }
+            let footerNib = UINib(nibName: ActionableFooterView.identifier, bundle: nil)
+            collectionView.register(
+                footerNib,
+                forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
+                withReuseIdentifier: ActionableFooterView.identifier
+            )
         }
     }
 }
@@ -306,11 +303,11 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 width: collectionView.bounds.width,
                 height: ActionableFooterView.height()
             )
-        case .overview:
-            return CGSize(
+        case .overview(let trade):
+            return trade.status == .expired ? CGSize(
                 width: collectionView.bounds.width,
                 height: ActionableFooterView.height()
-            )
+            ) : .zero
         }
     }
 }

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -139,7 +139,7 @@ class ExchangeDetailViewController: UIViewController {
                 withReuseIdentifier: ExchangeDetailHeaderView.identifier
             )
 
-            if trade.status == .expired || trade.status == .failed {
+            if trade.status == .expired {
                 let footerNib = UINib(nibName: ActionableFooterView.identifier, bundle: nil)
                 collectionView.register(
                     footerNib,

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -256,7 +256,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 ) as? ActionableFooterView else { return UICollectionReusableView() }
                 footer.title = LocalizationConstants.Exchange.requestRefund
                 footer.actionBlock = {
-                    guard let url = URL(string: Constants.Url.blockchainSupportRequest) else {
+                    guard let url = URL(string: Constants.Url.supportTicketBuySellExchange) else {
                         return
                     }
                     let viewController = SFSafariViewController(url: url)

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SafariServices
 
 protocol ExchangeDetailDelegate: class {
     func onViewLoaded()
@@ -130,13 +131,22 @@ class ExchangeDetailViewController: UIViewController {
                 withReuseIdentifier: ActionableFooterView.identifier
             )
             
-        case .overview:
+        case .overview(let trade):
             let headerNib = UINib(nibName: ExchangeDetailHeaderView.identifier, bundle: nil)
             collectionView.register(
                 headerNib,
                 forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
                 withReuseIdentifier: ExchangeDetailHeaderView.identifier
             )
+
+            if trade.status == .expired || trade.status == .failed {
+                let footerNib = UINib(nibName: ActionableFooterView.identifier, bundle: nil)
+                collectionView.register(
+                    footerNib,
+                    forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
+                    withReuseIdentifier: ActionableFooterView.identifier
+                )
+            }
         }
     }
 }
@@ -173,6 +183,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
         return CGSize(width: width, height: height)
     }
 
+    // swiftlint:disable function_body_length
     func collectionView(
         _ collectionView: UICollectionView,
         viewForSupplementaryElementOfKind
@@ -228,16 +239,37 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 return UICollectionReusableView()
             }
         case .overview(let trade):
-            guard let header = collectionView.dequeueReusableSupplementaryView(
-                ofKind: UICollectionElementKindSectionHeader,
-                withReuseIdentifier: ExchangeDetailHeaderView.identifier,
-                for: indexPath
+            switch kind {
+            case UICollectionElementKindSectionHeader:
+                guard let header = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: UICollectionElementKindSectionHeader,
+                    withReuseIdentifier: ExchangeDetailHeaderView.identifier,
+                    for: indexPath
                 ) as? ExchangeDetailHeaderView else { return UICollectionReusableView() }
-            header.title = trade.amountReceivedCrypto
-            return header
+                header.title = trade.amountReceivedCrypto
+                return header
+            case UICollectionElementKindSectionFooter:
+                guard let footer = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: UICollectionElementKindSectionFooter,
+                    withReuseIdentifier: ActionableFooterView.identifier,
+                    for: indexPath
+                ) as? ActionableFooterView else { return UICollectionReusableView() }
+                footer.title = LocalizationConstants.Exchange.requestRefund
+                footer.actionBlock = {
+                    guard let url = URL(string: Constants.Url.blockchainSupportRequest) else {
+                        return
+                    }
+                    let viewController = SFSafariViewController(url: url)
+                    self.present(viewController, animated: true, completion: nil)
+                }
+                return footer
+            default:
+                return UICollectionReusableView()
+            }
         }
     }
-    
+    // swiftlint:enable function_body_length
+
     func collectionView(
         _ collectionView: UICollectionView,
         layout collectionViewLayout: UICollectionViewLayout,
@@ -275,7 +307,10 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                 height: ActionableFooterView.height()
             )
         case .overview:
-            return .zero
+            return CGSize(
+                width: collectionView.bounds.width,
+                height: ActionableFooterView.height()
+            )
         }
     }
 }

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeDetailViewController.swift
@@ -257,6 +257,7 @@ extension ExchangeDetailViewController: UICollectionViewDelegateFlowLayout {
                         return
                     }
                     let viewController = SFSafariViewController(url: url)
+                    viewController.modalPresentationStyle = .overFullScreen
                     self.present(viewController, animated: true, completion: nil)
                 }
                 return footer

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -168,7 +168,7 @@ class ExchangeDetailCoordinator: NSObject {
                 
                 let paragraphStyle = NSMutableParagraphStyle()
                 paragraphStyle.alignment = .center
-                
+
                 let attributedTextFont = UIFont(name: Constants.FontNames.montserratRegular, size: 16.0)
                     ?? UIFont.systemFont(ofSize: 16.0, weight: .regular)
                 let attributedText = NSAttributedString(
@@ -177,11 +177,11 @@ class ExchangeDetailCoordinator: NSObject {
                                  NSAttributedStringKey.font: attributedTextFont,
                                  NSAttributedStringKey.paragraphStyle: paragraphStyle]
                 )
-                
+
                 let text = ExchangeCellModel.Text(
                     attributedString: attributedText
                 )
-                
+
                 cellModels.append(contentsOf: [
                     .tradingPair(pair),
                     .plain(value),
@@ -192,7 +192,7 @@ class ExchangeDetailCoordinator: NSObject {
                     .text(text)
                     ]
                 )
-                
+
                 delegate?.coordinator(self, updated: cellModels)
             case .overview(let trade):
                 interface?.updateBackgroundColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))
@@ -265,6 +265,28 @@ class ExchangeDetailCoordinator: NSObject {
                     ]
                 )
                 
+                if trade.status == .expired || trade.status == .failed {
+                    let paragraphStyle = NSMutableParagraphStyle()
+                    paragraphStyle.alignment = .center
+
+                    let attributedTextFont = UIFont(name: Constants.FontNames.montserratRegular, size: 12.0)
+                        ?? UIFont.systemFont(ofSize: 12.0, weight: .regular)
+                    let attributedText = NSAttributedString(
+                        string: LocalizationConstants.Exchange.refundDescription,
+                        attributes: [NSAttributedStringKey.foregroundColor: #colorLiteral(red: 0.64, green: 0.64, blue: 0.64, alpha: 1),
+                                     NSAttributedStringKey.font: attributedTextFont,
+                                     NSAttributedStringKey.paragraphStyle: paragraphStyle]
+                    )
+
+                    let text = ExchangeCellModel.Text(
+                        attributedString: attributedText
+                    )
+                    cellModels.append(contentsOf: [
+                            .text(text)
+                        ]
+                    )
+                }
+
                 delegate?.coordinator(self, updated: cellModels)
             }
         case .confirmExchange(let transaction):

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -265,14 +265,15 @@ class ExchangeDetailCoordinator: NSObject {
                     ]
                 )
                 
-                if trade.status == .expired {
+                if let description = trade.statusDescription {
+
                     let paragraphStyle = NSMutableParagraphStyle()
                     paragraphStyle.alignment = .center
 
                     let attributedTextFont = UIFont(name: Constants.FontNames.montserratRegular, size: 12.0)
                         ?? UIFont.systemFont(ofSize: 12.0, weight: .regular)
                     let attributedText = NSAttributedString(
-                        string: LocalizationConstants.Exchange.refundDescription,
+                        string: description,
                         attributes: [NSAttributedStringKey.foregroundColor: #colorLiteral(red: 0.64, green: 0.64, blue: 0.64, alpha: 1),
                                      NSAttributedStringKey.font: attributedTextFont,
                                      NSAttributedStringKey.paragraphStyle: paragraphStyle]

--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -265,7 +265,7 @@ class ExchangeDetailCoordinator: NSObject {
                     ]
                 )
                 
-                if trade.status == .expired || trade.status == .failed {
+                if trade.status == .expired {
                     let paragraphStyle = NSMutableParagraphStyle()
                     paragraphStyle.alignment = .center
 

--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -73,6 +73,18 @@ enum ExchangeTradeModel {
 }
 
 extension ExchangeTradeModel {
+    var statusDescription: String? {
+        switch self {
+        case .partner:
+            return nil
+        case .homebrew:
+            switch self.status {
+            case .expired: return LocalizationConstants.Exchange.expiredDescription
+            case .failed: return LocalizationConstants.Exchange.failedDescription
+            default: return nil
+            }
+        }
+    }
     var withdrawalAddress: String {
         switch self {
         case .partner(let model):

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -428,9 +428,13 @@ struct LocalizationConstants {
             "Request refund",
             comment: "Button text shown to allow a user to request a refund for a failed or expired exchange order."
         )
-        static let refundDescription = NSLocalizedString(
+        static let expiredDescription = NSLocalizedString(
             "Your trade has expired. Any funds broadcast from your wallet will be returned minus the network fee. Contact User Support with your Order ID to request a refund.",
-            comment: "Helper text shown when a user is viewing an order that has expired or failed."
+            comment: "Helper text shown when a user is viewing an order that has expired."
+        )
+        static let failedDescription = NSLocalizedString(
+            "Your trade has failed. If any funds have been broadcast from your wallet, they will be returned automatically minus the network fee. Please return to the New Exchange screen to start a new trade.",
+            comment: "Helper text shown when a user is viewing an order that has expired."
         )
         static let whatDoYouWantToExchange = NSLocalizedString(
             "What do you want to exchange?",

--- a/Blockchain/LocalizationConstants.swift
+++ b/Blockchain/LocalizationConstants.swift
@@ -424,6 +424,14 @@ struct LocalizationConstants {
         static let sendTo = NSLocalizedString(
             "Send to",
             comment: "Text displayed when reviewing where the result of an exchange order will be sent to")
+        static let requestRefund = NSLocalizedString(
+            "Request refund",
+            comment: "Button text shown to allow a user to request a refund for a failed or expired exchange order."
+        )
+        static let refundDescription = NSLocalizedString(
+            "Your trade has expired. Any funds broadcast from your wallet will be returned minus the network fee. Contact User Support with your Order ID to request a refund.",
+            comment: "Helper text shown when a user is viewing an order that has expired or failed."
+        )
         static let whatDoYouWantToExchange = NSLocalizedString(
             "What do you want to exchange?",
             comment: "Text displayed on the action sheet that is presented when the user is selecting an account to exchange from."


### PR DESCRIPTION
## Objective

Add refund button to expired trades and link to support ticket request page.

## Description

- Added description sections for expired and failed trades.
- Added button for expired trades to open an `SFSafariViewController` to the support page.

## How to Test

- Go to Exchange
- See that all trade detail views are viewable from the `ExchangeListViewController`
- See that descriptions are shown for expired and failed trades.
- See that a request refund option is available for expired trades and that it opens the support page.

## Screenshot/Design assessment

![simulator screen shot - iphone 5s - 2018-10-04 at 20 46 09](https://user-images.githubusercontent.com/10579422/46510372-92a62d80-c816-11e8-877c-936321c8f9b4.png)
![simulator screen shot - iphone 5s - 2018-10-04 at 20 46 03](https://user-images.githubusercontent.com/10579422/46510373-92a62d80-c816-11e8-9555-917ea8a3bf09.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
