### PR TITLE
feat(HB): Resolving IOS-1416 - UI for outside limits

### DIFF
--- a/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
+++ b/Blockchain/Homebrew/Exchange/Interactors/ExchangeCreateInteractor.swift
@@ -151,13 +151,13 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
         let symbol = model.fiatCurrencySymbol
         let suffix = model.pair.from.symbol
         
-        let secondaryAmount = conversions.output.count == 0 ? "0.00": conversions.output
+        let secondaryAmount = conversions.output == "0" ? "0.00": conversions.output
         let secondaryResult = model.isUsingFiat ? (secondaryAmount + " " + suffix) : (symbol + secondaryAmount)
         let primaryOffset = inputs.estimatedSymbolWidth(currencySymbol: symbol, template: output.styleTemplate())
 
         if model.isUsingFiat {
             let primary = inputs.primaryFiatAttributedString(currencySymbol: symbol)
-            output.updatedInput(primary: primary, secondary: conversions.output, primaryOffset: -primaryOffset)
+            output.updatedInput(primary: primary, secondary: secondaryResult, primaryOffset: -primaryOffset)
         } else {
             let assetType = model.isUsingBase ? model.pair.from : model.pair.to
             let symbol = assetType.symbol
@@ -396,6 +396,29 @@ extension ExchangeCreateInteractor: ExchangeCreateInput {
 
         let errorDisposable = markets.errors.subscribe(onNext: { [weak self] socketError in
             guard let this = self else { return }
+            guard let model = this.model else { return }
+            guard let output = this.output else { return }
+            let symbol = model.fiatCurrencySymbol
+            let suffix = model.pair.from.symbol
+            
+            let secondaryAmount = "0.00"
+            let secondaryResult = model.isUsingFiat ? (secondaryAmount + " " + suffix) : (symbol + secondaryAmount)
+            let primaryOffset = this.inputs.estimatedSymbolWidth(currencySymbol: symbol, template: output.styleTemplate())
+            
+            /// When users are above or below the trading limit, `conversion.output` will not be updated
+            /// with the correct conversion value. This is because the volume entered is either too little
+            /// or too large. In this case we want the `secondaryAmountLabel` to read as `0.00`. We don't
+            /// want to update `conversion.output` manually though as that'd be a side-effect. 
+            if model.isUsingFiat {
+                let primary = this.inputs.primaryFiatAttributedString(currencySymbol: symbol)
+                output.updatedInput(primary: primary, secondary: secondaryResult, primaryOffset: -primaryOffset)
+            } else {
+                let assetType = model.isUsingBase ? model.pair.from : model.pair.to
+                let symbol = assetType.symbol
+                let primary = this.inputs.primaryAssetAttributedString(symbol: symbol)
+                output.updatedInput(primary: primary, secondary: secondaryResult, primaryOffset: -primaryOffset)
+            }
+            
             Logger.shared.error(socketError.description)
 
             switch socketError.errorType {


### PR DESCRIPTION
## Objective

When a user inputs a value that is outside the `TradingLimits` the `secondaryAmountLabel` should show `0.00`.

## Description

When the user is above or below the `TradingLimits` we get an error. In this case we update the `secondaryAmountLabel` to show `0.00` rather than the prior (and incorrect) conversion. 

## How to Test

1. Build and run
2. Go to the exchange
3. Enter in an amount above and/or below the `TradingLimits`
4. The `secondaryAmountLabel` should read `0.00`

## Screenshot/Design assessment

![above_trading_limit](https://user-images.githubusercontent.com/41585563/46747830-d74b2200-cc77-11e8-9b9c-86d2a3180585.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] You have added sufficient documentation (descriptive comments).
- [x] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
