### PR TITLE
fix(Homebrew-KYC): treat userIds and tokens with length 0 as invalid

### DIFF
--- a/Blockchain/Models/Wallet.m
+++ b/Blockchain/Models/Wallet.m
@@ -2619,7 +2619,8 @@
     if ([self isInitialized]) {
         JSValue *userId = [self.context evaluateScript:@"MyWalletPhone.KYC.userId()"];
         if ([userId isNull] || [userId isUndefined]) return nil;
-        return [userId toString];
+        NSString *userIdString = [userId toString];
+        return userIdString.length > 0 ? userIdString : nil;
     }
     return nil;
 }
@@ -2629,7 +2630,8 @@
     if ([self isInitialized]) {
         JSValue *lifetimeToken = [self.context evaluateScript:@"MyWalletPhone.KYC.lifetimeToken()"];
         if ([lifetimeToken isNull] || [lifetimeToken isUndefined]) return nil;
-        return [lifetimeToken toString];
+        NSString *tokenString = [lifetimeToken toString];
+        return tokenString.length > 0 ? tokenString : nil;
     }
     return nil;
 }


### PR DESCRIPTION
## Objective

Fix issue where an empty `userId` is sent to the server. The error "userId format is incorrect" is returned.

## Description

The `userId` and `lifetimeToken` were both strings of length 0 when checking the QA wallet that was having this issue. With the changes made in 45970d4, tapping on the Exchange showed the "User already exists" error which displays as "This email address has already been used to verify an existing wallet." in an alert view.

Unsure of whether this issue is fully resolved at this point and looking for feedback here.

## How to Test

Tap on Exchange, should not see an error.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
