### PR TITLE
feat(Lockbox): Hiding menu item if lockbox isn't enabled.

### DIFF
--- a/Blockchain/Models/Wallet.h
+++ b/Blockchain/Models/Wallet.h
@@ -340,6 +340,7 @@
 
 - (BOOL)isBuyEnabled;
 - (BOOL)canUseSfox;
+- (BOOL)isLockboxEnabled;
 
 // Settings
 - (void)getAccountInfo;

--- a/Blockchain/Models/Wallet.m
+++ b/Blockchain/Models/Wallet.m
@@ -36,6 +36,9 @@
 
 #define DICTIONARY_KEY_CURRENCY @"currency"
 
+NSString * const kAccountInvitations = @"invited";
+NSString * const kLockboxInvitation = @"lockbox";
+
 @interface Wallet ()
 @property (nonatomic) JSContext *context;
 @property (nonatomic) BOOL isSettingDefaultAccount;
@@ -2407,6 +2410,17 @@
 - (BOOL)canUseSfox
 {
     return [[self.context evaluateScript:@"MyWalletPhone.canUseSfox()"] toBool];
+}
+
+- (BOOL)isLockboxEnabled
+{
+    if ([self.accountInfo objectForKey:kAccountInvitations]) {
+        NSDictionary *invitations = [self.accountInfo objectForKey:kAccountInvitations];
+        BOOL enabled = [invitations objectForKey:kLockboxInvitation];
+        return enabled;
+    } else {
+        return NO;
+    }
 }
 
 - (void)watchPendingTrades:(BOOL)shouldSync

--- a/Blockchain/Side Menu/SideMenuPresenter.swift
+++ b/Blockchain/Side Menu/SideMenuPresenter.swift
@@ -63,6 +63,7 @@ class SideMenuPresenter {
 
     private func setMenuItems(showExchange: Bool) {
         var items: [SideMenuItem] = []
+        
         if wallet.isBuyEnabled() {
             items.append(.buyBitcoin)
         }
@@ -76,12 +77,19 @@ class SideMenuPresenter {
         }
         items.append(contentsOf: [
             .settings,
-            .accountsAndAddresses,
-            .lockbox,
-            .webLogin,
-            .support,
-            .logout
-        ])
+            .accountsAndAddresses
+            ]
+        )
+        if wallet.isLockboxEnabled() {
+            items.append(.lockbox)
+        }
+        items.append(
+            contentsOf: [
+                .webLogin,
+                .support,
+                .logout
+            ]
+        )
         view?.setMenu(items: items)
     }
 }


### PR DESCRIPTION
## Objective

Hides `Lockbox` menu item based on `accountInfo` value.

## How to Test

1. Build and run
2. Go to the side menu
3. See that `Lockbox` is shown based on the value of `@"lockbox"` in the `@"invitations` dictionary of `accountInfo`.

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
