### PR TITLE
fix(Websocket): fix WS auth (IOS-1405)

### DIFF
--- a/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/MarketsService.swift
@@ -248,7 +248,7 @@ private extension MarketsService {
     }
 
     func authenticateSocket() {
-        let authenticationDisposable = authentication.getSessionToken()
+        let authenticationDisposable = authentication.getSessionToken(requestNewToken: true)
             .map { tokenResponse -> Subscription<AuthSubscribeParams> in
                 let params = AuthSubscribeParams(type: "auth", token: tokenResponse.token)
                 return Subscription(channel: "auth", params: params)


### PR DESCRIPTION
## Objective

Fixing failed ws auth errors.

## Description

Attempt # 3 for fixing the failed WS auth issue. I was able to repo the ws auth error by sending an expired token

i.e. this error

```
["description": Can not process auth request, token can not be found, "channel": auth, "type": error, "sequenceNumber": 0]
```

To circumvent this issue altogether, this PR always will request a new session token upon WS connection. I exited/re-entered the exchange screen numerous times and I was not able to repro that error anymore.

## How to Test

Enter/exit exchange create screen a number of times.

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [X] All unit tests pass.
- [ ] You have added unit tests.
- [X] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
