### PR TITLE
fix(Homebrew-Exchange): add and use transparent visibility case for e…

### DIFF
--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -40,6 +40,7 @@ protocol ExchangeCreateInterface: class {
     func exchangeButtonEnabled(_ enabled: Bool)
 
     func isShowingConversionRatesView() -> Bool
+    func isExchangeButtonEnabled() -> Bool
 }
 
 // Conforms to NumberKeypadViewDelegate to avoid redundancy of keypad input methods

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -303,6 +303,8 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
                 )
             case .hidden:
                 LoadingViewPresenter.shared.hideBusyView()
+            default:
+                Logger.shared.warning("Visibility not handled")
             }
         case .conversionRatesView(let visibility, animated: let animated):
             conversionRatesView.updateVisibility(visibility, animated: animated)
@@ -403,6 +405,10 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
 
     func isShowingConversionRatesView() -> Bool {
         return conversionRatesView.alpha == 1
+    }
+
+    func isExchangeButtonEnabled() -> Bool {
+        return exchangeButton.isEnabled
     }
     
     func showSummary(orderTransaction: OrderTransaction, conversion: Conversion) {

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -79,7 +79,7 @@ class ExchangeCreatePresenter {
 
     fileprivate func disableExchangeButton() {
         interface?.exchangeButtonEnabled(false)
-        exchangeButtonVisibility(.transparent)
+        exchangeButtonVisibility(.translucent)
     }
 }
 
@@ -135,7 +135,7 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
                 animations: [
                     .conversionView(.visible),
                     .ratesChevron(.hidden),
-                    .exchangeButton(interface?.isExchangeButtonEnabled() == true ? .visible : .transparent)
+                    .exchangeButton(interface?.isExchangeButtonEnabled() == true ? .visible : .translucent)
                 ],
                 animation: .easeIn(duration: 0.2)
             )

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -75,8 +75,11 @@ class ExchangeCreatePresenter {
                 animation: .standard(duration: 0.2)
             )
         )
+    }
 
+    fileprivate func disableExchangeButton() {
         interface?.exchangeButtonEnabled(false)
+        exchangeButtonVisibility(.transparent)
     }
 }
 
@@ -132,7 +135,7 @@ extension ExchangeCreatePresenter: ExchangeCreateDelegate {
                 animations: [
                     .conversionView(.visible),
                     .ratesChevron(.hidden),
-                    .exchangeButton(.visible)
+                    .exchangeButton(interface?.isExchangeButtonEnabled() == true ? .visible : .transparent)
                 ],
                 animation: .easeIn(duration: 0.2)
             )
@@ -193,23 +196,27 @@ extension ExchangeCreatePresenter: ExchangeCreateOutput {
     func insufficientFunds(balance: String) {
         interface?.apply(presentationUpdates: [.updateErrorLabel(balance)])
         displayError()
+        disableExchangeButton()
     }
     
     func entryBelowMinimumValue(minimum: String) {
         let display = LocalizationConstants.Exchange.yourMin + " " + minimum
         interface?.apply(presentationUpdates: [.updateErrorLabel(display)])
         displayError()
+        disableExchangeButton()
     }
     
     func entryAboveMaximumValue(maximum: String) {
         let display = LocalizationConstants.Exchange.yourMax + " " + maximum
         interface?.apply(presentationUpdates: [.updateErrorLabel(display)])
         displayError()
+        disableExchangeButton()
     }
 
     func showError(message: String) {
         interface?.apply(presentationUpdates: [.updateErrorLabel(message)])
         displayError()
+        disableExchangeButton()
     }
     
     func updateTradingPair(pair: TradingPair, fix: Fix) {

--- a/Blockchain/Models/ViewModels/Visibility.swift
+++ b/Blockchain/Models/ViewModels/Visibility.swift
@@ -10,13 +10,18 @@
 /// specific views. It's easier to read
 enum Visibility: Int {
     case hidden
+    case transparent
     case visible
 
     var defaultAlpha: CGFloat {
-        return self == .visible ? 1 : 0
+        switch self {
+        case .hidden: return 0
+        case .transparent: return 0.5
+        case .visible: return 1
+        }
     }
 
     var isHidden: Bool {
-        return self == .visible ? false: true
+        return self == .hidden ? true : false
     }
 }

--- a/Blockchain/Models/ViewModels/Visibility.swift
+++ b/Blockchain/Models/ViewModels/Visibility.swift
@@ -10,13 +10,13 @@
 /// specific views. It's easier to read
 enum Visibility: Int {
     case hidden
-    case transparent
+    case translucent
     case visible
 
     var defaultAlpha: CGFloat {
         switch self {
         case .hidden: return 0
-        case .transparent: return 0.5
+        case .translucent: return 0.5
         case .visible: return 1
         }
     }


### PR DESCRIPTION
…xchange button

## Objective

Indicate to the user whether the Exchange button is disabled.

## Description

- Added new `Visibility` case `transparent` (alpha = 0.5).
- Added getter `isExchangeButtonEnabled` to maintain the correct `Visibility` when dismissing the `conversionRatesView`

I had considered and tried another approach to this which involved subclassing UIButton to add mutable closures like `onDidSetIsEnabled ((UIButton, isEnabled) -> ())` but it felt messy managing states in two different places (the closure and the interactor/presenter/interface). The trade-off here is repeating `disableExchangeButton()` in a few places to avoid side effects.

## How to Test

Go to Exchange. When errors appear, the "Exchange X for Y" button should be disabled. It should also be hidden appropriately when expanding the rates view and remain disabled after dismissing it if the input is still invalid (and enabled if the input is valid).

## Screenshot/Design assessment

`.transparent` (alpha = 0.5)
<img width="310" alt="screen shot 2018-10-09 at 7 21 19 pm" src="https://user-images.githubusercontent.com/10579422/46704337-847e5580-cbf8-11e8-9bbf-7cfc5653be43.png">

`.visible` (alpha = 1)
<img width="306" alt="screen shot 2018-10-09 at 7 21 39 pm" src="https://user-images.githubusercontent.com/10579422/46704361-a081f700-cbf8-11e8-9cab-74a0a8bbdce1.png">

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
