### PR TITLE
dep(Cocoapods): lock versions of Charts, Onfido, and Starscream.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,13 +7,13 @@ target 'Blockchain' do
   inhibit_all_warnings!
   # Pods for Blockchain
     pod 'SwiftLint'
-    pod 'Onfido'
+    pod 'Onfido', '8.0.0'
     pod 'Alamofire', '~> 4.7'
-    pod 'Charts'
+    pod 'Charts', '3.1.0'
     pod 'RxSwift', '~> 4.0'
     pod 'RxCocoa', '~> 4.0'
     pod 'PhoneNumberKit', '~> 2.1'
-    pod 'Starscream', '~> 3.0.2'
+    pod 'Starscream', '3.0.5'
 
   target 'BlockchainTests' do
     inherit! :search_paths


### PR DESCRIPTION
## Objective

So that doing a `pod install` while on XCode 9 doesn't break things.

## Description

Charts, Onfido, and Starscream were not specifying the exact version that we need for it to be compatible with XCode 9 (i.e. the latest versions are build against XCode 10). Locking the specific version we need is safer, but once we upgrade to XCode 10, we can make sure to update these versions as well.
