### PR TITLE
fix(HB): IOS-1402 - Fixing trades not paginating correctly

### DIFF
--- a/Blockchain/Homebrew/Exchange/DataProviders/ExchangeListDataProvider.swift
+++ b/Blockchain/Homebrew/Exchange/DataProviders/ExchangeListDataProvider.swift
@@ -179,6 +179,15 @@ extension ExchangeListDataProvider: UITableViewDataSource {
                     withIdentifier: loadingIdentifier,
                     for: indexPath
                     ) as? LoadingTableViewCell else { return UITableViewCell() }
+                
+                /// This particular cell shouldn't have a separator.
+                /// This is how we hide it.
+                cell.separatorInset = UIEdgeInsets(
+                    top: 0.0,
+                    left: 0.0,
+                    bottom: 0.0,
+                    right: .greatestFiniteMagnitude
+                )
                 return cell
             }
             

--- a/Blockchain/Homebrew/Exchange/Services/HomebrewExchangeService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/HomebrewExchangeService.swift
@@ -47,7 +47,7 @@ class HomebrewExchangeService: HomebrewExchangeAPI {
         guard let baseURL = URL(string: BlockchainAPI.shared.retailCoreUrl) else {
             return .error(HomebrewExchangeServiceError.generic)
         }
-        let dateParameter = DateFormatter.HTTPRequestDateFormat.string(from: timestamp)
+        let dateParameter = DateFormatter.iso8601Format.string(from: timestamp)
         guard let endpoint = URL.endpoint(baseURL, pathComponents: ["trades"], queryParameters: ["before": dateParameter]) else {
             return .error(HomebrewExchangeServiceError.generic)
         }


### PR DESCRIPTION
## Objective

Fixes an issue where we weren't fetching the next page correctly in trade history.

## Description

The incorrect date formatter was used in fetching the next page of exchanges. 

## How to Test

1. Build and run
2. Sign into account referenced in ticket
3. Go to the trade history screen
4. Scroll. It should paginate. It should show older trades. It should eventually get to the last page and stop. 

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] You have added sufficient documentation (descriptive comments).
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
