### PR TITLE
fix(Homebrew-Exchange): display deposit/withdrawal amounts as 0 if va…

### DIFF
--- a/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
+++ b/Blockchain/Homebrew/Exchange/Models/CellModels/ExchangeTradeCellModel.swift
@@ -126,7 +126,9 @@ extension ExchangeTradeModel {
         case .partner(let model):
             return model.amountDepositedCryptoValue
         case .homebrew(let model):
-            return model.deposit.value + " " + model.deposit.symbol
+            return model.deposit != nil ?
+            model.deposit!.value + " " + model.deposit!.symbol :
+            "0" + " " + model.pair.from.symbol
         }
     }
     
@@ -138,7 +140,7 @@ extension ExchangeTradeModel {
             if let value = model.withdrawal?.value, let symbol = model.withdrawal?.symbol {
                 return value + " " + symbol
             } else {
-                return ""
+                return "0" + " " + model.pair.to.symbol
             }
         }
     }
@@ -260,7 +262,7 @@ struct ExchangeTradeCellModel: Decodable {
     let refundAddress: String
     let rate: String?
     let depositAddress: String
-    let deposit: SymbolValue
+    let deposit: SymbolValue?
     let withdrawalAddress: String
     let withdrawal: SymbolValue?
     let withdrawalFee: SymbolValue
@@ -334,7 +336,7 @@ struct ExchangeTradeCellModel: Decodable {
         refundAddress = try values.decode(String.self, forKey: .refundAddress)
         rate = try values.decodeIfPresent(String.self, forKey: .rate)
         depositAddress = try values.decode(String.self, forKey: .depositAddress)
-        deposit = try values.decode(SymbolValue.self, forKey: .deposit)
+        deposit = try values.decodeIfPresent(SymbolValue.self, forKey: .deposit)
         withdrawalAddress = try values.decode(String.self, forKey: .withdrawalAddress)
         withdrawal = try values.decodeIfPresent(SymbolValue.self, forKey: .withdrawal)
         withdrawalFee = try values.decode(SymbolValue.self, forKey: .withdrawalFee)


### PR DESCRIPTION
…lues are nil

## Objective

Fix issue where trades are not loading because of a null `deposit`.

## Description

- Made `deposit` optional.
- Displayed zero amount if the required `withdrawal` or `deposit` value was nil.

## How to Test

Go to Exchange - trades should load, and failed trade should show zero received amount.

## Screenshot/Design assessment

![simulator screen shot - iphone 6 - 2018-10-15 at 13 39 39](https://user-images.githubusercontent.com/10579422/46967865-c8051380-d07f-11e8-942f-353413606781.png)
![simulator screen shot - iphone 6 - 2018-10-15 at 13 39 37](https://user-images.githubusercontent.com/10579422/46967868-c8051380-d07f-11e8-9661-7ba84d55d99c.png)

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
