### PR TITLE
fix(KYCInformationViewModel): IOS-1427 hide button if accountStatus is .failed

### DIFF
--- a/Blockchain/KYC/Information/KYCInformationViewModel.swift
+++ b/Blockchain/KYC/Information/KYCInformationViewModel.swift
@@ -111,7 +111,7 @@ extension KYCInformationViewConfig {
             isPrimaryButtonEnabled = true
         case .failed, .expired, .none:
             titleColor = UIColor.error
-            isPrimaryButtonEnabled = true
+            isPrimaryButtonEnabled = accountStatus != .failed
         case .pending:
             titleColor = UIColor.orange
             isPrimaryButtonEnabled = !UIApplication.shared.isRegisteredForRemoteNotifications

--- a/Blockchain/KYC/Information/KYCInformationViewModel.swift
+++ b/Blockchain/KYC/Information/KYCInformationViewModel.swift
@@ -111,7 +111,7 @@ extension KYCInformationViewConfig {
             isPrimaryButtonEnabled = true
         case .failed, .expired, .none:
             titleColor = UIColor.error
-            isPrimaryButtonEnabled = accountStatus != .failed
+            isPrimaryButtonEnabled = false
         case .pending:
             titleColor = UIColor.orange
             isPrimaryButtonEnabled = !UIApplication.shared.isRegisteredForRemoteNotifications


### PR DESCRIPTION
## Description

Removed button for account status failed screen.

## How to Test

cherry-pick 710458e431b75d2e6065d4e3715acb47583abe19 to show the verification failed page when tapping on Exchange.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
