### PR TITLE
fix(Homebrew-Exchange): show error messages immediately and disable e…

### DIFF
--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -36,6 +36,8 @@ protocol ExchangeCreateInterface: class {
     func apply(presentationUpdates: [PresentationUpdate])
     func apply(animatedUpdate: AnimatedUpdate)
     func apply(transitionPresentation: AnimatedTransitionUpdate)
+
+    func exchangeEnabled(_ enabled: Bool)
 }
 
 // Conforms to NumberKeypadViewDelegate to avoid redundancy of keypad input methods
@@ -57,8 +59,9 @@ protocol ExchangeCreateOutput: class {
     func updateTradingPairValues(left: String, right: String)
     func updateTradingPair(pair: TradingPair, fix: Fix)
     func insufficientFunds(balance: String)
-    func entryBelowMinimumValue(minimum: String)
-    func entryAboveMaximumValue(maximum: String)
+    func entryBelowMinimumValue(minimum: String?)
+    func entryAboveMaximumValue(maximum: String?)
     func loadingVisibility(_ visibility: Visibility)
+    func exchangeEnabled(_ enabled: Bool)
     func showSummary(orderTransaction: OrderTransaction, conversion: Conversion)
 }

--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -59,6 +59,7 @@ protocol ExchangeCreateOutput: class {
     func updateTradingPairValues(left: String, right: String)
     func updateTradingPair(pair: TradingPair, fix: Fix)
     func insufficientFunds(balance: String)
+    func genericSocketError()
     func entryBelowMinimumValue(minimum: String?)
     func entryAboveMaximumValue(maximum: String?)
     func loadingVisibility(_ visibility: Visibility)

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -397,6 +397,11 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
         tradingPairView.apply(transitionUpdate: transitionUpdate)
     }
     
+    func exchangeEnabled(_ enabled: Bool) {
+        exchangeButton.alpha = enabled ? 1 : 0.5
+        exchangeButton.isEnabled = enabled
+    }
+    
     func showSummary(orderTransaction: OrderTransaction, conversion: Conversion) {
         ExchangeCoordinator.shared.handle(event: .confirmExchange(orderTransaction: orderTransaction, conversion: conversion))
     }

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -370,7 +370,7 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
             // is than parsing the string
             if socketError.description.contains("small") {
                 this.output?.entryBelowMinimumValue(minimum: nil)
-            } else if socketError.description.contains("large") {
+            } else if socketError.description.contains("big") {
                 this.output?.entryAboveMaximumValue(maximum: nil)
             } else {
                 this.output?.genericSocketError()

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -366,12 +366,14 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
 
         let errorDisposable = markets.errors.subscribe(onNext: { [weak self] socketError in
             guard let this = self else { return }
+            // There needs to be a better way to find out what the error
+            // is than parsing the string
             if socketError.description.contains("small") {
                 this.output?.entryBelowMinimumValue(minimum: nil)
             } else if socketError.description.contains("large") {
                 this.output?.entryAboveMaximumValue(maximum: nil)
             } else {
-                this.validateInput()
+                this.output?.genericSocketError()
             }
         })
 

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -368,9 +368,10 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
             guard let this = self else { return }
             // There needs to be a better way to find out what the error
             // is than parsing the string
-            if socketError.description.contains("small") {
+            if socketError.code == .tooSmallVolume ||
+                socketError.code == .resultCurrencyRatioTooSmall {
                 this.output?.entryBelowMinimumValue(minimum: nil)
-            } else if socketError.description.contains("big") {
+            } else if socketError.code == .tooBigVolume {
                 this.output?.entryAboveMaximumValue(maximum: nil)
             } else {
                 this.output?.genericSocketError()

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -93,19 +93,15 @@ class ExchangeCreatePresenter {
             events.forEach({ this.handle(internalEvent: $0) })
         }
         
-        let block = { [weak self] in
-            guard let this = self else { return }
-            this.setErrorDisappearanceTimer(duration: 2.5)
-        }
-        
         let group = ViewUpdateGroup(
             preparations: [.secondaryLabel(.hidden)],
             animations: [.errorLabel(.visible)],
             animation: .standard(duration: 0.2),
-            completionEvents: [.block(block)],
+            completionEvents: [],
             completion: completion
         )
         interface?.apply(presentationUpdateGroup: group)
+        interface?.exchangeEnabled(false)
     }
     
     fileprivate func triggerErrorFeedback() {
@@ -249,21 +245,18 @@ extension ExchangeCreatePresenter: ExchangeCreateOutput {
     func insufficientFunds(balance: String) {
         interface?.apply(presentationUpdates: [.updateErrorLabel(balance)])
         displayError()
-        triggerErrorFeedback()
     }
     
-    func entryBelowMinimumValue(minimum: String) {
-        let display = LocalizationConstants.Exchange.yourMin + " " + minimum
+    func entryBelowMinimumValue(minimum: String?) {
+        let display = minimum == nil ? LocalizationConstants.Exchange.belowTradingLimit : LocalizationConstants.Exchange.yourMin + " " + minimum!
         interface?.apply(presentationUpdates: [.updateErrorLabel(display)])
         displayError()
-        triggerErrorFeedback()
     }
     
-    func entryAboveMaximumValue(maximum: String) {
-        let display = LocalizationConstants.Exchange.yourMax + " " + maximum
+    func entryAboveMaximumValue(maximum: String?) {
+        let display = maximum == nil ? LocalizationConstants.Exchange.aboveTradingLimit : LocalizationConstants.Exchange.yourMax + " " + maximum!
         interface?.apply(presentationUpdates: [.updateErrorLabel(display)])
         displayError()
-        triggerErrorFeedback()
     }
     
     func updateTradingPair(pair: TradingPair, fix: Fix) {
@@ -302,6 +295,11 @@ extension ExchangeCreatePresenter: ExchangeCreateOutput {
 
     func loadingVisibility(_ visibility: Visibility) {
         interface?.apply(presentationUpdates: [.loadingIndicator(visibility)])
+    }
+
+    func exchangeEnabled(_ enabled: Bool) {
+        errorDisappearanceTimerFired()
+        interface?.exchangeEnabled(enabled)
     }
 
     func showSummary(orderTransaction: OrderTransaction, conversion: Conversion) {

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -258,6 +258,12 @@ extension ExchangeCreatePresenter: ExchangeCreateOutput {
         interface?.apply(presentationUpdates: [.updateErrorLabel(display)])
         displayError()
     }
+
+    func genericSocketError() {
+        let display = LocalizationConstants.Errors.genericError
+        interface?.apply(presentationUpdates: [.updateErrorLabel(display)])
+        displayError()
+    }
     
     func updateTradingPair(pair: TradingPair, fix: Fix) {
         interface?.updateTradingPairView(pair: pair, fix: fix)

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -207,26 +207,29 @@ struct SocketError: SocketMessageCodable, Error {
             }
         }
     }
-    
-    
+
     let errorType: SocketErrorType
     let channel: String
     let description: String
+    let code: NabuNetworkErrorCode
     
     private enum CodingKeys: CodingKey {
         case type
         case channel
         case error
+        case code
     }
     
     private enum ErrorKeys: CodingKey {
         case description
+        case code
     }
     
     init(channel: String, description: String) {
         self.errorType = .default
         self.channel = channel
         self.description = description
+        self.code = .notFound
     }
     
     init(from decoder: Decoder) throws {
@@ -236,6 +239,7 @@ struct SocketError: SocketMessageCodable, Error {
         channel = try container.decode(String.self, forKey: .channel)
         let errorContainer = try container.nestedContainer(keyedBy: ErrorKeys.self, forKey: .error)
         description = try errorContainer.decode(String.self, forKey: .description)
+        code = try errorContainer.decode(NabuNetworkErrorCode.self, forKey: .code)
     }
     
     func encode(to encoder: Encoder) throws {
@@ -244,6 +248,7 @@ struct SocketError: SocketMessageCodable, Error {
         try container.encode(channel, forKey: .channel)
         var errorContainer = container.nestedContainer(keyedBy: ErrorKeys.self, forKey: .error)
         try errorContainer.encode(description, forKey: .description)
+        try errorContainer.encode(code, forKey: .code)
     }
 }
 


### PR DESCRIPTION
…xchange button until input is valid

## Objective

Prevent user from continuing to the confirm screen until the input being displayed is valid.

## Description

Currently, user is allowed to continue to the confirm screen when typing in a valid input and then deleting that input. This is because conversion volume errors (in this case, the volume is too small) are not being taken into account. Since errors are not displayed immediately, these errors would have to be stored, which would complicate state management.

Web and Android are also displaying errors immediately.

## How to Test

Go to Exchange. By the time you are able to tap on "Exchange X for Y", the input should be valid

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
