### PR TITLE
fix(WS Authentication): fix WS auth failures (IOS-1405)

### DIFF
--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -84,10 +84,10 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         updatedInput()
         
         markets.setup()
-        tradeLimitService.initialize(withFiatCurrency: model.fiatCurrencyCode)
 
         // Authenticate, then listen for conversions
         markets.authenticate(completion: { [unowned self] in
+            self.tradeLimitService.initialize(withFiatCurrency: model.fiatCurrencyCode)
             self.subscribeToConversions()
             self.updateMarketsConversion()
             self.subscribeToBestRates()


### PR DESCRIPTION
## Objective

Another attempt at fixing WS auth failure. 

## Description

My hypothesis is that another reason WS auth can fail is because of a race condition wherein the token we are sending for WS auth is invalidated since another request (i.e. the request to get trade limits), may be interfering and requesting a _new_ session token.

This PR mitigates that issue by first waiting for the WS auth to complete before requesting a token from `NabuAuthenticationService`.

## How to Test

Jump in and out of exchange create view and notice you don't get the WS auth error.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
