### PR TITLE
fix(Lockbox): IOS-1475 hide side menu item based on invitation status

### DIFF
--- a/Blockchain/Models/Wallet.m
+++ b/Blockchain/Models/Wallet.m
@@ -2416,7 +2416,7 @@ NSString * const kLockboxInvitation = @"lockbox";
 {
     if ([self.accountInfo objectForKey:kAccountInvitations]) {
         NSDictionary *invitations = [self.accountInfo objectForKey:kAccountInvitations];
-        BOOL enabled = [invitations objectForKey:kLockboxInvitation];
+        BOOL enabled = [[invitations objectForKey:kLockboxInvitation] boolValue];
         return enabled;
     } else {
         return NO;


### PR DESCRIPTION
## Objective

Fix issue where Lockbox was showing even if the wallet was not invited.

## Description

`lockbox = 0` was being converted to `YES`. Changed to convert it to `NO`.

## How to Test

- Create wallet with invitation status of `true`. Lockbox should show in side menu.
- Create wallet with invitation status of `false`. Lockbox should not show in side menu.

## Screenshot/Design assessment

N/A

## Merge Checklist

- [x] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] Areas of technical debt are marked with a `// TICKET:` comment that includes a ticket number.
- [x] All unit tests pass.
- [ ] You have added unit tests.
- [ ] You have added sufficient documentation (descriptive comments).
- [ ] New files added are within the correct directory. (e.g. if a file is required for unit tests to compile, be sure it is added to the tests target.)
