### PR TITLE
fix(Homebrew-KYC): IOS-1370 make line 2 of address optional

### DIFF
--- a/Blockchain/KYC/Search/Models/PostalAddress.swift
+++ b/Blockchain/KYC/Search/Models/PostalAddress.swift
@@ -20,7 +20,7 @@ struct PostalAddress {
 // TICKET: IOS-1145 - Combine PostalAddress and UserAddress models.
 struct UserAddress: Codable {
     let lineOne: String
-    let lineTwo: String
+    let lineTwo: String?
     let postalCode: String
     let city: String
     let state: String?
@@ -50,7 +50,6 @@ extension UserAddress: Equatable {
 extension UserAddress: Hashable {
     var hashValue: Int {
         return lineOne.hashValue ^
-            lineTwo.hashValue ^
             postalCode.hashValue ^
             city.hashValue ^
             countryCode.hashValue


### PR DESCRIPTION
## Objective

Allow KYC verified users to use Exchange.

## Description

Fixed issue where KYC users without a `lineTwo` of the `PostalAddress` filled would see an alert with the error "The data couldn’t be read because it is missing”

## How to Test

Go through KYC but do not fill in line 2 of the address ("APT, Floor, #"). After getting verified, you should be able to tap on the Exchange side menu item without seeing an error.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
