### PR TITLE
fix(ExchangeDetailCoordinator): IOS-1439 remove send to field from exchange hi…

### DIFF
--- a/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
+++ b/Blockchain/Homebrew/Exchange/ExchangeDetailCoordinator.swift
@@ -231,12 +231,6 @@ class ExchangeDetailCoordinator: NSObject {
                     value: trade.feeDisplayValue,
                     backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
                 )
-                
-                let sendTo = ExchangeCellModel.Plain(
-                    description: LocalizationConstants.Exchange.sendTo,
-                    value: accountRepository.nameOfAccountContaining(address: trade.withdrawalAddress),
-                    backgroundColor: #colorLiteral(red: 0.9450980392, green: 0.9529411765, blue: 0.9607843137, alpha: 1)
-                )
 
                 var orderId = ExchangeCellModel.Plain(
                     description: LocalizationConstants.Exchange.orderID,
@@ -260,7 +254,6 @@ class ExchangeDetailCoordinator: NSObject {
                     .plain(exchange),
                     .plain(receive),
                     .plain(fees),
-                    .plain(sendTo),
                     .plain(orderId)
                     ]
                 )


### PR DESCRIPTION
…story

## Description

Removed send to field from Order History as it's not in the other platforms.

## How to Test

Go to order history, see that "Send to" cell is removed.

## Screenshot/Design assessment

![simulator screen shot - iphone 6 - 2018-10-12 at 11 37 01](https://user-images.githubusercontent.com/10579422/46879137-309b8880-ce13-11e8-8a28-3d07c6e1a967.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
