### PR TITLE
fix(TradeExecutionService): IOS-1437 prompt for second password before posting…

### DIFF
--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -141,7 +141,7 @@ class TradeExecutionService: TradeExecutionAPI {
                 return .error(TradeExecutionAPIError.generic)
         }
 
-        return authentication.getSessionToken().flatMap { token in
+        return authentication.getSessionToken().flatMap { [weak self] token in
             return NetworkRequest.POST(
                 url: endpoint,
                 body: try? JSONEncoder().encode(order),
@@ -152,7 +152,12 @@ class TradeExecutionService: TradeExecutionAPI {
     }
 
     // Sign and send the payment object created by either of the buildOrder methods.
-    fileprivate func sendTransaction(assetType: AssetType, success: @escaping (() -> Void), error: @escaping ((String) -> Void)) {
+    fileprivate func sendTransaction(
+        assetType: AssetType,
+        secondPassword: String?,
+        success: @escaping (() -> Void),
+        error: @escaping ((String) -> Void)
+    ) {
         isExecuting = true
         let executionDone = { [weak self] in
             guard let this = self else { return }
@@ -160,6 +165,7 @@ class TradeExecutionService: TradeExecutionAPI {
         }
         wallet.sendOrderTransaction(
             assetType.legacy,
+            secondPassword: secondPassword,
             completion: executionDone,
             success: success,
             error: error,
@@ -295,20 +301,42 @@ extension TradeExecutionService {
         success: @escaping ((OrderTransaction) -> Void),
         error: @escaping ((String) -> Void)
     ) {
-        processAndBuildOrder(
-            with: conversion,
-            fromAccount: from,
-            toAccount: to,
-            success: { [weak self] orderTransaction, _ in
-                guard let this = self else { return }
-                this.sendTransaction(
-                    assetType: orderTransaction.to.assetType,
-                    success: {
-                        success(orderTransaction)
-                    },
-                    error: error)
-            },
-            error: error
-        )
+        let processAndBuild: ((String?) -> ()) = { [weak self] secondPassword in
+            guard let this = self else { return }
+            this.processAndBuildOrder(
+                with: conversion,
+                fromAccount: from,
+                toAccount: to,
+                success: { [weak self] orderTransaction, _ in
+                    guard let this = self else { return }
+                    this.sendTransaction(
+                        assetType: orderTransaction.to.assetType,
+                        secondPassword: secondPassword,
+                        success: {
+                            success(orderTransaction)
+                        },
+                        error: error
+                    )
+                },
+                error: error
+            )
+        }
+
+        // Second password must be prompted before an order is processed since it is
+        // a cancellable action - otherwise an order will be created even if cancelling
+        // second password
+        if wallet.needsSecondPassword() {
+            AuthenticationCoordinator.shared.showPasswordConfirm(
+                withDisplayText: LocalizationConstants.Authentication.secondPasswordDefaultDescription,
+                headerText: LocalizationConstants.Authentication.secondPasswordRequired,
+                validateSecondPassword: true,
+                confirmHandler: { (secondPass) in
+                    processAndBuild(secondPass)
+                }
+            )
+        } else {
+            processAndBuild(nil)
+        }
+
     }
 }

--- a/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
+++ b/Blockchain/Homebrew/Exchange/Services/TradeExecutionService.swift
@@ -141,7 +141,7 @@ class TradeExecutionService: TradeExecutionAPI {
                 return .error(TradeExecutionAPIError.generic)
         }
 
-        return authentication.getSessionToken().flatMap { [weak self] token in
+        return authentication.getSessionToken().flatMap { token in
             return NetworkRequest.POST(
                 url: endpoint,
                 body: try? JSONEncoder().encode(order),

--- a/Blockchain/Models/Wallet.h
+++ b/Blockchain/Models/Wallet.h
@@ -487,7 +487,7 @@
 ///   - completion: handler called when the payment is successfully sent
 ///   - error: handler called when an error occurs while sending the payment
 ///   - cancel: handler called when the payment is cancelled (e.g., when an intermediate screen such as second password is dismissed)
-- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error cancel:(void (^ _Nonnull)(void))cancel;
+- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType secondPassword:(NSString* _Nullable)secondPassword completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error cancel:(void (^ _Nonnull)(void))cancel;
 // Top Bar Display
 - (NSDecimalNumber *)btcDecimalBalance;
 - (NSDecimalNumber *)ethDecimalBalance;

--- a/Blockchain/Models/Wallet.m
+++ b/Blockchain/Models/Wallet.m
@@ -2699,7 +2699,7 @@ NSString * const kLockboxInvitation = @"lockbox";
     [self.context evaluateScript:script];
 }
 
-- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error cancel:(void (^ _Nonnull)(void))cancel
+- (void)sendOrderTransaction:(LegacyAssetType)legacyAssetType secondPassword:(NSString* _Nullable)secondPassword completion:(void (^ _Nonnull)(void))completion success:(void (^ _Nonnull)(void))success error:(void (^ _Nonnull)(NSString *_Nonnull))error cancel:(void (^ _Nonnull)(void))cancel
 {
     [self.context invokeOnceWithFunctionBlock:^{
         completion();
@@ -2727,7 +2727,7 @@ NSString * const kLockboxInvitation = @"lockbox";
         return;
     }
     
-    [self.context evaluateScript:[NSString stringWithFormat:@"MyWalletPhone.tradeExecution.%@.send()", tradeExecutionType]];
+    [self.context evaluateScript:[NSString stringWithFormat:@"MyWalletPhone.tradeExecution.%@.send(%@)", tradeExecutionType, [secondPassword escapedForJS]]];
 }
 
 # pragma mark - Ethereum

--- a/Blockchain/js/wallet-ios.js
+++ b/Blockchain/js/wallet-ios.js
@@ -2458,20 +2458,28 @@ MyWalletPhone.sendEtherPaymentWithNote = function(note) {
         objc_on_send_ether_payment_error(e);
     }
 
-    MyWalletPhone.sendEtherPayment(currentEtherPayment, success, error);
+    MyWalletPhone.sendEtherPayment(currentEtherPayment, null, success, error);
 }
 
-MyWalletPhone.sendEtherPayment = function(payment, success, error, dismiss) {
+MyWalletPhone.sendEtherPayment = function(payment, secondPassword, success, error, dismiss) {
     var eth = MyWallet.wallet.eth;
 
     if (MyWallet.wallet.isDoubleEncrypted) {
-        MyWalletPhone.getSecondPassword(function (pw) {
-            var privateKey = eth.getPrivateKeyForAccount(eth.defaultAccount, pw);
+        if (secondPassword) {
+            var privateKey = eth.getPrivateKeyForAccount(eth.defaultAccount, secondPassword);
             payment.sign(privateKey);
             payment
             .publish()
             .then(success).catch(error);
-        }, dismiss);
+        } else {
+            MyWalletPhone.getSecondPassword(function (pw) {
+                var privateKey = eth.getPrivateKeyForAccount(eth.defaultAccount, pw);
+                payment.sign(privateKey);
+                payment
+                .publish()
+                .then(success).catch(error);
+            }, dismiss);
+        }
     } else {
         var privateKey = eth.getPrivateKeyForAccount(eth.defaultAccount);
         payment.sign(privateKey);
@@ -3165,8 +3173,8 @@ MyWalletPhone.tradeExecution = {
                 return paymentPromise
             }).catch(objc_on_create_order_payment_error);
         },
-        send: function() {
-            MyWalletPhone.sendBitcoinPayment(currentPayment, null, objc_on_send_order_transaction_success, objc_on_send_order_transaction_error, objc_on_send_order_transaction_dismiss);
+        send: function(secondPassword) {
+            MyWalletPhone.sendBitcoinPayment(currentPayment, secondPassword, objc_on_send_order_transaction_success, objc_on_send_order_transaction_error, objc_on_send_order_transaction_dismiss);
         }
     },
 
@@ -3187,8 +3195,8 @@ MyWalletPhone.tradeExecution = {
                 objc_on_create_order_payment_success(maxAvailable, fee);
             }).catch(objc_on_create_order_payment_error);
         },
-        send: function() {
-            MyWalletPhone.sendBitcoinPayment(currentBitcoinCashPayment, null, objc_on_send_order_transaction_success, objc_on_send_order_transaction_error, objc_on_send_order_transaction_dismiss);
+        send: function(secondPassword) {
+            MyWalletPhone.sendBitcoinPayment(currentBitcoinCashPayment, secondPassword, objc_on_send_order_transaction_success, objc_on_send_order_transaction_error, objc_on_send_order_transaction_dismiss);
         },
     },
 
@@ -3204,8 +3212,8 @@ MyWalletPhone.tradeExecution = {
                 objc_on_create_order_payment_success(currentEtherPayment.fee);
             }).catch(objc_on_create_order_payment_error);
         },
-        send: function() {
-            MyWalletPhone.sendEtherPayment(currentEtherPayment, objc_on_send_order_transaction_success, objc_on_send_order_transaction_error, objc_on_send_order_transaction_dismiss);
+        send: function(secondPassword) {
+            MyWalletPhone.sendEtherPayment(currentEtherPayment, secondPassword, objc_on_send_order_transaction_success, objc_on_send_order_transaction_error, objc_on_send_order_transaction_dismiss);
         }
     }
 }


### PR DESCRIPTION
… to trades endpoint

## Objective

Prompt for second password before processing an `Order`.

## Description

- Prompted for second password in `buildAndSend`
- Added second password parameter to `Wallet.h`'s `sendOrder...`
- Added second password parameter to `MyWalletPhone.sendEtherPayment`

## How to Test

- Exchange from BTC/ETH/BCH with/without second password
- Send from ETH with/without second password

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [x] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
