### PR TITLE
fix(HB): IOS-1401 - Removing Min/Max buttons. Layout cleanup.

### DIFF
--- a/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeCreateContracts.swift
@@ -56,7 +56,7 @@ protocol ExchangeCreateInput: NumberKeypadViewDelegate {
 protocol ExchangeCreateOutput: class {
     func entryRejected()
     func styleTemplate() -> ExchangeStyleTemplate
-    func updatedInput(primary: NSAttributedString?, secondary: String?)
+    func updatedInput(primary: NSAttributedString?, secondary: String?, primaryOffset: CGFloat)
     func updatedRates(first: String, second: String, third: String)
     func updateTradingPairValues(left: String, right: String)
     func updateTradingPair(pair: TradingPair, fix: Fix)

--- a/Blockchain/Homebrew/Exchange/API/ExchangeInputsAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeInputsAPI.swift
@@ -20,6 +20,8 @@ protocol ExchangeInputsAPI: class {
     func primaryAssetAttributedString(symbol: String) -> NSAttributedString
     func estimatedSymbolWidth(currencySymbol: String, template: ExchangeStyleTemplate) -> CGFloat
     
+    func maxFiatInteger() -> Int
+    func maxAssetInteger() -> Int
     func maxFiatFractional() -> Int
     func maxAssetFractional() -> Int
     

--- a/Blockchain/Homebrew/Exchange/API/ExchangeInputsAPI.swift
+++ b/Blockchain/Homebrew/Exchange/API/ExchangeInputsAPI.swift
@@ -18,6 +18,7 @@ protocol ExchangeInputsAPI: class {
     
     func primaryFiatAttributedString(currencySymbol: String) -> NSAttributedString
     func primaryAssetAttributedString(symbol: String) -> NSAttributedString
+    func estimatedSymbolWidth(currencySymbol: String, template: ExchangeStyleTemplate) -> CGFloat
     
     func maxFiatFractional() -> Int
     func maxAssetFractional() -> Int

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -49,10 +49,10 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eA3-pM-NKs">
-                                <rect key="frame" x="16" y="310" width="303" height="32"/>
+                                <rect key="frame" x="16" y="309.5" width="303" height="32"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9l-S4-AAj">
-                                        <rect key="frame" x="151.5" y="16.5" width="0.0" height="0.0"/>
+                                        <rect key="frame" x="151.5" y="16" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -111,58 +111,60 @@
                                 <rect key="frame" x="0.0" y="96" width="375" height="213.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gwW-KU-9VB">
-                                        <rect key="frame" x="119" y="64" width="137" height="86"/>
+                                        <rect key="frame" x="0.0" y="41" width="375" height="132"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$200.42" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okC-2w-xB9">
-                                                <rect key="frame" x="36" y="45" width="65.5" height="20.5"/>
+                                                <rect key="frame" x="155" y="90" width="65.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your min is $4.56" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fAr-Eh-XkB">
-                                                <rect key="frame" x="0.0" y="69.5" width="136.5" height="16.5"/>
+                                                <rect key="frame" x="0.0" y="114.5" width="375" height="17.5"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
                                                 <color key="textColor" red="0.95999999999999996" green="0.26000000000000001" blue="0.26000000000000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0.01 BTC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
-                                                <rect key="frame" x="0.0" y="0.0" width="136.5" height="41"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="34"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf" userLabel="Fiat Button">
+                                                <rect key="frame" x="330" y="78" width="45" height="45"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="45" id="DPy-T1-MAF"/>
+                                                    <constraint firstAttribute="width" constant="45" id="jae-sI-L1J"/>
+                                                </constraints>
+                                                <state key="normal" image="Icon-Switch"/>
+                                                <connections>
+                                                    <action selector="displayInputTypeTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="f6g-9r-iu8"/>
+                                                </connections>
+                                            </button>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12345.12345678 BTC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.29999999999999999" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
+                                                <rect key="frame" x="16" y="0.0" width="343" height="86"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="72"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
+                                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerY" secondItem="okC-2w-xB9" secondAttribute="centerY" id="8qn-ac-Woq"/>
+                                            <constraint firstAttribute="trailing" secondItem="DPE-Uz-yYf" secondAttribute="trailing" id="A3D-F1-Oro"/>
                                             <constraint firstItem="fAr-Eh-XkB" firstAttribute="top" secondItem="okC-2w-xB9" secondAttribute="bottom" constant="4" id="Dse-WZ-OY8"/>
-                                            <constraint firstAttribute="trailing" secondItem="fAr-Eh-XkB" secondAttribute="trailing" id="FZG-1L-jGq"/>
                                             <constraint firstAttribute="bottom" secondItem="fAr-Eh-XkB" secondAttribute="bottom" id="MrC-6v-eup"/>
                                             <constraint firstItem="cbA-yh-J0A" firstAttribute="top" secondItem="gwW-KU-9VB" secondAttribute="top" id="MzA-bE-IaC"/>
+                                            <constraint firstItem="cbA-yh-J0A" firstAttribute="leading" secondItem="gwW-KU-9VB" secondAttribute="leading" constant="16" id="PkR-1x-AFO"/>
                                             <constraint firstItem="okC-2w-xB9" firstAttribute="top" secondItem="cbA-yh-J0A" secondAttribute="bottom" constant="4" id="QpJ-IH-NaM"/>
-                                            <constraint firstAttribute="trailing" secondItem="cbA-yh-J0A" secondAttribute="trailing" id="hzz-Fp-TRR"/>
-                                            <constraint firstItem="cbA-yh-J0A" firstAttribute="leading" secondItem="gwW-KU-9VB" secondAttribute="leading" id="l91-fZ-glO"/>
+                                            <constraint firstItem="fAr-Eh-XkB" firstAttribute="centerX" secondItem="okC-2w-xB9" secondAttribute="centerX" id="cAM-3p-PGb"/>
+                                            <constraint firstAttribute="trailing" secondItem="cbA-yh-J0A" secondAttribute="trailing" constant="16" id="oB3-g6-V6O"/>
                                             <constraint firstItem="fAr-Eh-XkB" firstAttribute="leading" secondItem="gwW-KU-9VB" secondAttribute="leading" id="wX1-QX-Lf4"/>
                                         </constraints>
                                     </view>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf" userLabel="Fiat Button">
-                                        <rect key="frame" x="305" y="49.5" width="70" height="70"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="70" id="0tt-lY-z1M"/>
-                                            <constraint firstAttribute="width" constant="70" id="jae-sI-L1J"/>
-                                        </constraints>
-                                        <state key="normal" image="Icon-Switch"/>
-                                        <connections>
-                                            <action selector="displayInputTypeTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="f6g-9r-iu8"/>
-                                        </connections>
-                                    </button>
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="DPE-Uz-yYf" secondAttribute="trailing" id="0Hb-8I-FYZ"/>
-                                    <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerY" secondItem="cbA-yh-J0A" secondAttribute="centerY" id="OqH-bV-I4t"/>
                                     <constraint firstItem="okC-2w-xB9" firstAttribute="centerX" secondItem="lwt-zv-6qV" secondAttribute="centerX" id="UIl-Md-uYE"/>
-                                    <constraint firstItem="gwW-KU-9VB" firstAttribute="centerX" secondItem="lwt-zv-6qV" secondAttribute="centerX" id="qeu-Y7-opE"/>
+                                    <constraint firstItem="gwW-KU-9VB" firstAttribute="leading" secondItem="lwt-zv-6qV" secondAttribute="leading" id="qWS-HE-cPF"/>
+                                    <constraint firstItem="gwW-KU-9VB" firstAttribute="leading" secondItem="lwt-zv-6qV" secondAttribute="leading" id="r1Q-nL-7aJ"/>
+                                    <constraint firstAttribute="trailing" secondItem="gwW-KU-9VB" secondAttribute="trailing" id="rSf-Y5-fnQ"/>
                                     <constraint firstItem="gwW-KU-9VB" firstAttribute="centerY" secondItem="lwt-zv-6qV" secondAttribute="centerY" id="yQV-1A-N3f"/>
                                 </constraints>
                             </view>
@@ -172,6 +174,7 @@
                             <constraint firstItem="j0b-5p-LkW" firstAttribute="top" secondItem="lwt-zv-6qV" secondAttribute="bottom" id="3sV-yd-AEv"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="DUe-4D-nhJ" secondAttribute="trailing" constant="16" id="5hU-Xa-xif"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="6Rb-58-f8o"/>
+                            <constraint firstItem="lwt-zv-6qV" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" id="9Jd-5s-Udh"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="AHN-eg-W66"/>
                             <constraint firstItem="eA3-pM-NKs" firstAttribute="centerY" secondItem="j0b-5p-LkW" secondAttribute="centerY" id="C5T-DZ-FPd"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="top" secondItem="dfm-a1-ad2" secondAttribute="bottom" constant="16" id="EPf-w5-lBJ"/>
@@ -180,16 +183,15 @@
                             <constraint firstItem="V30-pI-8jo" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="HgH-sR-rJB"/>
                             <constraint firstItem="lwt-zv-6qV" firstAttribute="trailing" secondItem="FIv-WY-bvA" secondAttribute="trailing" id="LAm-P9-dMs"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="width" secondItem="dfm-a1-ad2" secondAttribute="width" id="NgP-UU-rcW"/>
-                            <constraint firstItem="cbA-yh-J0A" firstAttribute="centerX" secondItem="V30-pI-8jo" secondAttribute="centerX" id="Old-86-Ci3"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="height" secondItem="dfm-a1-ad2" secondAttribute="height" multiplier="0.85" id="PLc-ir-uPC"/>
                             <constraint firstItem="coY-Dg-Mc5" firstAttribute="centerY" secondItem="DUe-4D-nhJ" secondAttribute="centerY" id="Pxh-nT-mtp"/>
+                            <constraint firstItem="cbA-yh-J0A" firstAttribute="centerX" secondItem="V30-pI-8jo" secondAttribute="centerX" id="UFh-rC-wXL"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="centerX" secondItem="dfm-a1-ad2" secondAttribute="centerX" id="bJ3-Vq-GwG"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="centerY" secondItem="dfm-a1-ad2" secondAttribute="centerY" id="dnB-8I-crf"/>
                             <constraint firstItem="eA3-pM-NKs" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="enm-Og-Fbn"/>
                             <constraint firstItem="V30-pI-8jo" firstAttribute="top" secondItem="FIv-WY-bvA" secondAttribute="top" constant="8" id="fNG-KC-mpx"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="j0b-5p-LkW" secondAttribute="trailing" constant="16" id="gZz-dZ-XiQ"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="height" secondItem="jre-mq-FDr" secondAttribute="height" multiplier="0.35" id="jtO-7D-eg1"/>
-                            <constraint firstItem="lwt-zv-6qV" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" id="lhM-0J-fNu"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="bottom" secondItem="DUe-4D-nhJ" secondAttribute="bottom" constant="16" id="oTE-Cd-lXS"/>
                             <constraint firstItem="lwt-zv-6qV" firstAttribute="top" secondItem="V30-pI-8jo" secondAttribute="bottom" constant="8" id="p6w-Sf-w1z"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="dfm-a1-ad2" secondAttribute="trailing" constant="16" id="pXZ-qz-MkO"/>
@@ -208,7 +210,7 @@
                         <outlet property="hideRatesButton" destination="coY-Dg-Mc5" id="bEB-4e-zyz"/>
                         <outlet property="numberKeypadView" destination="dfm-a1-ad2" id="yN5-Le-zxp"/>
                         <outlet property="primaryAmountLabel" destination="cbA-yh-J0A" id="xGh-pL-sDT"/>
-                        <outlet property="primaryLabelCenterXConstraint" destination="Old-86-Ci3" id="HyA-dZ-VT6"/>
+                        <outlet property="primaryLabelCenterXConstraint" destination="UFh-rC-wXL" id="ROV-fk-3TO"/>
                         <outlet property="secondaryAmountLabel" destination="okC-2w-xB9" id="K2v-uv-GkY"/>
                         <outlet property="tradingPairView" destination="V30-pI-8jo" id="DIp-jX-nte"/>
                     </connections>
@@ -220,7 +222,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="-74.400000000000006" y="16.641679160419791"/>
+            <point key="canvasLocation" x="-75" y="15.845070422535212"/>
         </scene>
     </scenes>
     <resources>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.storyboard
@@ -30,47 +30,8 @@
                                     <constraint firstAttribute="height" constant="60" id="eAr-RZ-O8R"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf" userLabel="Fiat Button">
-                                <rect key="frame" x="308" y="115" width="70" height="70"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="70" id="4dm-4V-5VL"/>
-                                    <constraint firstAttribute="height" constant="70" id="fWa-MZ-Ert"/>
-                                </constraints>
-                                <state key="normal" image="Icon-Switch"/>
-                                <connections>
-                                    <action selector="displayInputTypeTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="f6g-9r-iu8"/>
-                                </connections>
-                            </button>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="5uc-t6-nYA">
-                                <rect key="frame" x="16" y="269.5" width="295" height="32"/>
-                                <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gyg-rh-rE6">
-                                        <rect key="frame" x="0.0" y="0.0" width="139.5" height="32"/>
-                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
-                                        <state key="normal" title="0.05 BTC Min">
-                                            <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="useMinimumButtonTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="D8v-2W-2Gs"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kyX-88-NsD">
-                                        <rect key="frame" x="155.5" y="0.0" width="139.5" height="32"/>
-                                        <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
-                                        <state key="normal" title="1.48 BTC Max">
-                                            <color key="titleColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="useMaximumButtonTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="EB8-o2-qlv"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="32" id="iIj-Hh-NEZ"/>
-                                </constraints>
-                            </stackView>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j0b-5p-LkW">
-                                <rect key="frame" x="327" y="269.5" width="32" height="32"/>
+                                <rect key="frame" x="327" y="309.5" width="32" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="32" id="yuY-LZ-oDw"/>
                                 </constraints>
@@ -88,16 +49,16 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eA3-pM-NKs">
-                                <rect key="frame" x="16" y="309.5" width="343" height="32"/>
+                                <rect key="frame" x="16" y="310" width="303" height="32"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9l-S4-AAj">
-                                        <rect key="frame" x="172" y="16.5" width="0.0" height="0.0"/>
+                                        <rect key="frame" x="151.5" y="16.5" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.28999999999999998" blue="0.48999999999999999" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wCs-Hh-I8i">
-                                        <rect key="frame" x="323" y="9" width="8" height="14"/>
+                                        <rect key="frame" x="283" y="9" width="8" height="14"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="14" id="M20-tN-3VR"/>
                                             <constraint firstAttribute="width" constant="8" id="wN4-Hn-SZR"/>
@@ -146,66 +107,94 @@
                                     <action selector="exchangeButtonTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="yeg-hs-kSJ"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$200.42" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okC-2w-xB9">
-                                <rect key="frame" x="155" y="208" width="65.5" height="53.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0.01 BTC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
-                                <rect key="frame" x="16" y="96" width="342.5" height="108"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="34"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your min is $4.56" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fAr-Eh-XkB">
-                                <rect key="frame" x="16" y="223" width="343" height="23.5"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="19"/>
-                                <color key="textColor" red="0.95999999999999996" green="0.26000000000000001" blue="0.26000000000000001" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lwt-zv-6qV">
+                                <rect key="frame" x="0.0" y="96" width="375" height="213.5"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gwW-KU-9VB">
+                                        <rect key="frame" x="119" y="64" width="137" height="86"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$200.42" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="okC-2w-xB9">
+                                                <rect key="frame" x="36" y="45" width="65.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your min is $4.56" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fAr-Eh-XkB">
+                                                <rect key="frame" x="0.0" y="69.5" width="136.5" height="16.5"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
+                                                <color key="textColor" red="0.95999999999999996" green="0.26000000000000001" blue="0.26000000000000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0.01 BTC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbA-yh-J0A">
+                                                <rect key="frame" x="0.0" y="0.0" width="136.5" height="41"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="34"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="fAr-Eh-XkB" firstAttribute="top" secondItem="okC-2w-xB9" secondAttribute="bottom" constant="4" id="Dse-WZ-OY8"/>
+                                            <constraint firstAttribute="trailing" secondItem="fAr-Eh-XkB" secondAttribute="trailing" id="FZG-1L-jGq"/>
+                                            <constraint firstAttribute="bottom" secondItem="fAr-Eh-XkB" secondAttribute="bottom" id="MrC-6v-eup"/>
+                                            <constraint firstItem="cbA-yh-J0A" firstAttribute="top" secondItem="gwW-KU-9VB" secondAttribute="top" id="MzA-bE-IaC"/>
+                                            <constraint firstItem="okC-2w-xB9" firstAttribute="top" secondItem="cbA-yh-J0A" secondAttribute="bottom" constant="4" id="QpJ-IH-NaM"/>
+                                            <constraint firstAttribute="trailing" secondItem="cbA-yh-J0A" secondAttribute="trailing" id="hzz-Fp-TRR"/>
+                                            <constraint firstItem="cbA-yh-J0A" firstAttribute="leading" secondItem="gwW-KU-9VB" secondAttribute="leading" id="l91-fZ-glO"/>
+                                            <constraint firstItem="fAr-Eh-XkB" firstAttribute="leading" secondItem="gwW-KU-9VB" secondAttribute="leading" id="wX1-QX-Lf4"/>
+                                        </constraints>
+                                    </view>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DPE-Uz-yYf" userLabel="Fiat Button">
+                                        <rect key="frame" x="305" y="49.5" width="70" height="70"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="70" id="0tt-lY-z1M"/>
+                                            <constraint firstAttribute="width" constant="70" id="jae-sI-L1J"/>
+                                        </constraints>
+                                        <state key="normal" image="Icon-Switch"/>
+                                        <connections>
+                                            <action selector="displayInputTypeTapped:" destination="ZL9-nX-8IY" eventType="touchUpInside" id="f6g-9r-iu8"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="DPE-Uz-yYf" secondAttribute="trailing" id="0Hb-8I-FYZ"/>
+                                    <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerY" secondItem="cbA-yh-J0A" secondAttribute="centerY" id="OqH-bV-I4t"/>
+                                    <constraint firstItem="okC-2w-xB9" firstAttribute="centerX" secondItem="lwt-zv-6qV" secondAttribute="centerX" id="UIl-Md-uYE"/>
+                                    <constraint firstItem="gwW-KU-9VB" firstAttribute="centerX" secondItem="lwt-zv-6qV" secondAttribute="centerX" id="qeu-Y7-opE"/>
+                                    <constraint firstItem="gwW-KU-9VB" firstAttribute="centerY" secondItem="lwt-zv-6qV" secondAttribute="centerY" id="yQV-1A-N3f"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="5uc-t6-nYA" firstAttribute="top" secondItem="okC-2w-xB9" secondAttribute="bottom" constant="8" id="5a3-e0-C6T"/>
+                            <constraint firstItem="j0b-5p-LkW" firstAttribute="top" secondItem="lwt-zv-6qV" secondAttribute="bottom" id="3sV-yd-AEv"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="DUe-4D-nhJ" secondAttribute="trailing" constant="16" id="5hU-Xa-xif"/>
-                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerY" secondItem="cbA-yh-J0A" secondAttribute="centerY" id="6OF-I7-jLH"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="6Rb-58-f8o"/>
-                            <constraint firstItem="cbA-yh-J0A" firstAttribute="top" secondItem="V30-pI-8jo" secondAttribute="bottom" constant="8" id="7kf-Ns-aJR"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="AHN-eg-W66"/>
-                            <constraint firstItem="okC-2w-xB9" firstAttribute="height" secondItem="cbA-yh-J0A" secondAttribute="height" multiplier="0.5" id="AsX-Mv-rk9"/>
+                            <constraint firstItem="eA3-pM-NKs" firstAttribute="centerY" secondItem="j0b-5p-LkW" secondAttribute="centerY" id="C5T-DZ-FPd"/>
                             <constraint firstItem="DUe-4D-nhJ" firstAttribute="top" secondItem="dfm-a1-ad2" secondAttribute="bottom" constant="16" id="EPf-w5-lBJ"/>
-                            <constraint firstItem="j0b-5p-LkW" firstAttribute="leading" secondItem="5uc-t6-nYA" secondAttribute="trailing" constant="16" id="Es9-o0-zzi"/>
-                            <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="fAr-Eh-XkB" secondAttribute="trailing" constant="16" id="FMh-T4-biV"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="V30-pI-8jo" secondAttribute="trailing" constant="16" id="GHI-5B-7xh"/>
+                            <constraint firstItem="j0b-5p-LkW" firstAttribute="leading" secondItem="eA3-pM-NKs" secondAttribute="trailing" constant="8" id="HZ8-jr-fK9"/>
                             <constraint firstItem="V30-pI-8jo" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="HgH-sR-rJB"/>
+                            <constraint firstItem="lwt-zv-6qV" firstAttribute="trailing" secondItem="FIv-WY-bvA" secondAttribute="trailing" id="LAm-P9-dMs"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="width" secondItem="dfm-a1-ad2" secondAttribute="width" id="NgP-UU-rcW"/>
+                            <constraint firstItem="cbA-yh-J0A" firstAttribute="centerX" secondItem="V30-pI-8jo" secondAttribute="centerX" id="Old-86-Ci3"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="height" secondItem="dfm-a1-ad2" secondAttribute="height" multiplier="0.85" id="PLc-ir-uPC"/>
-                            <constraint firstItem="j0b-5p-LkW" firstAttribute="centerY" secondItem="5uc-t6-nYA" secondAttribute="centerY" id="Ppq-Xx-PSZ"/>
                             <constraint firstItem="coY-Dg-Mc5" firstAttribute="centerY" secondItem="DUe-4D-nhJ" secondAttribute="centerY" id="Pxh-nT-mtp"/>
-                            <constraint firstItem="cbA-yh-J0A" firstAttribute="centerX" secondItem="V30-pI-8jo" secondAttribute="centerX" id="Qr8-L9-lCF"/>
-                            <constraint firstItem="fAr-Eh-XkB" firstAttribute="centerY" secondItem="okC-2w-xB9" secondAttribute="centerY" id="RFn-jm-ND2"/>
-                            <constraint firstItem="eA3-pM-NKs" firstAttribute="top" secondItem="5uc-t6-nYA" secondAttribute="bottom" constant="8" id="TBU-fM-o9r"/>
-                            <constraint firstItem="5uc-t6-nYA" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="Txz-FX-khz"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="centerX" secondItem="dfm-a1-ad2" secondAttribute="centerX" id="bJ3-Vq-GwG"/>
-                            <constraint firstItem="DPE-Uz-yYf" firstAttribute="centerX" secondItem="j0b-5p-LkW" secondAttribute="centerX" id="bdm-fi-6LK"/>
-                            <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="eA3-pM-NKs" secondAttribute="trailing" constant="16" id="bhv-Sp-60b"/>
                             <constraint firstItem="Hcw-SG-3XL" firstAttribute="centerY" secondItem="dfm-a1-ad2" secondAttribute="centerY" id="dnB-8I-crf"/>
                             <constraint firstItem="eA3-pM-NKs" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="enm-Og-Fbn"/>
-                            <constraint firstItem="cbA-yh-J0A" firstAttribute="trailing" secondItem="V30-pI-8jo" secondAttribute="trailing" id="fCT-6x-0Y5"/>
                             <constraint firstItem="V30-pI-8jo" firstAttribute="top" secondItem="FIv-WY-bvA" secondAttribute="top" constant="8" id="fNG-KC-mpx"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="j0b-5p-LkW" secondAttribute="trailing" constant="16" id="gZz-dZ-XiQ"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="height" secondItem="jre-mq-FDr" secondAttribute="height" multiplier="0.35" id="jtO-7D-eg1"/>
-                            <constraint firstItem="okC-2w-xB9" firstAttribute="centerX" secondItem="cbA-yh-J0A" secondAttribute="centerX" id="kRJ-eC-1n8"/>
-                            <constraint firstItem="fAr-Eh-XkB" firstAttribute="centerX" secondItem="okC-2w-xB9" secondAttribute="centerX" id="mYy-MV-An8"/>
+                            <constraint firstItem="lwt-zv-6qV" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" id="lhM-0J-fNu"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="bottom" secondItem="DUe-4D-nhJ" secondAttribute="bottom" constant="16" id="oTE-Cd-lXS"/>
-                            <constraint firstItem="cbA-yh-J0A" firstAttribute="leading" secondItem="V30-pI-8jo" secondAttribute="leading" id="p9e-tX-pLR"/>
+                            <constraint firstItem="lwt-zv-6qV" firstAttribute="top" secondItem="V30-pI-8jo" secondAttribute="bottom" constant="8" id="p6w-Sf-w1z"/>
                             <constraint firstItem="FIv-WY-bvA" firstAttribute="trailing" secondItem="dfm-a1-ad2" secondAttribute="trailing" constant="16" id="pXZ-qz-MkO"/>
                             <constraint firstItem="dfm-a1-ad2" firstAttribute="top" secondItem="eA3-pM-NKs" secondAttribute="bottom" constant="16" id="sAe-mI-cf2"/>
-                            <constraint firstItem="fAr-Eh-XkB" firstAttribute="leading" secondItem="FIv-WY-bvA" secondAttribute="leading" constant="16" id="sYk-ft-v7v"/>
                             <constraint firstItem="coY-Dg-Mc5" firstAttribute="centerX" secondItem="DUe-4D-nhJ" secondAttribute="centerX" id="wL1-Jj-oLT"/>
-                            <constraint firstItem="okC-2w-xB9" firstAttribute="top" secondItem="cbA-yh-J0A" secondAttribute="bottom" constant="4" id="wMz-b9-sNk"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="FIv-WY-bvA"/>
                     </view>
@@ -219,10 +208,9 @@
                         <outlet property="hideRatesButton" destination="coY-Dg-Mc5" id="bEB-4e-zyz"/>
                         <outlet property="numberKeypadView" destination="dfm-a1-ad2" id="yN5-Le-zxp"/>
                         <outlet property="primaryAmountLabel" destination="cbA-yh-J0A" id="xGh-pL-sDT"/>
+                        <outlet property="primaryLabelCenterXConstraint" destination="Old-86-Ci3" id="HyA-dZ-VT6"/>
                         <outlet property="secondaryAmountLabel" destination="okC-2w-xB9" id="K2v-uv-GkY"/>
                         <outlet property="tradingPairView" destination="V30-pI-8jo" id="DIp-jX-nte"/>
-                        <outlet property="useMaximumButton" destination="kyX-88-NsD" id="1kX-WQ-I1q"/>
-                        <outlet property="useMinimumButton" destination="Gyg-rh-rE6" id="e6a-pn-89k"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="J6x-Pe-arO" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -23,8 +23,9 @@ class ExchangeCreateViewController: UIViewController {
     
     // MARK: Private Static Properties
     
+    static let isLargerThan5S: Bool = Constants.Booleans.IsUsingScreenSizeLargerThan5s
     static let primaryFontName: String = Constants.FontNames.montserratMedium
-    static let primaryFontSize: CGFloat = 72.0
+    static let primaryFontSize: CGFloat = isLargerThan5S ? 72.0 : Constants.FontSizes.Gigantic
     static let secondaryFontName: String = Constants.FontNames.montserratRegular
     static let secondaryFontSize: CGFloat = Constants.FontSizes.Huge
 
@@ -126,6 +127,7 @@ class ExchangeCreateViewController: UIViewController {
         }
         
         secondaryAmountLabel.font = styleTemplate().secondaryFont
+        errorLabel.font = UIFont(name: Constants.FontNames.montserratRegular, size: Constants.FontSizes.ExtraExtraSmall)
         
         [conversionView, hideRatesButton].forEach {
             addStyleToView($0)

--- a/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
+++ b/Blockchain/Homebrew/Exchange/Controllers/ExchangeCreateViewController.swift
@@ -24,9 +24,9 @@ class ExchangeCreateViewController: UIViewController {
     // MARK: Private Static Properties
     
     static let primaryFontName: String = Constants.FontNames.montserratMedium
-    static let primaryFontSize: CGFloat = Constants.FontSizes.Huge
-    static let secondaryFontName: String = Constants.FontNames.montserratMedium
-    static let secondaryFontSize: CGFloat = Constants.FontSizes.MediumLarge
+    static let primaryFontSize: CGFloat = 72.0
+    static let secondaryFontName: String = Constants.FontNames.montserratRegular
+    static let secondaryFontSize: CGFloat = Constants.FontSizes.Huge
 
     // MARK: - IBOutlets
 
@@ -45,17 +45,16 @@ class ExchangeCreateViewController: UIViewController {
 
     @IBOutlet private var hideRatesButton: UIButton!
     @IBOutlet private var conversionRatesView: ConversionRatesView!
-    @IBOutlet private var useMinimumButton: UIButton!
-    @IBOutlet private var useMaximumButton: UIButton!
     @IBOutlet private var fixToggleButton: UIButton!
     @IBOutlet private var conversionView: UIView!
     @IBOutlet private var conversionTitleLabel: UILabel!
     @IBOutlet private var exchangeButton: UIButton!
+    @IBOutlet private var primaryLabelCenterXConstraint: NSLayoutConstraint!
     
     enum PresentationUpdate {
         case wiggleInputLabels
         case wigglePrimaryLabel
-        case updatePrimaryLabel(NSAttributedString?)
+        case updatePrimaryLabel(NSAttributedString?, CGFloat)
         case updateSecondaryLabel(String?)
         case updateErrorLabel(String)
         case updateRateLabels(first: String, second: String, third: String)
@@ -69,7 +68,6 @@ class ExchangeCreateViewController: UIViewController {
         case conversionView(Visibility)
         case exchangeButton(Visibility)
         case ratesChevron(Visibility)
-        case secondaryLabel(Visibility)
         case errorLabel(Visibility)
     }
     
@@ -128,10 +126,8 @@ class ExchangeCreateViewController: UIViewController {
         }
         
         secondaryAmountLabel.font = styleTemplate().secondaryFont
-
-        useMinimumButton.setTitle(LocalizationConstants.Exchange.useMin, for: .normal)
-        useMaximumButton.setTitle(LocalizationConstants.Exchange.useMax, for: .normal)
-        [useMaximumButton, useMinimumButton, conversionView, hideRatesButton].forEach {
+        
+        [conversionView, hideRatesButton].forEach {
             addStyleToView($0)
         }
 
@@ -163,14 +159,6 @@ class ExchangeCreateViewController: UIViewController {
     }
     
     // MARK: - IBActions
-    
-    @IBAction func useMinimumButtonTapped(_ sender: Any) {
-        delegate?.onUseMinimumTapped(assetAccount: fromAccount)
-    }
-
-    @IBAction func useMaximumButtonTapped(_ sender: Any) {
-        delegate?.onUseMaximumTapped(assetAccount: fromAccount)
-    }
 
     @IBAction func fixToggleButtonTapped(_ sender: UIButton) {
         let imageToggle = (fixToggleButton.currentImage == #imageLiteral(resourceName: "icon-toggle-left")) ? #imageLiteral(resourceName: "icon-toggle-right") : #imageLiteral(resourceName: "icon-toggle-left")
@@ -286,8 +274,6 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
             exchangeButton.alpha = visibility.defaultAlpha
         case .ratesChevron(let visibility):
             hideRatesButton.alpha = visibility.defaultAlpha
-        case .secondaryLabel(let visibility):
-            secondaryAmountLabel.alpha = visibility.defaultAlpha
         case .errorLabel(let visibility):
             errorLabel.alpha = visibility.defaultAlpha
         }
@@ -311,8 +297,12 @@ extension ExchangeCreateViewController: ExchangeCreateInterface {
                 guard let this = self else { return }
                 this.delegate?.onKeypadVisibilityUpdated(visibility, animated: animated)
             }
-        case .updatePrimaryLabel(let value):
+        case .updatePrimaryLabel(let value, let offset):
             primaryAmountLabel.attributedText = value
+            guard primaryLabelCenterXConstraint.constant != offset else { return }
+            primaryLabelCenterXConstraint.constant = offset
+            view.setNeedsLayout()
+            view.layoutIfNeeded()
         case .updateSecondaryLabel(let value):
             secondaryAmountLabel.text = value
         case .wiggleInputLabels:

--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -153,15 +153,16 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         
         let secondaryAmount = conversions.output.count == 0 ? "0.00": conversions.output
         let secondaryResult = model.isUsingFiat ? (secondaryAmount + " " + suffix) : (symbol + secondaryAmount)
+        let primaryOffset = inputs.estimatedSymbolWidth(currencySymbol: symbol, template: output.styleTemplate())
 
         if model.isUsingFiat {
             let primary = inputs.primaryFiatAttributedString(currencySymbol: symbol)
-            output.updatedInput(primary: primary, secondary: conversions.output)
+            output.updatedInput(primary: primary, secondary: conversions.output, primaryOffset: -primaryOffset)
         } else {
             let assetType = model.isUsingBase ? model.pair.from : model.pair.to
             let symbol = assetType.symbol
             let primary = inputs.primaryAssetAttributedString(symbol: symbol)
-            output.updatedInput(primary: primary, secondary: secondaryResult)
+            output.updatedInput(primary: primary, secondary: secondaryResult, primaryOffset: -primaryOffset)
         }
     }
 

--- a/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
+++ b/Blockchain/Homebrew/Exchange/Presenters/ExchangeCreatePresenter.swift
@@ -48,11 +48,6 @@ class ExchangeCreatePresenter {
     }
     
     internal func hideError() {
-        interface?.apply(animatedUpdate: ExchangeCreateInterface.AnimatedUpdate(
-            animations: [.secondaryLabel(.visible)],
-            animation: .none
-            )
-        )
         interface?.apply(
             animatedUpdate: ExchangeCreateInterface.AnimatedUpdate(
                 animations: [.errorLabel(.hidden)],
@@ -71,7 +66,7 @@ class ExchangeCreatePresenter {
     fileprivate func displayError() {
         interface?.apply(
             animatedUpdate: ExchangeCreateInterface.AnimatedUpdate(
-                animations: [.secondaryLabel(.hidden), .errorLabel(.visible)],
+                animations: [.errorLabel(.visible)],
                 animation: .standard(duration: 0.2)
             )
         )
@@ -224,9 +219,9 @@ extension ExchangeCreatePresenter: ExchangeCreateOutput {
         return interface?.styleTemplate() ?? .standard
     }
     
-    func updatedInput(primary: NSAttributedString?, secondary: String?) {
+    func updatedInput(primary: NSAttributedString?, secondary: String?, primaryOffset: CGFloat) {
         interface?.apply(presentationUpdates: [
-            .updatePrimaryLabel(primary),
+            .updatePrimaryLabel(primary, primaryOffset),
             .updateSecondaryLabel(secondary)
             ]
         )

--- a/Blockchain/Homebrew/Exchange/Services/ExchangeInputsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/ExchangeInputsService.swift
@@ -35,6 +35,12 @@ class ExchangeInputsService: ExchangeInputsAPI {
         isUsingFiat = usingFiat
     }
     
+    func estimatedSymbolWidth(currencySymbol: String, template: ExchangeStyleTemplate) -> CGFloat {
+        let component = InputComponent(value: currencySymbol, type: .symbol)
+        let value = component.attributedString(with: template)
+        return isUsingFiat ? (value.width / 2) : 0.0
+    }
+    
     func primaryFiatAttributedString(currencySymbol: String) -> NSAttributedString {
         guard components.count > 0 else { return NSAttributedString(string: "NaN")}
         let symbolComponent = InputComponent(

--- a/Blockchain/Homebrew/Exchange/Services/ExchangeInputsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/ExchangeInputsService.swift
@@ -59,6 +59,14 @@ class ExchangeInputsService: ExchangeInputsAPI {
         return inputComponents.primaryAssetAttributedString(suffixComponent)
     }
     
+    func maxFiatInteger() -> Int {
+        return 6
+    }
+    
+    func maxAssetInteger() -> Int {
+        return 5
+    }
+    
     func maxFiatFractional() -> Int {
         return NumberFormatter.localCurrencyFractionDigits
     }
@@ -73,18 +81,22 @@ class ExchangeInputsService: ExchangeInputsAPI {
     
     func canAddFiatCharacter(_ character: String) -> Bool {
         guard components.count > 0 else { return true }
-        if components.contains(where: { $0.type == .pendingFractional }) {
+        let pendingFractional = components.contains(where: { $0.type == .pendingFractional })
+        if pendingFractional {
             return components.filter({ $0.type == .fractional }).count < maxFiatFractional()
+        } else {
+            return components.filter({ $0.type == .whole }).count < maxFiatInteger()
         }
-        return true
     }
     
     func canAddAssetCharacter(_ character: String) -> Bool {
         guard components.count > 0 else { return true }
-        if components.contains(where: { $0.type == .pendingFractional }) {
+        let pendingFractional = components.contains(where: { $0.type == .pendingFractional })
+        if pendingFractional {
             return components.filter({ $0.type == .fractional }).count < maxAssetFractional()
+        } else {
+            return components.filter({ $0.type == .whole }).count < maxAssetInteger()
         }
-        return true
     }
     
     func canAddDelimiter() -> Bool {


### PR DESCRIPTION
## Objective

This removes the min and max buttons. Additionally this fixes some layout issues that were present on the exchange screen. 

## Description

In addition to removing the min and max buttons, we're now accounting for the currency symbol when setting the horizontal constraint on the `primaryAmountLabel`. We're no longer hiding the `secondaryAmountLabel` beneath the `errorLabel`. The `primaryAmountLabel`, `secondaryAmountLabel` and `errorLabel` are all within the same container view. This container view is in another container that is pinned to the `TradingPairView` and the `conversionRateView`. The container view holding the `UILabels` is centered vertically. The `primaryAmountLabel` now shrinks up to 30% its original size should the user enter in a very long value like `88888.88888888 BTC`. There's now rules applied for the number of integers and fractional values that the user can input. Lastly the exchange/swap button was moved per design input. 

## How to Test

1. Build and run
2. Go to the exchange
3. Look at the exchange on various device sizes
4. Input in values, try to break the UI. 
5. The min/max buttons should be gone. 

## Screenshot/Design assessment

![exchange_ui_work](https://user-images.githubusercontent.com/41585563/46704681-b7711b00-cbf1-11e8-9505-f0a261719008.png)
![exchange_ui_work_b](https://user-images.githubusercontent.com/41585563/46704698-cce64500-cbf1-11e8-8c92-664ff8399a94.png)


## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [x] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
