### PR TITLE
fix(NetworkManager): IOS-1194 remove whitelist

### DIFF
--- a/Blockchain/Network/NetworkManager.swift
+++ b/Blockchain/Network/NetworkManager.swift
@@ -157,8 +157,7 @@ class NetworkManager: NSObject, URLSessionDelegate {
         let host = challenge.protectionSpace.host
         Logger.shared.info("Received challenge from \(host)")
 
-        // TICKET: IOS-1194 - ⚠️ Do not ship `|| true`, this is for debugging purposes only.
-        if BlockchainAPI.PartnerHosts.rawValues.contains(host) || true {
+        if BlockchainAPI.PartnerHosts.rawValues.contains(host) {
             completionHandler(.performDefaultHandling, nil)
         } else {
             CertificatePinner.shared.didReceive(challenge, completion: completionHandler)


### PR DESCRIPTION
## Objective

Restore public key pinning.

## Description

Removed whitelist from `didReceiveChallenge` delegate method.

## How to Test

- Go through KYC and send an exchange order on production. You should not see any "Failure to validate certificate" alerts.
- See the "Testing Certificate Pinning" section on the iOS wiki page.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
