### PR TITLE
fix(Websocket Auth): fixing failed ws auth (IOS-1405, IOS-1434).

### DIFF
--- a/Blockchain/AppDelegate.swift
+++ b/Blockchain/AppDelegate.swift
@@ -145,6 +145,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             onboardingSettings.shouldShowBiometrySetup = true
         }
 
+        SocketManager.shared.disconnectAll()
+
         // UI-related background actions
         ModalPresenter.shared.closeAllModals()
 

--- a/Blockchain/Network/Models/SocketMessage.swift
+++ b/Blockchain/Network/Models/SocketMessage.swift
@@ -17,6 +17,14 @@ enum SocketType: String {
     case bitcoin
     case ether
     case bitcoinCash
+
+    static let all: [SocketType] = [
+        .unassigned,
+        .exchange,
+        .bitcoin,
+        .ether,
+        .bitcoinCash
+    ]
 }
 
 struct SocketMessage {


### PR DESCRIPTION
## Objective

Fix issue where token expires after 5 minutes and isn't refreshed.

## Description

- `pendingSocketMessages` is an array used to store socket messages in case an attempt to send was made while the socket wasn't connected. This was not being cleared/reset properly, so multiple authentication messages were being sent, including ones that were using old session tokens. For now we clear the `pendingSocketMessages` the after `.forEach` has completed, but this should be improved on later.
- Disconnected from socket in `applicationDidEnterBackground`.
- Fixed logger typo.

## How to Test

- Open Exchange, leave on for > 5 minutes. You should still get conversion and rate updates.
- Open Exchange, leave on for > 5 minutes, tap sleep/wake button, go back to exchange, you should still get conversion and rate updates.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
