### PR TITLE
fix(Biometric Auth): fix face ID bug (IOS-1433).

### DIFF
--- a/Blockchain/Authentication/AuthenticationCoordinator+Pin.swift
+++ b/Blockchain/Authentication/AuthenticationCoordinator+Pin.swift
@@ -44,7 +44,7 @@ extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
             encryptedPinPassword,
             password: decryptionKey,
             pbkdf2_iterations: Int32(Constants.Security.pinPBKDF2Iterations)
-            ), decryptedPassword.count > 0 else {
+        ), decryptedPassword.count > 0 else {
                 showPinError(withMessage: LocalizationConstants.Pin.decryptedPasswordLengthZero)
                 askIfUserWantsToResetPIN()
                 return
@@ -63,6 +63,10 @@ extension AuthenticationCoordinator: PEPinEntryControllerDelegate {
     }
 
     func pinEntryControllerDidChangePin(_ controller: PEPinEntryController) {
+        // Set the last entered PIN so that during pin setting, if the user enabled biometric auth
+        // we can persist the pin to the keychain
+        self.lastEnteredPIN = controller.lastEnteredPin
+
         closePinEntryView(animated: true)
 
         let inSettings = pinEntryViewController?.inSettings ?? false

--- a/Third Party/PinEntry/Classes/PEPinEntryController.h
+++ b/Third Party/PinEntry/Classes/PEPinEntryController.h
@@ -41,7 +41,6 @@
 
 @class PEViewController;
 
-
 @interface PEPinEntryController : UINavigationController <PEViewControllerDelegate, UIScrollViewDelegate>
 {
 	BOOL verifyOnly;
@@ -57,6 +56,7 @@
 @property (nonatomic, readonly) BOOL verifyOptional;
 @property (nonatomic, readwrite) BOOL inSettings;
 @property (nonatomic) PinPresenter *pinPresenter;
+@property (nonatomic) Pin *lastEnteredPin;
 @property (nonatomic) UILongPressGestureRecognizer *longPressGesture;
 @property (nonatomic) UIButton *debugButton;
 @property (nonatomic) UIPageControl *scrollViewPageControl;

--- a/Third Party/PinEntry/Classes/PEPinEntryController.m
+++ b/Third Party/PinEntry/Classes/PEPinEntryController.m
@@ -56,10 +56,6 @@ static PEViewController *VerifyController()
 	return c;
 }
 
-@interface PEPinEntryController ()
-@property (nonatomic) Pin *lastEnteredPIN;
-@end
-
 @implementation PEPinEntryController
 
 @synthesize pinDelegate, verifyOnly, verifyOptional, inSettings;
@@ -273,14 +269,14 @@ static PEViewController *VerifyController()
 
 - (void)pinEntryControllerDidEnteredPin:(PEViewController *)controller
 {
+    Pin *pin = [[Pin alloc] initWithCode:[controller.pin intValue]];
 	switch (pinStage) {
 		case PS_VERIFY: {
-            self.lastEnteredPIN = [[Pin alloc] initWithCode:[controller.pin intValue]];
-            [self validateWithPin:self.lastEnteredPIN];
+            [self validateWithPin:pin];
 			break;
         }
 		case PS_ENTER1: {
-            [self didEnterFirstPinForChangePinFlowFrom:controller previousPin:self.lastEnteredPIN];
+            [self didEnterFirstPinForChangePinFlowFrom:controller previousPin:self.lastEnteredPin];
 			break;
 		}
 		case PS_ENTER2:
@@ -289,6 +285,7 @@ static PEViewController *VerifyController()
 		default:
 			break;
 	}
+    self.lastEnteredPin = pin;
 }
 
 - (void)goToEnter1Pin


### PR DESCRIPTION
## Objective

Fix bug where biometric auth fails when you enable it right after creating a wallet.

## Description

Fix bug where biometric auth fails when you enable it right after creating a wallet.

## How to Test

Test the following cases:
1. create a new wallet and enable face auth
2. create a new wallet, don't enable face auth, but enable face auth in the settings screen.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [X] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [ ] All unit tests pass.
- [X] You have added unit tests.
- [X] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
